### PR TITLE
fix(ops): install-location-agnostic scripts + deploy path rewrite

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -56,12 +56,13 @@ Production deploys can run through a self-hosted GitHub Actions runner on the
 target server. The runner should be registered to the repository with the label
 `kaos-deploy`.
 
-Current target:
+Register the runner on the target server, then configure it (values are
+install-specific):
 
 ```text
-roman@178.105.30.82
-runner: fkv-kaos-deploy
-labels: self-hosted, kaos-deploy, linux, x64
+host:        <user>@<your-server>
+runner:      <your-runner-name>
+labels:      self-hosted, kaos-deploy, linux, x64
 deploy root: /opt/kaos
 ```
 

--- a/scripts/contact-profiler.py
+++ b/scripts/contact-profiler.py
@@ -8,7 +8,7 @@ Usage:
     contact-profiler.py --chat @username [--limit 300] [--dry-run] [--no-notify]
 
 Environment:
-    WORKSPACE           Workspace dir (default: /opt/kaos/app/workspace)
+    WORKSPACE           Workspace dir (default: <app>/workspace)
     BRIDGE_URL          Bridge HTTP URL (default: http://127.0.0.1:8788)
     WEBHOOK_SECRET      Auth secret for bridge
     DEEPSEEK_API_KEY    DeepSeek API key
@@ -35,7 +35,7 @@ from kronos.security.sanitize import sanitize_text, detect_injection, wrap_untru
 
 # --- Config ---
 
-WORKSPACE = Path(os.environ.get("WORKSPACE", "/opt/kaos/workspace"))
+WORKSPACE = Path(os.environ.get("WORKSPACE", str(Path(__file__).resolve().parent.parent / "workspace")))
 CONTACTS_DIR = WORKSPACE / "notes" / "world" / "contacts"
 BRIDGE_URL = os.environ.get("BRIDGE_URL", "http://127.0.0.1:8788")
 WEBHOOK_SECRET = os.environ.get("WEBHOOK_SECRET", "")

--- a/scripts/cost-stats.sh
+++ b/scripts/cost-stats.sh
@@ -2,8 +2,11 @@
 # cost-stats.sh — Show LLM cost statistics from audit log
 # Usage: cost-stats.sh [today|week|all]
 
-COST_LOG="/opt/kaos/data/logs/cost.jsonl"
-AUDIT_LOG="/opt/kaos/data/logs/audit.jsonl"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LOG_DIR="${KAOS_LOG_DIR:-$APP_DIR/data/logs}"
+COST_LOG="$LOG_DIR/cost.jsonl"
+AUDIT_LOG="$LOG_DIR/audit.jsonl"
 
 if [ ! -f "$COST_LOG" ]; then
   echo "No cost log found at $COST_LOG"

--- a/scripts/daily-status.sh
+++ b/scripts/daily-status.sh
@@ -7,22 +7,33 @@
 
 set -uo pipefail
 
+# Resolve the install dir relative to this script (works on any deploy path).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Main agent systemd unit name. Generic default; override via KAOS_MAIN_UNIT.
+MAIN_UNIT="${KAOS_MAIN_UNIT:-kaos}"
+
 # NTFY config (loaded from .env if available)
-if [ -f /opt/kaos/app/.env ]; then
+if [ -f "$APP_DIR/.env" ]; then
   # shellcheck disable=SC1091
-  source /opt/kaos/app/.env 2>/dev/null || true
+  source "$APP_DIR/.env" 2>/dev/null || true
 fi
+MAIN_UNIT="${KAOS_MAIN_UNIT:-$MAIN_UNIT}"
 NTFY_URL="${NTFY_URL:-${NTFY_URL:-https://ntfy.sh}}"
 NTFY_TOKEN="${NTFY_TOKEN:-}"
 NTFY_TOPIC="${NTFY_TOPIC:-persona-alerts}"
 
+# Audit log path — matches kronos.audit (Path(db_path).parent/logs); override via env.
+AUDIT_LOG="${KAOS_AUDIT_LOG:-$APP_DIR/data/logs/audit.jsonl}"
+
 # --- Gather data ---
 
 # Service status
-service_status=$(systemctl is-active kaos 2>/dev/null || echo "unknown")
+service_status=$(systemctl is-active "$MAIN_UNIT" 2>/dev/null || echo "unknown")
 
 # Service uptime (from systemd ActiveEnterTimestamp)
-service_started=$(systemctl show kaos --property=ActiveEnterTimestamp --value 2>/dev/null || echo "")
+service_started=$(systemctl show "$MAIN_UNIT" --property=ActiveEnterTimestamp --value 2>/dev/null || echo "")
 if [ -n "$service_started" ] && [ "$service_started" != "n/a" ]; then
   started_ts=$(date -d "$service_started" +%s 2>/dev/null) || started_ts=0
   now_ts=$(date +%s)
@@ -73,10 +84,10 @@ else
 fi
 
 # Recent service restarts (last 24h)
-service_restarts=$(journalctl -u kaos --since "24 hours ago" 2>/dev/null | grep -c "Started\|Stopped" 2>/dev/null) || service_restarts=0
+service_restarts=$(journalctl -u "$MAIN_UNIT" --since "24 hours ago" 2>/dev/null | grep -c "Started\|Stopped" 2>/dev/null) || service_restarts=0
 
 # Audit log stats (if available)
-audit_log="/opt/kaos/data/audit.jsonl"
+audit_log="$AUDIT_LOG"
 audit_stats="N/A"
 if [ -f "$audit_log" ]; then
   audit_today=$(grep "$(date -u +%Y-%m-%d)" "$audit_log" 2>/dev/null | wc -l | tr -d ' ')
@@ -97,7 +108,7 @@ report=$(cat <<EOF
 Kronos Agent OS Daily Status [$status_word]
 
 Services:
-  kaos: $service_status
+  $MAIN_UNIT: $service_status
   Bridge (8788): $bridge_health
   Dashboard (8789): $dashboard_health
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,10 +32,12 @@ AGENTS="${KAOS_AGENTS:-kaos}"
 # agent_name list in KAOS_AGENTS (e.g. the main kronos agent runs as the
 # `kronos-ii` unit). Defaults to KAOS_AGENTS when not set.
 SERVICES="${KAOS_SERVICES:-$AGENTS}"
-# Whether deploy installs app/systemd/* units into /etc/systemd/system. Set
-# false when systemd units are managed outside the deploy (e.g. the kronos-ii
-# install, whose live units don't come from app/systemd/) so the deploy never
-# overwrites them.
+# Whether deploy installs app/systemd/* units into /etc/systemd/system. The
+# units in app/systemd/ are generic: they use the /opt/kaos placeholder path
+# and User=kronos. On install the deploy rewrites /opt/kaos -> KAOS_REMOTE_DIR
+# and User=kronos -> the remote user, so the public units land correctly on any
+# install dir (incl. /opt/kronos-ii). Set false only when units are fully
+# provisioned outside the deploy (e.g. hand-managed per-agent named units).
 MANAGE_SYSTEMD="${KAOS_MANAGE_SYSTEMD:-true}"
 SOURCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -137,10 +139,14 @@ PY
     app/.venv/bin/pip install -e "app/.[dev]"
     app/.venv/bin/pip install edge-tts
 
-    # Install systemd units (replace default User=kronos with actual remote user)
+    # Install systemd units: rewrite the generic /opt/kaos placeholder to this
+    # install's KAOS_REMOTE_DIR and the User=kronos placeholder to the remote user.
     REMOTE_USER=$(whoami)
     for f in app/systemd/*.service app/systemd/*.timer; do
-      sudo sed "s/User=kronos/User=$REMOTE_USER/" "$f" | sudo tee "/etc/systemd/system/$(basename "$f")" >/dev/null
+      sudo sed \
+        -e "s/User=kronos/User=$REMOTE_USER/" \
+        -e "s|/opt/kaos|$KAOS_REMOTE_DIR|g" \
+        "$f" | sudo tee "/etc/systemd/system/$(basename "$f")" >/dev/null
     done
     sudo systemctl daemon-reload
 
@@ -184,13 +190,19 @@ else
       fi
     done
 
-    # Update systemd units if changed (replace default User=kronos with actual
-    # remote user). Skipped when KAOS_MANAGE_SYSTEMD=false — for installs whose
-    # live units are managed outside the deploy and don't come from app/systemd/.
+    # Install/update systemd units: rewrite the generic /opt/kaos placeholder to
+    # this install's KAOS_REMOTE_DIR and the User=kronos placeholder to the
+    # remote user. The generic public units (kaos.service, ops .service/.timer)
+    # thus land with correct absolute paths on any install dir. Hand-managed
+    # per-agent named units (not in the repo) are left untouched.
+    # Skipped when KAOS_MANAGE_SYSTEMD=false.
     if [ "${KAOS_MANAGE_SYSTEMD:-true}" = "true" ]; then
       REMOTE_USER=$(whoami)
       for f in app/systemd/*.service app/systemd/*.timer; do
-        [ -f "$f" ] && sudo sed "s/User=kronos/User=$REMOTE_USER/" "$f" | sudo tee "/etc/systemd/system/$(basename "$f")" >/dev/null
+        [ -f "$f" ] && sudo sed \
+          -e "s/User=kronos/User=$REMOTE_USER/" \
+          -e "s|/opt/kaos|$KAOS_REMOTE_DIR|g" \
+          "$f" | sudo tee "/etc/systemd/system/$(basename "$f")" >/dev/null
       done
       sudo systemctl daemon-reload
     else

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -12,14 +12,25 @@ set -uo pipefail
 VERBOSE="${1:-}"
 ALERT="${2:-}"
 
+# Resolve the install dir relative to this script so the checks work on any
+# deployment path without hardcoding it.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Main agent systemd unit name. Generic default; override via KAOS_MAIN_UNIT in
+# the environment / .env (e.g. KAOS_MAIN_UNIT=kronos-ii) when the unit is named
+# differently than the public default.
+MAIN_UNIT="${KAOS_MAIN_UNIT:-kaos}"
+
 WEBHOOK_URL="${REMINDER_WEBHOOK_URL:-http://127.0.0.1:8788/webhook}"
 WEBHOOK_SECRET="${WEBHOOK_SECRET:-}"
 
 # NTFY config (loaded from .env if available)
-if [ -f /opt/kaos/app/.env ]; then
+if [ -f "$APP_DIR/.env" ]; then
   # shellcheck disable=SC1091
-  source /opt/kaos/app/.env 2>/dev/null || true
+  source "$APP_DIR/.env" 2>/dev/null || true
 fi
+MAIN_UNIT="${KAOS_MAIN_UNIT:-$MAIN_UNIT}"
 NTFY_URL="${NTFY_URL:-${NTFY_URL:-https://ntfy.sh}}"
 NTFY_TOKEN="${NTFY_TOKEN:-}"
 NTFY_TOPIC="${NTFY_TOPIC:-persona-alerts}"
@@ -54,12 +65,19 @@ check_warn() {
   warnings+=("$1")
 }
 
-# --- Check 1: kaos systemd service ---
-service_active=$(systemctl is-active kaos 2>/dev/null)
+# --- Check 1: main agent systemd service ---
+service_active=$(systemctl is-active "$MAIN_UNIT" 2>/dev/null)
 if [ "$service_active" = "active" ]; then
-  check_pass "kaos service active"
+  check_pass "$MAIN_UNIT service active"
 else
-  check_fail "kaos service: ${service_active:-unknown}"
+  # The configured unit name may differ from this install's actual unit. The
+  # bridge /health endpoint is the authoritative liveness signal, so treat a
+  # name mismatch with a healthy bridge as a warning, not a failure.
+  if curl -sf --max-time 5 "$BRIDGE_HEALTH" 2>/dev/null | grep -q '"status".*"ok"'; then
+    check_warn "$MAIN_UNIT service not active, but bridge is healthy (set KAOS_MAIN_UNIT to this install's unit name)"
+  else
+    check_fail "$MAIN_UNIT service: ${service_active:-unknown}"
+  fi
 fi
 
 # --- Check 2: Bridge health endpoint (port 8788) ---

--- a/scripts/notion-helper.sh
+++ b/scripts/notion-helper.sh
@@ -7,13 +7,16 @@
 #   team     — Team workspace
 #
 # Tokens are loaded from env vars: NOTION_TOKEN_PERSONAL, NOTION_TOKEN_TEAM
-# Fallback: load from /opt/kaos/app/.env if the file exists
+# Fallback: load from the app's .env (resolved relative to this script).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Load .env if tokens not already in environment
 if [ -z "${NOTION_TOKEN_PERSONAL:-}" ] || [ -z "${NOTION_TOKEN_TEAM:-}" ]; then
-  if [ -f /opt/kaos/app/.env ]; then
+  if [ -f "$APP_DIR/.env" ]; then
     # shellcheck disable=SC1091
-    source /opt/kaos/app/.env 2>/dev/null || true
+    source "$APP_DIR/.env" 2>/dev/null || true
   fi
 fi
 
@@ -34,7 +37,7 @@ if [ -z "$NOTION_KEY" ]; then
   if [ -z "${WORKSPACES[$WORKSPACE]+x}" ]; then
     echo "ERROR: Unknown workspace '$WORKSPACE'. Available: ${!WORKSPACES[*]}"
   else
-    echo "ERROR: Token for workspace '$WORKSPACE' is not set. Set NOTION_TOKEN_${WORKSPACE^^} env var or add it to /opt/kaos/app/.env"
+    echo "ERROR: Token for workspace '$WORKSPACE' is not set. Set NOTION_TOKEN_${WORKSPACE^^} env var or add it to $APP_DIR/.env"
   fi
   exit 1
 fi
@@ -148,7 +151,7 @@ case "$1" in
     echo "  -w team       Team workspace"
     echo ""
     echo "Tokens: set NOTION_TOKEN_PERSONAL and NOTION_TOKEN_TEAM in env"
-    echo "  or add them to /opt/kaos/app/.env"
+    echo "  or add them to $APP_DIR/.env"
     echo ""
     echo "Commands:"
     echo "  search <query>                    Search pages and databases"

--- a/scripts/recall.py
+++ b/scripts/recall.py
@@ -12,8 +12,8 @@ Usage:
     recall.py stats              — show index statistics
 
 Environment:
-    AUDIT_LOG           Audit log path (default: /opt/kaos/data/audit.jsonl)
-    DB_PATH             SQLite database path (default: /opt/kaos/data/recall.db)
+    AUDIT_LOG           Audit log path (default: <app>/data/logs/audit.jsonl)
+    DB_PATH             SQLite database path (default: <app>/data/recall.db)
     DEEPSEEK_API_KEY    DeepSeek API key (for --summarize)
     RECALL_LOG          Log file (default: /var/log/kaos/recall.log)
 """
@@ -30,8 +30,9 @@ from pathlib import Path
 
 # --- Config ---
 
-AUDIT_LOG = Path(os.environ.get("AUDIT_LOG", "/opt/kaos/data/audit.jsonl"))
-DB_PATH = Path(os.environ.get("DB_PATH", "/opt/kaos/data/recall.db"))
+_APP_DIR = Path(__file__).resolve().parent.parent  # scripts/ -> app/
+AUDIT_LOG = Path(os.environ.get("AUDIT_LOG", str(_APP_DIR / "data" / "logs" / "audit.jsonl")))
+DB_PATH = Path(os.environ.get("DB_PATH", str(_APP_DIR / "data" / "recall.db")))
 DEEPSEEK_API_KEY = os.environ.get("DEEPSEEK_API_KEY", "")
 LOG_FILE = os.environ.get("RECALL_LOG", "/var/log/kaos/recall.log")
 

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -2,9 +2,13 @@
 # security-audit.sh — Kronos Agent OS Security Audit Report
 # Usage: security-audit.sh [today|week|all]
 
-SECURITY_LOG="/opt/kaos/data/security.jsonl"
-AUDIT_LOG="/opt/kaos/data/audit.jsonl"
-WORKSPACE_PATH="/opt/kaos/workspace"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MAIN_UNIT="${KAOS_MAIN_UNIT:-kaos}"
+LOG_DIR="${KAOS_LOG_DIR:-$APP_DIR/data/logs}"
+SECURITY_LOG="$LOG_DIR/security.jsonl"
+AUDIT_LOG="$LOG_DIR/audit.jsonl"
+WORKSPACE_PATH="${KAOS_WORKSPACE_SRC:-$APP_DIR/workspaces}"
 
 PERIOD="${1:-today}"
 TODAY=$(date -u +%Y-%m-%d)
@@ -102,10 +106,10 @@ echo ""
 echo "▸ System Checks"
 
 # Check services
-echo -n "  kaos:         "
-systemctl is-active kaos 2>/dev/null || echo "UNKNOWN"
-echo -n "  heartbeat timer:   "
-systemctl is-active kronos-heartbeat.timer 2>/dev/null || echo "UNKNOWN"
+echo -n "  $MAIN_UNIT:         "
+systemctl is-active "$MAIN_UNIT" 2>/dev/null || echo "UNKNOWN"
+echo -n "  health timer:   "
+systemctl is-active kronos-health.timer 2>/dev/null || echo "UNKNOWN"
 
 # Check API keys exposed in workspace
 echo ""
@@ -120,7 +124,7 @@ fi
 # Check log sizes
 echo ""
 echo "▸ Log Sizes"
-for logfile in "$SECURITY_LOG" "$AUDIT_LOG" "/opt/kaos/data/router-cost.jsonl"; do
+for logfile in "$SECURITY_LOG" "$AUDIT_LOG" "$LOG_DIR/router-cost.jsonl"; do
   if [ -f "$logfile" ]; then
     SIZE=$(du -h "$logfile" | cut -f1)
     LINES=$(wc -l < "$logfile")

--- a/scripts/setup-agents.sh
+++ b/scripts/setup-agents.sh
@@ -2,7 +2,7 @@
 # Setup .env files for optional swarm agents.
 # Run once on the server after initial deploy.
 #
-# Usage: cd /opt/kaos/app && bash scripts/setup-agents.sh
+# Usage: bash scripts/setup-agents.sh   (run from the app dir)
 #
 # Prerequisites:
 #   - .env already exists with shared keys (LLM, MCP, etc.)
@@ -10,7 +10,8 @@
 
 set -euo pipefail
 
-APP_DIR="/opt/kaos/app"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 BASE_ENV="$APP_DIR/.env"
 
 if [ ! -f "$BASE_ENV" ]; then

--- a/scripts/workspace-backup.sh
+++ b/scripts/workspace-backup.sh
@@ -1,19 +1,25 @@
 #!/bin/bash
 # workspace-backup.sh — Auto-backup workspace files to Git
-# Commits workspace changes in /opt/kaos/app/ repo and pushes.
+# Commits workspace changes in the app repo and pushes.
 #
 # Usage: workspace-backup.sh
 # Designed to run via cron every 6 hours
 
 set -uo pipefail
 
-WORKSPACE_SRC="/opt/kaos/workspace"
-REPO_DIR="/opt/kaos/app"
+# Resolve the install dir relative to this script (works on any deploy path).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Git repo to commit into = the app dir; workspace source defaults to the
+# per-agent workspaces dir. Override either via env.
+REPO_DIR="${KAOS_REPO_DIR:-$APP_DIR}"
+WORKSPACE_SRC="${KAOS_WORKSPACE_SRC:-$APP_DIR/workspaces}"
 
 # NTFY config
-if [ -f /opt/kaos/app/.env ]; then
+if [ -f "$APP_DIR/.env" ]; then
   # shellcheck disable=SC1091
-  source /opt/kaos/app/.env 2>/dev/null || true
+  source "$APP_DIR/.env" 2>/dev/null || true
 fi
 NTFY_URL="${NTFY_URL:-${NTFY_URL:-https://ntfy.sh}}"
 NTFY_TOKEN="${NTFY_TOKEN:-}"


### PR DESCRIPTION
## Problem
The systemd ops units (health / backup / daily-status) and the ops scripts hardcoded the generic `/opt/kaos` prefix, so they broke on installs using a different prefix. `health-check.sh` also checked a hardcoded unit name, producing false failures (and false alerts via `OnFailure`).

## Fix
- **deploy.sh**: on unit install, rewrite the generic `/opt/kaos` placeholder to `KAOS_REMOTE_DIR` (alongside the existing `User=kronos` → remote-user rewrite). Generic public units now land with correct absolute paths on any install dir.
- **ops scripts**: resolve the app dir relative to the script (`SCRIPT_DIR`) instead of a hardcoded prefix; main unit name via `KAOS_MAIN_UNIT` (default `kaos`); audit/cost log dir matches `kronos.audit` (`data/logs`). `health-check.sh` falls back to the bridge `/health` endpoint when the unit name differs → warns instead of failing.
- **docs**: replace the example host/runner in `DEPLOYMENT.md` with placeholders.

## Verification
- `tests/test_public_surface.py`: 23 passed (generic public units preserved).
- All ops scripts pass `bash -n` / `py_compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)