### PR TITLE
fix(pulse): exclude "update available" notifications from health assessment

### DIFF
--- a/kronos/analytics/pulse.py
+++ b/kronos/analytics/pulse.py
@@ -73,6 +73,8 @@ Generate a concise daily pulse:
 
 If a data source returned an error, note it as "⚠️ Source unavailable" — don't skip the section.
 
+Note: Zabbix `updates_available` = count of pending Docker image updates. It is informational ONLY — never treat it as a 🔴/🟡 signal, never list it under "Issues requiring attention", and never let it affect the overall status. Mention it at most as a neutral one-liner under Infrastructure.
+
 Write in Russian. Format for Telegram — use emoji, keep it under 1800 chars.
 Be specific with numbers, don't be vague."""
 

--- a/kronos/analytics/sources/zabbix.py
+++ b/kronos/analytics/sources/zabbix.py
@@ -58,6 +58,7 @@ def collect() -> dict:
             "limit": 20,
             "severities": [2, 3, 4, 5],  # Warning, Average, High, Disaster
             "selectHosts": ["host"],
+            "suppressed": False,  # exclude problems intentionally suppressed in Zabbix
         })
 
         # Active triggers
@@ -70,21 +71,34 @@ def collect() -> dict:
         })
 
         hosts_total = len(hosts)
-        critical_triggers = [t for t in triggers if int(t.get("priority", "0")) >= 4]
-        warning_triggers = [t for t in triggers if int(t.get("priority", "0")) in (2, 3)]
+
+        # "Update available" notifications (diun) are informational only — pending
+        # Docker image updates, not a health issue. They must NOT influence the
+        # assessment (counts / summary). Split them out; report count separately.
+        def _is_update(text: str) -> bool:
+            t = (text or "").lower()
+            return "обновлени" in t or "update available" in t
+
+        real_problems = [p for p in problems if not _is_update(p.get("name", ""))]
+        updates_available = [p for p in problems if _is_update(p.get("name", ""))]
+        real_triggers = [t for t in triggers if not _is_update(t.get("description", ""))]
+
+        critical_triggers = [t for t in real_triggers if int(t.get("priority", "0")) >= 4]
+        warning_triggers = [t for t in real_triggers if int(t.get("priority", "0")) in (2, 3)]
 
         problems_summary = []
-        for p in problems[:5]:
+        for p in real_problems[:5]:
             host = p.get("hosts", [{}])[0].get("host", "unknown")
             name = p.get("name", "Unknown problem")
             problems_summary.append(f"{name} on {host}")
 
         return {
             "hosts_total": hosts_total,
-            "active_problems": len(problems),
+            "active_problems": len(real_problems),
             "critical_triggers": len(critical_triggers),
             "warning_triggers": len(warning_triggers),
             "problems_summary": problems_summary,
+            "updates_available": len(updates_available),  # informational only, not a health issue
         }
 
     except Exception as e:


### PR DESCRIPTION
## Проблема
Уведомления diun об доступных Docker-обновлениях («X: доступно обновление» / «update available») учитывались как active problems и warning-триггеры в ежедневном пульсе, раздувая оценку тяжести ситуации (sev-1/2 шум маскировал реальные проблемы).

## Изменения
- `sources/zabbix.py`: «update available» вынесены в отдельное информационное поле `updates_available` — отображается числом, но НЕ входит в `active_problems` / `warning_triggers` / `problems_summary` / оценку. Дополнительно `problem.get` фильтрует `suppressed:False`, чтобы сознательно подавленные проблемы тоже не влияли.
- `pulse.py`: в промпт добавлена инструкция — `updates_available` информационное, никогда не 🔴/🟡 и не в «Issues requiring attention».

## Проверка
- `py_compile` обоих файлов — OK.
- Задеплоено на FRA-01 (`scripts/deploy.sh`), агенты active. Следующий `kronos-daily-status` подхватит.

🤖 Generated with [Claude Code](https://claude.com/claude-code)