### PR TITLE
fix: dedupe daily digest, fix pulse Sentry counts, enrich news format

### DIFF
--- a/kronos/analytics/pulse.py
+++ b/kronos/analytics/pulse.py
@@ -75,6 +75,8 @@ If a data source returned an error, note it as "⚠️ Source unavailable" — d
 
 Note: Zabbix `updates_available` = count of pending Docker image updates. It is informational ONLY — never treat it as a 🔴/🟡 signal, never list it under "Issues requiring attention", and never let it affect the overall status. Mention it at most as a neutral one-liner under Infrastructure.
 
+Note: For Sentry, base the status and "Issues requiring attention" ONLY on `unresolved_active_24h` and `top_issues_active_24h` (issues actually seen in the last 24h). `unresolved_total` is the historical backlog and `total_events_all_time` is a lifetime counter — never present a large all-time count as a fresh spike or as today's problem. If `unresolved_active_24h` is 0, Sentry is calm regardless of backlog size.
+
 Write in Russian. Format for Telegram — use emoji, keep it under 1800 chars.
 Be specific with numbers, don't be vague."""
 

--- a/kronos/analytics/sources/sentry.py
+++ b/kronos/analytics/sources/sentry.py
@@ -39,32 +39,42 @@ def collect() -> dict:
     project = settings.sentry_project
 
     try:
-        # Unresolved issues sorted by frequency
-        issues = _api_get(
+        # Full unresolved backlog (all-time, capped) — for context, NOT for alerting
+        backlog = _api_get(
             f"/projects/{org}/{project}/issues/",
-            {"query": "is:unresolved", "sort": "freq", "limit": "10"},
+            {"query": "is:unresolved", "sort": "date", "limit": "25"},
         )
 
-        # Project stats (events in last 24h)
+        # Unresolved issues that were actually seen in the last 24h — what matters today
+        active = _api_get(
+            f"/projects/{org}/{project}/issues/",
+            {"query": "is:unresolved lastSeen:-24h", "sort": "freq", "limit": "10"},
+        )
+
+        # Project stats (events received in last 24h)
         stats = _api_get(
             f"/projects/{org}/{project}/stats/",
             {"stat": "received", "resolution": "1d"},
         )
         events_24h = stats[-1][1] if stats else 0
 
+        # Top issues limited to those ACTIVE in the last 24h (a 9-day-dead issue
+        # with a large all-time count must not surface as a fresh spike).
         top_issues = []
-        for issue in (issues or [])[:5]:
+        for issue in (active or [])[:5]:
             top_issues.append({
                 "title": issue.get("title", "Unknown")[:100],
-                "count": issue.get("count", "0"),
+                "total_events_all_time": issue.get("count", "0"),
                 "level": issue.get("level", "error"),
                 "first_seen": issue.get("firstSeen", ""),
+                "last_seen": issue.get("lastSeen", ""),
             })
 
         return {
-            "unresolved_issues": len(issues) if issues else 0,
+            "unresolved_total": len(backlog) if backlog else 0,
+            "unresolved_active_24h": len(active) if active else 0,
             "events_24h": events_24h,
-            "top_issues": top_issues,
+            "top_issues_active_24h": top_issues,
         }
 
     except Exception as e:

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -28,7 +28,8 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     from kronos.cron.analytics_weekly import run_analytics_weekly
     from kronos.cron.expenses.processor import run_email_expenses
     from kronos.cron.expense_digest import run_expense_digest
-    from kronos.cron.group_digest import run_group_digest
+    # DISABLED 2026-07-07: group-digest paused — duplicate of news-monitor on Digest:News.
+    # from kronos.cron.group_digest import run_group_digest
     from kronos.cron.heartbeat import run_heartbeat
     from kronos.cron.market_review import run_market_review
     from kronos.cron.news_monitor import run_news_monitor
@@ -60,8 +61,14 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     # Personal Observer — daily at 23:00 UTC (07:00 UTC+8), avoids 00:00/01:00 digest conflicts.
     scheduler.add_daily("personal-observer", run_personal_observer, hour_utc=23)
 
-    # Group Digest — daily at 01:00 UTC (09:00 UTC+8)
-    scheduler.add_daily("group-digest", run_group_digest, hour_utc=1)
+    # Group Digest — daily at 01:00 UTC (09:00 UTC+8).
+    # DISABLED 2026-07-07: paused — news-monitor (Signal Intelligence) already
+    # publishes to the same Digest:News topic at 00:00 UTC, so group-digest at
+    # 01:00 produced a second, duplicate message. GROUPS.md Telegram sources are
+    # kept intact for a future merge into Signal Intelligence. To re-enable:
+    # uncomment the import above + this line, bump the job count below back to
+    # 15, then restart the kronos agent.
+    # scheduler.add_daily("group-digest", run_group_digest, hour_utc=1)
 
     # Jobs Digest — daily at 02:00 UTC (dedicated Signal Intelligence topic).
     # DISABLED 2026-06-11: paused — job-search signals are not being collected
@@ -144,5 +151,5 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
         scheduler.add_weekly("analytics-weekly", run_analytics_weekly, weekday=0, hour_utc=9)
         nexus_jobs_registered = 4
 
-    total = 15 + nexus_jobs_registered  # 18 base jobs; signal-jobs, travel insights and people-scout paused
+    total = 14 + nexus_jobs_registered  # 18 base jobs; signal-jobs, travel insights, people-scout and group-digest paused
     log.info("%d cron jobs registered for agent '%s'", total, me)

--- a/kronos/signals/digest.py
+++ b/kronos/signals/digest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import urllib.parse
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
@@ -187,6 +188,71 @@ NEWS_EDITOR_CANDIDATE_MULTIPLIER = 2
 IDEAS_EDITOR_CANDIDATE_LIMIT = 20
 DEFAULT_MAX_IDEAS = 8
 
+# Human-readable source names by domain — turns a bare "источник" link into a
+# recognizable label (Hugging Face, GitHub, Telegram…). Unknown hosts fall back
+# to the bare domain, which still reads better than a generic "источник".
+_SOURCE_LABELS = {
+    "huggingface.co": "Hugging Face",
+    "github.com": "GitHub",
+    "gitlab.com": "GitLab",
+    "reddit.com": "Reddit",
+    "x.com": "X",
+    "twitter.com": "X",
+    "t.me": "Telegram",
+    "telegram.me": "Telegram",
+    "youtube.com": "YouTube",
+    "youtu.be": "YouTube",
+    "arxiv.org": "arXiv",
+    "habr.com": "Habr",
+    "medium.com": "Medium",
+    "substack.com": "Substack",
+    "openai.com": "OpenAI",
+    "anthropic.com": "Anthropic",
+    "blog.google": "Google",
+    "techcrunch.com": "TechCrunch",
+    "theverge.com": "The Verge",
+    "venturebeat.com": "VentureBeat",
+}
+
+
+def _source_label(url: str) -> str:
+    """Human-readable source name from a URL (bare domain fallback, then 'источник')."""
+    if not url:
+        return "источник"
+    try:
+        host = urllib.parse.urlsplit(url).netloc.lower()
+    except (ValueError, TypeError):
+        return "источник"
+    host = host.removeprefix("www.")
+    for domain, label in _SOURCE_LABELS.items():
+        if host == domain or host.endswith("." + domain):
+            return label
+    return host or "источник"
+
+
+def _news_insights(titles: Sequence[str]) -> str | None:
+    """Synthesize a short 'trends of the day' note from the selected headlines.
+
+    Returns None when the LLM is unavailable or yields nothing usable, so the
+    caller simply omits the block — this never breaks the digest.
+    """
+    clean_titles = [t for t in titles if t]
+    if len(clean_titles) < 3:
+        return None
+    joined = "\n".join(f"- {t}" for t in clean_titles[:12])
+    prompt = (
+        "Вот заголовки главных новостей сегодняшнего AI/tech-дайджеста:\n\n"
+        f"{joined}\n\n"
+        "Сформулируй 2-3 предложения об общих трендах и выводах дня: что "
+        "связывает эти новости и куда движется индустрия. Только суть, без "
+        "вступления и списков. По-русски."
+    )
+    raw = _invoke_editor(NEWS_EDITOR_SYSTEM, prompt)
+    if not raw:
+        return None
+    text = _clean_display_text(raw, limit=600)
+    return text or None
+
 
 def curate_news_digest(
     rendered: RenderedDigest,
@@ -229,21 +295,32 @@ def curate_news_digest(
     lines = [f"<b>{escape(rendered.title)}</b>", ""]
     chosen_cluster_ids: list[int] = []
     chosen_item_ids: list[int] = []
+    chosen_titles: list[str] = []
     for entry in selection:
         cluster = candidates[entry["index"]]
         cluster_id = int(cluster.get("id", 0) or 0)
         items = tuple(items_by_cluster.get(cluster_id, ()))
         title = _clean_display_text(str(cluster.get("title") or "Без названия"))
         first_url = next((item.url for item in items if item.url), "")
-        link = f' (<a href="{escape(first_url, quote=True)}">источник</a>)' if first_url else ""
+        link = (
+            f' (<a href="{escape(first_url, quote=True)}">{escape(_source_label(first_url))}</a>)'
+            if first_url
+            else ""
+        )
         lines.append(f"• <b>{escape(title)}</b>{link}")
         why = _clean_display_text(entry["why"], limit=280)
         if why:
             lines.append(f"  <i>Почему важно:</i> {escape(why)}")
         lines.append("")  # blank line separates items for readability
+        chosen_titles.append(title)
         if cluster_id:
             chosen_cluster_ids.append(cluster_id)
         chosen_item_ids.extend(int(i) for i in (cluster.get("item_ids") or []) if i)
+
+    insight = _news_insights(chosen_titles)
+    if insight:
+        lines.append("<b>💡 Инсайты дня:</b>")
+        lines.append(f"  {escape(insight)}")
 
     body = "\n".join(lines).strip()
     return replace(
@@ -455,7 +532,7 @@ def _render_cluster(
     title = _clean_display_text(sanitize_trend_language(str(cluster.get("title") or "Без названия"), assessment))
     summary = _clean_display_text(sanitize_trend_language(str(cluster.get("summary") or ""), assessment))
     first_url = next((item.url for item in items if item.url), "")
-    link = f' (<a href="{escape(first_url, quote=True)}">источник</a>)' if first_url else ""
+    link = f' (<a href="{escape(first_url, quote=True)}">{escape(_source_label(first_url))}</a>)' if first_url else ""
 
     parts = [
         f"• <b>{escape(title)}</b>{link}",


### PR DESCRIPTION
## Summary

Three related fixes to the Kronos daily digest / health pulse. All three are already deployed to prod (FRA-01 `/opt/kronos-ii/app`) via scp + `kronos-ii` restart; this PR syncs the repo history with prod.

### 1. Pulse — report Sentry 24h activity, not all-time counts (`analytics/sources/sentry.py`, `analytics/pulse.py`)
The daily pulse reported "2 unresolved / 69 events" by reading each issue's **lifetime** event count and the whole `is:unresolved` backlog, so a 9-day-dead issue surfaced as a fresh spike. Now splits `unresolved_total` (backlog) vs `unresolved_active_24h` (`lastSeen:-24h`); top issues are limited to the last 24h and carry `last_seen`. Prompt guidance bases status on 24h activity.

### 2. Cron — disable group-digest to stop duplicate Digest:News (`cron/setup.py`)
`news-monitor` (00:00 UTC) and `group-digest` (01:00 UTC) both publish to `Digest:News`, producing two digest messages per day. Paused `group-digest` via the standard `DISABLED` pattern. `GROUPS.md` Telegram sources still feed Signal Intelligence through `merge_legacy_group_digest_sources`, so **no news coverage is lost**.

### 3. Signals — named source links + trends-of-day (`signals/digest.py`)
Replaced the generic "источник" link label with a recognizable source name (Hugging Face, GitHub, Telegram…) derived from the URL host, and appended an optional "Инсайты дня" summary. Both are **render-only and fallback-safe** — the deterministic digest is unchanged when the LLM is unavailable. Pipeline / scoring / clustering untouched.

## Verification
- `py_compile` clean on all files (local + server)
- `kronos-ii.service` reports `active` after each deploy — import chain intact
- Telegram-channel coverage (B) confirmed as pre-existing behavior of `load_sources()` → no code change required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
