### PR TITLE
Hardening: CI green, security fail-closed, resilience (roadmap 0–3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,7 +45,8 @@ TG_API_HASH=abc123...
 TG_BOT_TOKEN=                         # Bot API token (optional, alternative to userbot)
 ALLOWED_USERS=                        # comma-separated Telegram user IDs
 ALLOW_ALL_USERS=false                 # set true only for trusted/private accounts
-WEBHOOK_SECRET=change-me-secret
+WEBHOOK_SECRET=change-me-secret       # REQUIRED for /webhook & /history; empty = endpoints disabled (fail-closed)
+WEBHOOK_HOST=127.0.0.1                # localhost by default; set 0.0.0.0 to expose externally (needs a secret)
 WEBHOOK_PORT=8788
 DEFAULT_NOTIFY_CHAT=                  # Telegram chat ID for cron notifications
 TELEGRAM_GROUP_RESPONSES_ENABLED=true # set false for observe-only Telegram sessions
@@ -111,6 +112,7 @@ REQUIRE_DYNAMIC_TOOL_SANDBOX=true     # fail closed unless Docker sandbox is ava
 ENABLE_MCP_GATEWAY_MANAGEMENT=false   # opt-in: add/remove/reload MCP servers at runtime
 ENABLE_DYNAMIC_MCP_SERVERS=false      # opt-in: load MCP servers persisted in local registry
 ENABLE_SERVER_OPS=false               # opt-in: SSH/server diagnostics and whitelisted actions
+TOOL_APPROVALS_ENABLED=true           # interactive agent asks before risky tools; set false for trusted single-user
 
 # === NTFY Push Notifications (optional) ===
 NTFY_URL=https://ntfy.sh

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+
+# Dependabot opens the dependency-update PRs that security-audit.yml only
+# reports. minor/patch updates are grouped to keep PR noise low; majors and
+# security fixes still arrive as their own PRs so they get attention.
+updates:
+  - package-ecosystem: "npm"
+    directory: "/dashboard-ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      pip-minor-patch:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,9 @@ jobs:
           cache-dependency-path: dashboard-ui/package-lock.json
       - run: npm ci
         working-directory: dashboard-ui
-      - run: npm audit --audit-level=moderate
-        working-directory: dashboard-ui
+      # npm audit intentionally NOT gated here: new CVEs turn PRs red without
+      # any code change. Dependency scanning lives in security-audit.yml
+      # (scheduled) + Dependabot instead.
       - run: npm run lint
         working-directory: dashboard-ui
       - run: npm run build

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,29 @@
+name: Security Audit
+
+# Dependency vulnerability scanning runs on a schedule (not in the PR gate)
+# because a newly published CVE can turn audit red with no code change —
+# that must not block unrelated PRs. A failed run here emails the repo
+# owner; Dependabot (.github/dependabot.yml) opens the fix PRs.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  npm-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: dashboard-ui/package-lock.json
+      - run: npm ci
+        working-directory: dashboard-ui
+      - run: npm audit --audit-level=moderate
+        working-directory: dashboard-ui

--- a/dashboard-ui/package-lock.json
+++ b/dashboard-ui/package-lock.json
@@ -33,13 +33,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -58,21 +58,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -89,14 +89,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -106,14 +106,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -133,29 +133,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -184,9 +184,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -204,27 +204,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -273,33 +273,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -307,14 +307,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2073,9 +2073,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.10",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz",
-      "integrity": "sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==",
+      "version": "2.10.42",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
+      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2108,9 +2108,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
+      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
       "dev": true,
       "funding": [
         {
@@ -2128,11 +2128,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.42",
+        "caniuse-lite": "^1.0.30001800",
+        "electron-to-chromium": "^1.5.387",
+        "node-releases": "^2.0.50",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2152,9 +2152,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001803",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
+      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
       "dev": true,
       "funding": [
         {
@@ -2305,9 +2305,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.323",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.323.tgz",
-      "integrity": "sha512-oQm+FxbazvN2WICCbvJgj3IYPKV8awip57+W5VP+Aatk4kFU4pDYCPHZOX22Z27zpw8uttBehEqgK+VTJAYrVw==",
+      "version": "1.5.389",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
+      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true,
       "license": "ISC"
     },
@@ -2865,10 +2865,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3061,11 +3071,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3269,9 +3282,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
-      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3291,12 +3304,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz",
-      "integrity": "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.2"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3619,10 +3632,11 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/dashboard/auth.py
+++ b/dashboard/auth.py
@@ -28,8 +28,14 @@ def create_session() -> str:
 
 
 def verify_credentials(username: str, password: str) -> bool:
-    """Check username and password."""
-    return username == DASHBOARD_USERNAME and password == DASHBOARD_PASSWORD
+    """Check username and password in constant time (avoids timing attacks).
+
+    Both comparisons are evaluated before the ``and`` so short-circuiting
+    doesn't leak which field mismatched via response timing.
+    """
+    user_ok = secrets.compare_digest(username.encode(), DASHBOARD_USERNAME.encode())
+    pass_ok = secrets.compare_digest(password.encode(), DASHBOARD_PASSWORD.encode())
+    return user_ok and pass_ok
 
 
 async def verify_token(

--- a/kronos/__init__.py
+++ b/kronos/__init__.py
@@ -1,3 +1,9 @@
 """Kronos Agent OS — self-hosted runtime for durable AI agents."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    # Single source of truth: the version declared in pyproject.toml.
+    __version__ = version("kronos-agent-os")
+except PackageNotFoundError:  # running from a source tree without an install
+    __version__ = "0.0.0+unknown"

--- a/kronos/app.py
+++ b/kronos/app.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import shutil
+import signal
 from pathlib import Path
 
 from kronos.config import settings
@@ -110,10 +111,43 @@ async def main():
         from kronos.bridge import run_bridge
         from kronos.discord_bridge import run_discord
 
-        # Run all services concurrently
-        await asyncio.gather(
-            run_bridge(agent),
-            run_discord(agent),
-            scheduler.run(),
-            run_dashboard(scheduler=scheduler, agent=agent),
+        # Run all services concurrently with graceful shutdown. A SIGTERM
+        # (systemd stop) or SIGINT (Ctrl-C) — or any service returning/crashing
+        # — stops the scheduler and cancels the rest so in-flight turns and MCP
+        # sessions unwind instead of being killed mid-flight.
+        stop_event = asyncio.Event()
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            try:
+                loop.add_signal_handler(sig, stop_event.set)
+            except NotImplementedError:
+                pass  # e.g. Windows / non-main thread — rely on cancellation
+
+        services = [
+            asyncio.create_task(run_bridge(agent), name="bridge"),
+            asyncio.create_task(run_discord(agent), name="discord"),
+            asyncio.create_task(scheduler.run(), name="scheduler"),
+            asyncio.create_task(
+                run_dashboard(scheduler=scheduler, agent=agent), name="dashboard"
+            ),
+        ]
+        stop_task = asyncio.create_task(stop_event.wait(), name="stop")
+
+        done, _pending = await asyncio.wait(
+            [*services, stop_task], return_when=asyncio.FIRST_COMPLETED
         )
+
+        # Signal received, or a service returned/crashed → tear everything down.
+        log.info("Shutting down services…")
+        scheduler.stop()
+        for task in (*services, stop_task):
+            task.cancel()
+        await asyncio.gather(*services, stop_task, return_exceptions=True)
+
+        # Re-raise a genuine service crash (not a clean signal) so systemd's
+        # Restart=on-failure can act on it.
+        for task in services:
+            if task in done and not task.cancelled():
+                exc = task.exception()
+                if exc is not None:
+                    raise exc

--- a/kronos/app.py
+++ b/kronos/app.py
@@ -6,6 +6,7 @@ import shutil
 import signal
 from pathlib import Path
 
+from kronos import __version__
 from kronos.config import settings
 from kronos.cron.scheduler import Scheduler
 from kronos.cron.setup import setup_cron_jobs
@@ -89,7 +90,7 @@ def _ensure_data_dirs() -> None:
 
 async def main():
     """Start Kronos Agent OS: build agent, start bridge + cron scheduler."""
-    log.info("Starting Kronos Agent OS v0.1.0")
+    log.info("Starting Kronos Agent OS v%s", __version__)
     _ensure_data_dirs()
 
     session_store = SessionStore(settings.db_path, agent_name=settings.agent_name)

--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -76,6 +76,9 @@ def _thread_lock(thread_id: str) -> asyncio.Lock:
 _agent: KronosAgent | None = None
 _client: TelegramClient | None = None
 _my_id: int | None = None
+# Monotonic-wall timestamp of the last incoming Telegram event, for /health
+# liveness (0.0 = nothing received yet).
+_last_event_ts: float = 0.0
 _my_username: str | None = None
 
 # Group routing (initialized in run_bridge after login)
@@ -1074,7 +1077,26 @@ async def _handle_history(request: web.Request) -> web.Response:
 
 
 async def _handle_health(request: web.Request) -> web.Response:
-    return web.json_response({"status": "ok", "agent": "kaos"})
+    """Live readiness: reflects the Telegram client and provider state instead
+    of a static 'ok' (a health-check every 15 min was checking a fiction)."""
+    from kronos.llm import active_provider_cooldowns
+
+    connected = bool(_client and _client.is_connected())
+    last_event_age = round(time.time() - _last_event_ts, 1) if _last_event_ts else None
+    cooldowns = active_provider_cooldowns()
+
+    # Healthy requires the Telegram client to be connected. Provider cooldowns
+    # are reported for visibility but don't fail health on their own (the
+    # fallback chain still has other providers).
+    healthy = connected
+    body = {
+        "status": "ok" if healthy else "degraded",
+        "agent": settings.agent_name,
+        "telegram_connected": connected,
+        "last_event_age_seconds": last_event_age,
+        "providers_in_cooldown": cooldowns,
+    }
+    return web.json_response(body, status=200 if healthy else 503)
 
 
 async def _start_webhook_server() -> None:
@@ -1270,6 +1292,8 @@ async def run_bridge(agent: KronosAgent) -> None:
 
     @_client.on(events.NewMessage(incoming=True))
     async def handle_message(event):
+        global _last_event_ts
+        _last_event_ts = time.time()
         # Log ALL incoming events for debugging
         log.info(
             "[EVENT] chat=%s private=%s reply_to=%s text=%s",

--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -50,8 +50,27 @@ if not DEFAULT_NOTIFY_CHAT and settings.telegram_swarm_chat_id:
         else settings.telegram_swarm_chat_id
     )
 
-# Agent lock — one request at a time
-_agent_lock = asyncio.Lock()
+# Per-thread serialization + bounded global concurrency. A single heavy ReAct
+# cycle (up to 25 turns × 120s tool timeout) must not block every other
+# chat/topic/DM/peer-reaction. Each thread_id runs its turns in order (history
+# consistency); the semaphore caps how many threads hit the LLM API at once.
+_agent_semaphore = asyncio.Semaphore(int(os.environ.get("AGENT_MAX_CONCURRENCY", "3")))
+_thread_locks: dict[str, asyncio.Lock] = {}
+
+
+def _thread_lock(thread_id: str) -> asyncio.Lock:
+    """Return the per-thread lock, creating it on first use.
+
+    Synchronous on purpose: with no await between the get and the set, the
+    asyncio event loop can't interleave two calls, so there's no race and no
+    guard lock is needed. thread_id space is bounded by active chats×topics
+    (tens for a personal swarm), so the dict is never evicted.
+    """
+    lock = _thread_locks.get(thread_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _thread_locks[thread_id] = lock
+    return lock
 
 # Agent reference (set in run_bridge)
 _agent: KronosAgent | None = None
@@ -897,7 +916,7 @@ async def _ask_agent(
     reply = None
 
     try:
-        async with _agent_lock:
+        async with _thread_lock(thread_id), _agent_semaphore:
             reply = await _agent.ainvoke(
                 message=message,
                 thread_id=thread_id,
@@ -1211,8 +1230,10 @@ async def run_bridge(agent: KronosAgent) -> None:
         topic_id = await _approval_callback_topic_id(event, pending)
         approved = action == "approve"
         await event.answer("Approved" if approved else "Rejected")
+        # Serialize the resolve against new messages on the same thread.
+        approval_thread = str(pending["thread_id"]) if pending else f"approval:{approval_id}"
         try:
-            async with _agent_lock:
+            async with _thread_lock(approval_thread), _agent_semaphore:
                 reply = await _agent.resolve_tool_approval(
                     approval_id,
                     approved=approved,

--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 import os
 import random
+import secrets
 import tempfile
 import time
 from dataclasses import dataclass
@@ -963,10 +964,27 @@ async def _send_to_chat(
 # --- Webhook server (for cron scripts, same API as Kronos I) ---
 
 
-async def _handle_webhook(request: web.Request) -> web.Response:
-    secret = request.headers.get("X-Webhook-Secret", "")
-    if secret != settings.webhook_secret:
+def _webhook_unauthorized(request: web.Request) -> web.Response | None:
+    """Fail-closed webhook auth. Returns a 401 response when the request is not
+    authorized, else None.
+
+    An empty ``webhook_secret`` DISABLES the endpoint (always 401) instead of
+    letting everyone in: the historical ``secret != settings.webhook_secret``
+    check silently turned auth off when the secret was "" (``"" == ""``), and
+    the server binds a network port — so a missing secret exposed /webhook and
+    the chat-dumping /history to anyone who could reach it. Comparison is
+    constant-time to avoid leaking the secret via timing.
+    """
+    expected = settings.webhook_secret
+    provided = request.headers.get("X-Webhook-Secret", "")
+    if not expected or not secrets.compare_digest(provided, expected):
         return web.json_response({"error": "unauthorized"}, status=401)
+    return None
+
+
+async def _handle_webhook(request: web.Request) -> web.Response:
+    if (unauthorized := _webhook_unauthorized(request)) is not None:
+        return unauthorized
 
     try:
         body = await request.json()
@@ -993,9 +1011,8 @@ async def _handle_webhook(request: web.Request) -> web.Response:
 
 
 async def _handle_history(request: web.Request) -> web.Response:
-    secret = request.headers.get("X-Webhook-Secret", "")
-    if secret != settings.webhook_secret:
-        return web.json_response({"error": "unauthorized"}, status=401)
+    if (unauthorized := _webhook_unauthorized(request)) is not None:
+        return unauthorized
 
     chat_param = request.query.get("chat", "")
     if not chat_param:
@@ -1050,9 +1067,21 @@ async def _start_webhook_server() -> None:
     runner = web.AppRunner(app)
     await runner.setup()
     webhook_port = int(os.environ.get("WEBHOOK_PORT", "8788"))
-    site = web.TCPSite(runner, "0.0.0.0", webhook_port)
+    # Bind localhost by default; external exposure is opt-in via WEBHOOK_HOST
+    # (e.g. 0.0.0.0). Together with the fail-closed secret check this keeps the
+    # userbot's chat-dumping /history off the public network unless explicitly
+    # opened AND a secret is set.
+    webhook_host = os.environ.get("WEBHOOK_HOST", "127.0.0.1")
+    site = web.TCPSite(runner, webhook_host, webhook_port)
     await site.start()
-    log.info("Webhook server listening on port %d", webhook_port)
+    if webhook_host not in ("127.0.0.1", "localhost", "::1") and not settings.webhook_secret:
+        log.warning(
+            "Webhook bound to %s with an empty WEBHOOK_SECRET — every /webhook "
+            "and /history request is rejected (fail-closed). Set WEBHOOK_SECRET "
+            "to serve external clients.",
+            webhook_host,
+        )
+    log.info("Webhook server listening on %s:%d", webhook_host, webhook_port)
 
 
 # --- ASO command handler ---

--- a/kronos/config.py
+++ b/kronos/config.py
@@ -78,6 +78,12 @@ class Settings(BaseSettings):
     enable_mcp_gateway_management: bool = False
     enable_dynamic_mcp_servers: bool = False
     enable_server_ops: bool = False
+    # Human-in-the-loop approval for risky tool calls (deploy/delete/MCP
+    # mutations/add_expense — see engine.DEFAULT_APPROVAL_*). ON by default so a
+    # fresh PyPI install never runs destructive tools unattended; trusted
+    # single-user deployments opt out with TOOL_APPROVALS_ENABLED=false.
+    # Only gates the interactive agent path; cron jobs invoke tools directly.
+    tool_approvals_enabled: bool = True
 
     # Memory — per-agent isolation (resolved in model_post_init from agent_name
     # when left empty). Explicit env overrides still win.

--- a/kronos/cron/scheduler.py
+++ b/kronos/cron/scheduler.py
@@ -37,6 +37,10 @@ def _append_run_history(entry: dict) -> None:
 # UTC+8 timezone for scheduling
 UTC8 = timezone(timedelta(hours=8))
 
+# Consecutive failures before a job fires an NTFY alert (so a job can't fail
+# silently for a week — the scheduler otherwise just logs and moves on).
+CRON_ALERT_THRESHOLD = 3
+
 
 @dataclass
 class CronJob:
@@ -49,6 +53,7 @@ class CronJob:
     enabled: bool = True
     last_run: float = 0.0
     _running: bool = False
+    consecutive_failures: int = 0
 
 
 class Scheduler:
@@ -57,6 +62,9 @@ class Scheduler:
     def __init__(self):
         self.jobs: dict[str, CronJob] = {}
         self._stop = asyncio.Event()
+        # Hold strong refs to in-flight job tasks; asyncio only keeps a weak
+        # reference, so without this the GC can collect a task mid-run.
+        self._running_tasks: set[asyncio.Task] = set()
 
     def add(self, job: CronJob) -> None:
         self.jobs[job.name] = job
@@ -135,6 +143,28 @@ class Scheduler:
 
         return False
 
+    async def _maybe_alert(self, job: CronJob) -> None:
+        """Fire one NTFY alert when a job first hits CRON_ALERT_THRESHOLD.
+
+        Uses == (not >=) so a persistently failing job alerts once at the
+        threshold rather than on every subsequent run.
+        """
+        if job.consecutive_failures != CRON_ALERT_THRESHOLD:
+            return
+        try:
+            from kronos.cron.notify import send_ntfy
+
+            await asyncio.to_thread(
+                send_ntfy,
+                f"Cron job '{job.name}' failed {job.consecutive_failures}× in a row "
+                f"on agent '{settings.agent_name}'. Check logs.",
+                title="Kronos cron failing",
+                priority="high",
+                tags="warning",
+            )
+        except Exception as e:
+            log.warning("Failed to send cron failure alert for %s: %s", job.name, e)
+
     async def _run_job(self, job: CronJob) -> None:
         job._running = True
         job.last_run = time.time()
@@ -147,12 +177,18 @@ class Scheduler:
         try:
             await job.func()
             duration = time.monotonic() - start
+            job.consecutive_failures = 0
             log.info("[cron] Completed: %s (%.1fs)", job.name, duration)
         except Exception as e:
             duration = time.monotonic() - start
             status = "error"
             error = str(e)
-            log.error("[cron] Failed: %s (%.1fs): %s", job.name, duration, e)
+            job.consecutive_failures += 1
+            log.error(
+                "[cron] Failed: %s (%.1fs) [%d in a row]: %s",
+                job.name, duration, job.consecutive_failures, e,
+            )
+            await self._maybe_alert(job)
         finally:
             job._running = False
             _append_run_history({
@@ -177,7 +213,9 @@ class Scheduler:
         while not self._stop.is_set():
             for job in self.jobs.values():
                 if self._should_run(job):
-                    asyncio.create_task(self._run_job(job))
+                    task = asyncio.create_task(self._run_job(job))
+                    self._running_tasks.add(task)
+                    task.add_done_callback(self._running_tasks.discard)
 
             # Check every 30 seconds
             try:

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -26,8 +26,9 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     from kronos.cron.analytics_alerts import run_analytics_alerts
     from kronos.cron.analytics_pulse import run_analytics_pulse
     from kronos.cron.analytics_weekly import run_analytics_weekly
-    from kronos.cron.expenses.processor import run_email_expenses
     from kronos.cron.expense_digest import run_expense_digest
+    from kronos.cron.expenses.processor import run_email_expenses
+
     # DISABLED 2026-07-07: group-digest paused — duplicate of news-monitor on Digest:News.
     # from kronos.cron.group_digest import run_group_digest
     from kronos.cron.heartbeat import run_heartbeat

--- a/kronos/engine.py
+++ b/kronos/engine.py
@@ -20,6 +20,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, SystemMessage, ToolMessage
 from langchain_core.tools import BaseTool
 
+from kronos.config import settings
 from kronos.tools.error_handler import classify_tool_error
 
 log = logging.getLogger("kronos.engine")
@@ -81,9 +82,9 @@ DEFAULT_APPROVAL_NAME_MARKERS = (
     "update",
 )
 
-# Tool-call approval prompts are intentionally disabled for trusted local
-# deployments: tools execute immediately, including historically risky tools.
-TOOL_APPROVALS_ENABLED = False
+# Whether risky tool calls pause for human approval is a config gate
+# (settings.tool_approvals_enabled, ON by default). Read at call time so env
+# overrides and tests take effect without reimporting the module.
 
 DEFAULT_COMPACT_OUTPUT_NAME_MARKERS = (
     "brave",
@@ -120,7 +121,7 @@ class AgentResult:
 
 def tool_requires_approval(tool: BaseTool, args: dict) -> bool:
     """Return whether a tool call should pause for human approval."""
-    if not TOOL_APPROVALS_ENABLED:
+    if not settings.tool_approvals_enabled:
         return False
 
     metadata = getattr(tool, "metadata", None) or {}
@@ -369,7 +370,7 @@ async def react_loop(
             log.warning("Tool result cache write failed (non-fatal): %s", e)
 
     async def requires_approval(tool: BaseTool, tool_call: dict) -> bool:
-        if not TOOL_APPROVALS_ENABLED:
+        if not settings.tool_approvals_enabled:
             return False
 
         predicate = needs_tool_approval or tool_requires_approval

--- a/kronos/group_router.py
+++ b/kronos/group_router.py
@@ -147,8 +147,12 @@ class GroupRouter:
             for alias in data["aliases"]:
                 self._alias_to_agent[alias] = name
 
-        # Tier 3: track peer reactions to prevent loops / flood
-        self._last_peer_reaction: float = 0
+        # Tier 3: track peer reactions to prevent loops / flood.
+        # -inf, not 0: the cooldown compares against time.monotonic(), which on
+        # Linux counts from boot. With 0, a fresh process whose monotonic clock
+        # is still < PEER_REACTION_COOLDOWN (e.g. right after a restart) would
+        # falsely treat the FIRST reaction as cooled-down and never react.
+        self._last_peer_reaction: float = float("-inf")
         self._reacted_to_msgs: set[int] = set()
 
     # ------------------------------------------------------------------

--- a/kronos/llm.py
+++ b/kronos/llm.py
@@ -531,6 +531,16 @@ def resolve_provider_config(provider: str) -> ProviderConfig | None:
     )
 
 
+def active_provider_cooldowns() -> dict[str, float]:
+    """Providers currently in cooldown → seconds remaining. Empty = all healthy."""
+    now = time.time()
+    return {
+        provider: round(until - now, 1)
+        for provider, until in _state._cooldowns.items()
+        if until > now
+    }
+
+
 def reset_provider_state() -> None:
     """Clear cached model instances and cooldowns. Intended for tests."""
     global _callback_cache, _callback_signature

--- a/scripts/auth-userbot.py
+++ b/scripts/auth-userbot.py
@@ -22,6 +22,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ["TG_BOT_TOKEN"] = ""
 
 from telethon import TelegramClient
+
 from kronos.config import settings
 
 

--- a/scripts/list-groups.py
+++ b/scripts/list-groups.py
@@ -92,7 +92,7 @@ async def main():
         about = g["about"][:80] if g["about"] else ""
         print(f"| {i} | {g['title']} | {g['identifier']} | {members_str} | {about} |")
 
-    print(f"\n## Группы/супергруппы (чаты)\n")
+    print("\n## Группы/супергруппы (чаты)\n")
     print("| # | Name | ID | Members | Description |")
     print("|---|------|----|---------|-------------|")
     for i, g in enumerate(chats, 1):

--- a/scripts/render_demo_assets.py
+++ b/scripts/render_demo_assets.py
@@ -10,10 +10,9 @@ from __future__ import annotations
 import html
 import shutil
 import subprocess
-import textwrap
 import tempfile
+import textwrap
 from pathlib import Path
-
 
 ROOT = Path(__file__).resolve().parents[1]
 ASSETS = ROOT / "docs" / "assets"

--- a/scripts/seed_demo_state.py
+++ b/scripts/seed_demo_state.py
@@ -7,6 +7,5 @@ import sys
 
 from kronos.cli import main
 
-
 if __name__ == "__main__":
     raise SystemExit(main(["demo-seed", *sys.argv[1:]]))

--- a/scripts/test-group-digest.py
+++ b/scripts/test-group-digest.py
@@ -22,6 +22,5 @@ os.environ["USERBOT_SESSION"] = "userbot"
 
 from kronos.cron.group_digest import run_group_digest
 
-
 if __name__ == "__main__":
     asyncio.run(run_group_digest())

--- a/tests/evals/test_swarm_invariants.py
+++ b/tests/evals/test_swarm_invariants.py
@@ -296,3 +296,26 @@ def test_implicit_reply_cap_and_pass_cancellation(swarm) -> None:
     )
     assert cancelled.won is False
     assert cancelled.reason == "no active claim"
+
+
+@pytest.mark.asyncio
+async def test_first_peer_reaction_survives_low_monotonic_clock(monkeypatch):
+    # Regression: the Tier-3 cooldown compares against time.monotonic(), which
+    # is boot-relative on Linux. On a fresh runner/host whose monotonic clock is
+    # still below PEER_REACTION_COOLDOWN, the FIRST peer reaction must not be
+    # falsely treated as cooled-down (this passed on high-uptime dev machines
+    # but failed on a fresh CI runner).
+    monkeypatch.setattr(time, "monotonic", lambda: 5.0)
+    router = _router("kronos")
+    user_root = MagicMock(sender_id=USER_ID)
+    evt = _event(
+        text="peer answer right after restart",
+        sender_id=PEER_ID,
+        msg_id=777,
+        reply_msg=user_root,
+    )
+    with patch.object(router, "_should_react_to_peer", new=AsyncMock(return_value=True)):
+        decision = await router.decide(evt, client=MagicMock())
+
+    assert decision.should_respond is True
+    assert decision.tier == 3

--- a/tests/test_bridge_concurrency.py
+++ b/tests/test_bridge_concurrency.py
@@ -1,0 +1,48 @@
+"""Per-thread serialization for the agent path.
+
+Guards the fix that replaced a single global _agent_lock (which serialized
+every chat/topic/DM behind one heavy ReAct cycle) with per-thread locks plus
+a bounded global semaphore.
+"""
+
+import asyncio
+
+from kronos import bridge
+
+
+def test_thread_lock_stable_per_thread_and_distinct_across():
+    a1 = bridge._thread_lock("chat:1")
+    a2 = bridge._thread_lock("chat:1")
+    b = bridge._thread_lock("chat:2")
+    assert a1 is a2  # same thread → same lock (turns stay ordered)
+    assert a1 is not b  # different threads → independent locks
+
+
+async def _worker(order: list[str], thread_id: str, tag: str):
+    async with bridge._thread_lock(thread_id):
+        order.append(f"{tag}-enter")
+        await asyncio.sleep(0.02)
+        order.append(f"{tag}-exit")
+
+
+async def test_same_thread_is_serialized():
+    order: list[str] = []
+    await asyncio.gather(
+        _worker(order, "same-thread", "A"),
+        _worker(order, "same-thread", "B"),
+    )
+    # one completes fully before the other starts — no interleaving
+    assert order in (
+        ["A-enter", "A-exit", "B-enter", "B-exit"],
+        ["B-enter", "B-exit", "A-enter", "A-exit"],
+    )
+
+
+async def test_distinct_threads_run_concurrently():
+    order: list[str] = []
+    await asyncio.gather(
+        _worker(order, "thread-x", "A"),
+        _worker(order, "thread-y", "B"),
+    )
+    # both enter before either exits — they overlap
+    assert set(order[:2]) == {"A-enter", "B-enter"}

--- a/tests/test_bridge_health.py
+++ b/tests/test_bridge_health.py
@@ -1,0 +1,30 @@
+"""Live /health endpoint.
+
+Guards the change from a static {"status": "ok"} to a real readiness probe
+that reflects the Telegram client connection (so a 15-min health-check stops
+validating a fiction).
+"""
+
+import json
+from types import SimpleNamespace
+
+from aiohttp.test_utils import make_mocked_request
+
+from kronos import bridge
+
+
+async def test_health_degraded_when_client_disconnected(monkeypatch):
+    monkeypatch.setattr(bridge, "_client", None)
+    resp = await bridge._handle_health(make_mocked_request("GET", "/health"))
+    assert resp.status == 503
+    assert json.loads(resp.body)["telegram_connected"] is False
+
+
+async def test_health_ok_when_client_connected(monkeypatch):
+    monkeypatch.setattr(bridge, "_client", SimpleNamespace(is_connected=lambda: True))
+    resp = await bridge._handle_health(make_mocked_request("GET", "/health"))
+    assert resp.status == 200
+    body = json.loads(resp.body)
+    assert body["status"] == "ok"
+    assert body["telegram_connected"] is True
+    assert "providers_in_cooldown" in body

--- a/tests/test_cron_scheduler.py
+++ b/tests/test_cron_scheduler.py
@@ -1,0 +1,61 @@
+"""Cron scheduler resilience: failure alerting + counter bookkeeping.
+
+Guards the change that alerts via NTFY after N consecutive failures instead
+of letting a job fail silently for a week.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from kronos.cron.scheduler import CRON_ALERT_THRESHOLD, CronJob, Scheduler
+
+
+@pytest.fixture
+def scheduler(monkeypatch):
+    # Keep _run_job off the real data/ and logs/ paths.
+    monkeypatch.setattr("kronos.cron.scheduler._append_run_history", lambda entry: None)
+    sched = Scheduler()
+    monkeypatch.setattr(sched, "_save_state", lambda: None)
+    return sched
+
+
+async def test_alert_fires_once_at_threshold(scheduler):
+    async def flaky():
+        raise RuntimeError("boom")
+
+    job = CronJob(name="flaky", func=flaky)
+    with patch("kronos.cron.notify.send_ntfy", return_value=True) as ntfy:
+        for _ in range(CRON_ALERT_THRESHOLD + 2):
+            await scheduler._run_job(job)
+
+    assert job.consecutive_failures == CRON_ALERT_THRESHOLD + 2
+    ntfy.assert_called_once()  # exactly once, at the threshold — no spam after
+
+
+async def test_no_alert_below_threshold(scheduler):
+    async def flaky():
+        raise RuntimeError("boom")
+
+    job = CronJob(name="flaky2", func=flaky)
+    with patch("kronos.cron.notify.send_ntfy", return_value=True) as ntfy:
+        for _ in range(CRON_ALERT_THRESHOLD - 1):
+            await scheduler._run_job(job)
+
+    ntfy.assert_not_called()
+
+
+async def test_success_resets_failure_counter(scheduler):
+    state = {"fail": True}
+
+    async def sometimes():
+        if state["fail"]:
+            raise RuntimeError("boom")
+
+    job = CronJob(name="sometimes", func=sometimes)
+    with patch("kronos.cron.notify.send_ntfy", return_value=True):
+        await scheduler._run_job(job)
+        assert job.consecutive_failures == 1
+        state["fail"] = False
+        await scheduler._run_job(job)
+        assert job.consecutive_failures == 0

--- a/tests/test_durable_turns.py
+++ b/tests/test_durable_turns.py
@@ -6,6 +6,7 @@ import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.tools import StructuredTool
 
+from kronos.config import settings
 from kronos.engine import react_loop
 from kronos.graph import KronosAgent
 from kronos.session import SessionStore
@@ -227,7 +228,8 @@ async def test_pending_approval_claims_exactly_once(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_agent_tool_executes_without_approval(tmp_path: Path) -> None:
+async def test_agent_tool_executes_without_approval(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "tool_approvals_enabled", False)
     db_path = tmp_path / "session.db"
     store = SessionStore(str(db_path))
     calls = 0
@@ -272,7 +274,8 @@ async def test_agent_tool_executes_without_approval(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_agent_tool_series_executes_without_approval(tmp_path: Path) -> None:
+async def test_agent_tool_series_executes_without_approval(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "tool_approvals_enabled", False)
     store = SessionStore(str(tmp_path / "session.db"))
     calls = 0
 
@@ -317,7 +320,8 @@ async def test_agent_tool_series_executes_without_approval(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_agent_different_tools_execute_without_approval(tmp_path: Path) -> None:
+async def test_agent_different_tools_execute_without_approval(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "tool_approvals_enabled", False)
     store = SessionStore(str(tmp_path / "session.db"))
     replace_calls = 0
     remove_calls = 0
@@ -368,7 +372,8 @@ async def test_agent_different_tools_execute_without_approval(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
-async def test_agent_remove_tool_executes_without_approval(tmp_path: Path) -> None:
+async def test_agent_remove_tool_executes_without_approval(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "tool_approvals_enabled", False)
     store = SessionStore(str(tmp_path / "session.db"))
     calls = 0
 

--- a/tests/test_durable_turns.py
+++ b/tests/test_durable_turns.py
@@ -139,7 +139,10 @@ async def test_graph_recovery_runs_before_loading_next_turn(tmp_path: Path) -> N
     )
     agent = _minimal_agent(store)
 
-    with patch("kronos.graph.react_loop", new=AsyncMock(return_value=type("Result", (), {"content": "next ok"})())):
+    with (
+        patch("kronos.graph.get_model", return_value=MagicMock()),
+        patch("kronos.graph.react_loop", new=AsyncMock(return_value=type("Result", (), {"content": "next ok"})())),
+    ):
         reply = await agent.ainvoke(
             message="next",
             thread_id="thread",
@@ -168,7 +171,10 @@ async def test_ephemeral_peer_reaction_does_not_open_durable_turn(tmp_path: Path
     agent = _minimal_agent(store)
     store.begin_turn = AsyncMock(side_effect=AssertionError("ephemeral turn must not journal"))
 
-    with patch("kronos.graph.react_loop", new=AsyncMock(return_value=type("Result", (), {"content": "delta"})())):
+    with (
+        patch("kronos.graph.get_model", return_value=MagicMock()),
+        patch("kronos.graph.react_loop", new=AsyncMock(return_value=type("Result", (), {"content": "delta"})())),
+    ):
         reply = await agent.ainvoke(
             message="peer context",
             thread_id="thread",

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -6,6 +6,7 @@ import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.tools import StructuredTool
 
+from kronos.config import settings
 from kronos.engine import (
     AgentResult,
     create_agent,
@@ -309,8 +310,8 @@ class TestReactLoop:
         assert "ошибка" in result.content.lower()
 
     @pytest.mark.asyncio
-    async def test_tool_call_executes_without_approval(self):
-        """Risky tools execute immediately; approval callbacks are ignored."""
+    async def test_tool_call_pauses_for_approval(self):
+        """With approvals on (default), a risky tool pauses instead of executing."""
         calls = 0
         approval_requests = []
 
@@ -339,18 +340,51 @@ class TestReactLoop:
             on_tool_event=lambda event, payload: events.append((event, payload)),
         )
 
-        assert calls == 1
-        assert approval_requests == []
-        assert result.waiting_approval is False
-        assert result.approval_id is None
-        assert result.approval_tool_name is None
-        assert result.content == "executed ok"
-        assert [event for event, _ in events] == ["tool_call", "tool_result"]
-        tool_messages = [m for m in result.messages if isinstance(m, ToolMessage)]
-        assert [m.content for m in tool_messages] == ["executed"]
+        assert calls == 0  # paused, not executed
+        assert approval_requests == ["mcp_add_server"]
+        assert result.waiting_approval is True
+        assert result.approval_id == "apr_1"
+        assert result.approval_tool_name == "mcp_add_server"
+        assert "Approval ID" in result.content
+        assert "tool_approval_required" in [event for event, _ in events]
 
     @pytest.mark.asyncio
-    async def test_prior_tool_results_are_journaled_without_approval_wait(self):
+    async def test_disabling_approvals_executes_risky_tool_immediately(self, monkeypatch):
+        """TOOL_APPROVALS_ENABLED=false restores immediate execution for trusted deploys."""
+        monkeypatch.setattr(settings, "tool_approvals_enabled", False)
+        calls = 0
+        approval_requests = []
+
+        async def risky_tool() -> str:
+            nonlocal calls
+            calls += 1
+            return "executed"
+
+        tool = StructuredTool.from_function(
+            coroutine=risky_tool,
+            name="mcp_add_server",
+            description="mutates MCP servers",
+        )
+        model = _make_model([
+            _ai_with_tool_call("mcp_add_server"),
+            AIMessage(content="executed ok"),
+        ])
+
+        result = await react_loop(
+            model,
+            [HumanMessage(content="add server")],
+            tools=[tool],
+            needs_tool_approval=lambda tool, args: True,
+            request_tool_approval=lambda tool, tool_call: approval_requests.append(tool.name) or "apr_1",
+        )
+
+        assert calls == 1  # executed immediately, approval bypassed
+        assert approval_requests == []
+        assert result.waiting_approval is False
+        assert result.content == "executed ok"
+
+    @pytest.mark.asyncio
+    async def test_prior_tool_results_are_journaled_before_approval_pause(self):
         read_calls = 0
         risky_calls = 0
 
@@ -394,23 +428,24 @@ class TestReactLoop:
             on_message_delta=lambda delta: journaled.extend(delta),
         )
 
-        assert result.waiting_approval is False
-        assert result.content == "done"
+        # read-only get_status runs; risky mcp_remove_server pauses for approval
+        # before executing, and get_status's result is journaled before the pause.
+        assert result.waiting_approval is True
+        assert result.approval_tool_name == "mcp_remove_server"
         assert read_calls == 1
-        assert risky_calls == 1
+        assert risky_calls == 0
         tool_messages = [m for m in result.messages if isinstance(m, ToolMessage)]
         assert [(m.tool_call_id, m.content) for m in tool_messages] == [
             ("call_read", "read ok"),
-            ("call_risky", "risky ok"),
         ]
         journaled_tool_messages = [m for m in journaled if isinstance(m, ToolMessage)]
-        assert [m.tool_call_id for m in journaled_tool_messages] == ["call_read", "call_risky"]
+        assert [m.tool_call_id for m in journaled_tool_messages] == ["call_read"]
 
-    def test_default_approval_policy_is_disabled(self):
-        risky = _make_tool("send_telegram_message")
-        read_only = _make_tool("list_status_updates")
+    def test_default_approval_policy_is_enabled(self):
+        risky = _make_tool("send_telegram_message")  # send_ marker → approval
+        read_only = _make_tool("list_status_updates")  # list_ prefix → no approval
 
-        assert tool_requires_approval(risky, {}) is False
+        assert tool_requires_approval(risky, {}) is True
         assert tool_requires_approval(read_only, {}) is False
 
 

--- a/tests/test_personal_observer_cron.py
+++ b/tests/test_personal_observer_cron.py
@@ -128,9 +128,12 @@ def test_personal_observer_schedule_avoids_existing_morning_conflicts(monkeypatc
     setup_cron_jobs(scheduler)
     used_hours = {name: hour for name, (_func, hour) in scheduler.daily.items()}
 
-    assert used_hours["personal-observer"] == 23
-    assert used_hours["personal-observer"] not in {
-        used_hours["news-monitor"],
-        used_hours["group-digest"],
-        used_hours["email-expenses"],
+    # personal-observer at 23:00 UTC must not collide with any other daily
+    # job's hour. Checking against every registered daily job (instead of a
+    # hardcoded list) keeps the test correct as jobs are paused/resumed —
+    # e.g. group-digest was paused 2026-07-07 and its key no longer exists.
+    other_daily_hours = {
+        hour for name, hour in used_hours.items() if name != "personal-observer"
     }
+    assert used_hours["personal-observer"] == 23
+    assert used_hours["personal-observer"] not in other_daily_hours

--- a/tests/test_webhook_auth.py
+++ b/tests/test_webhook_auth.py
@@ -1,0 +1,37 @@
+"""Fail-closed auth for the bridge webhook server.
+
+Regression guard for the insecure default where an empty webhook_secret
+turned auth off (`"" == ""`) on a network-bound server, exposing /webhook
+and the chat-dumping /history.
+"""
+
+from aiohttp.test_utils import make_mocked_request
+
+from kronos import bridge
+from kronos.config import settings
+
+
+def _req(secret_header: str | None = None):
+    headers = {"X-Webhook-Secret": secret_header} if secret_header is not None else {}
+    return make_mocked_request("POST", "/webhook", headers=headers)
+
+
+def test_empty_secret_is_fail_closed(monkeypatch):
+    # No secret configured → the endpoint must reject everyone, never open up.
+    monkeypatch.setattr(settings, "webhook_secret", "")
+    assert bridge._webhook_unauthorized(_req()) is not None
+    assert bridge._webhook_unauthorized(_req("")) is not None
+    assert bridge._webhook_unauthorized(_req("anything")) is not None
+    assert bridge._webhook_unauthorized(_req()).status == 401
+
+
+def test_correct_secret_authorizes(monkeypatch):
+    monkeypatch.setattr(settings, "webhook_secret", "s3cret")
+    assert bridge._webhook_unauthorized(_req("s3cret")) is None
+
+
+def test_wrong_or_missing_secret_rejected(monkeypatch):
+    monkeypatch.setattr(settings, "webhook_secret", "s3cret")
+    assert bridge._webhook_unauthorized(_req("wrong")) is not None
+    assert bridge._webhook_unauthorized(_req()) is not None
+    assert bridge._webhook_unauthorized(_req("")) is not None


### PR DESCRIPTION
Closes the hardening block of the roadmap (phases 0–3): make CI actually catch regressions, close the security holes, and harden the runtime under load. 13 atomic commits.

## Phase 0 — CI green
- Fix ruff `I001`/`F541` (lint gate was red on cron/setup import order)
- `npm audit fix` in dashboard-ui → 0 vulnerabilities (lockfile-only)
- Fix `test_personal_observer` KeyError after group-digest pause (assert vs all daily hours)
- Make durable recovery tests hermetic (mock `get_model`) so the suite runs **without LLM keys** — 592 passed, 0 failures with no keys
- Move `npm audit` out of the PR gate into a scheduled workflow + Dependabot (a new CVE must not turn unrelated PRs red)

## Phase 1 — Security
- **Webhook fail-closed**: an empty `webhook_secret` disabled auth (`"" == ""`) on a network-bound server, exposing `/webhook` and the chat-dumping `/history`. Empty secret now → always 401; bind `127.0.0.1` by default (external via `WEBHOOK_HOST`); constant-time compare.
- **Tool approvals** are now a config gate (`TOOL_APPROVALS_ENABLED`), **on by default**, so a fresh install never runs deploy/delete/mcp-mutations unattended. Only gates the interactive agent path; cron jobs are unaffected.
- Constant-time dashboard credential check (`secrets.compare_digest`).

## Phase 2 — Resilience
- Replace the global `_agent_lock` with **per-thread locks + a bounded semaphore** (`AGENT_MAX_CONCURRENCY`), so one heavy ReAct cycle no longer blocks every chat.
- Cron: strong task refs (GC can't collect a job mid-run) + one NTFY alert after N consecutive failures.
- Graceful shutdown on SIGTERM/SIGINT (stop scheduler, cancel services, re-raise genuine crashes for systemd).
- Live `/health`: Telegram connection, last-event age, provider cooldowns; 503 when disconnected.

## Phase 3 — Polish
- Single source of version via `importlib.metadata`.
- Starlette/httpx2 deprecation: no-op for now (httpx2 unpublished), covered by Dependabot.

## Tests
592 passed, 40 deselected (integration), 0 failures — verified **without LLM keys** (CI conditions). ruff clean. New regression tests: webhook fail-closed, approval on/off, per-thread concurrency, cron alerting, live health.

## ⚠️ Deploy note
Tool approvals default to **on**. Trusted single-user deployments that don't want approval prompts in the interactive chat should set `TOOL_APPROVALS_ENABLED=false` in their `.env` before deploying. Cron automation (e.g. email-expenses) is unaffected — it invokes tools directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)