### PR TITLE
UX: live progress, scheduled tasks, agent follow-ups (roadmap phase 4)

### DIFF
--- a/kronos/agents/supervisor.py
+++ b/kronos/agents/supervisor.py
@@ -352,8 +352,16 @@ def build_supervisor(
     # Combine: delegation tools + supervisor-only tools + direct tools
     all_tools = delegation_tools + supervisor_tools + direct_tools
 
-    async def run(messages: list[BaseMessage], **react_loop_kwargs) -> AgentResult:
-        """Route request to appropriate sub-agent or respond directly."""
+    async def run(
+        messages: list[BaseMessage],
+        on_tool_event: Callable[[str, dict[str, Any]], None] | None = on_tool_event,
+        **react_loop_kwargs,
+    ) -> AgentResult:
+        """Route request to appropriate sub-agent or respond directly.
+
+        on_tool_event defaults to the build-time callback but can be overridden
+        per call (e.g. bridge live progress), so callers layer their own sink.
+        """
         return await react_loop(
             model=model,
             messages=list(messages),

--- a/kronos/audit.py
+++ b/kronos/audit.py
@@ -62,6 +62,15 @@ def reset_tool_audit_context(token: Token) -> None:
     _tool_audit_context.reset(token)
 
 
+def get_tool_audit_context() -> dict[str, str]:
+    """Current per-request context (agent, thread_id, session_id, ...) or {}.
+
+    Lets tools that run mid-invocation recover which chat/thread they belong to
+    (e.g. schedule_task needs the originating chat to deliver the reminder).
+    """
+    return dict(_tool_audit_context.get())
+
+
 def _redact_string(value: str, *, max_len: int = 500) -> str:
     redacted = value
     for pattern, replacement in _SECRET_PATTERNS:

--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -79,6 +79,15 @@ _my_id: int | None = None
 # Monotonic-wall timestamp of the last incoming Telegram event, for /health
 # liveness (0.0 = nothing received yet).
 _last_event_ts: float = 0.0
+
+
+def get_agent() -> "KronosAgent | None":
+    """Current KronosAgent instance (set in run_bridge), or None.
+
+    Lets in-process cron jobs (e.g. follow-ups) reuse the live agent instead of
+    building a second one.
+    """
+    return _agent
 _my_username: str | None = None
 
 # Group routing (initialized in run_bridge after login)

--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -884,6 +884,113 @@ async def _clear_context(chat_id: int, topic_id: int | None = None) -> str:
     return await _agent.clear_context(thread_id)
 
 
+# --- Live progress reporter (roadmap 4.1) ---
+
+_PROGRESS_THROTTLE_SECONDS = 1.6  # keep well under Telegram's edit rate limit
+_PROGRESS_TOOL_LABELS: tuple[tuple[str, str], ...] = (
+    ("brave", "🔍 ищу в вебе"),
+    ("exa", "🔍 ищу в вебе"),
+    ("search", "🔍 ищу"),
+    ("fetch", "📄 читаю источник"),
+    ("content", "📄 читаю источник"),
+    ("extract", "📄 разбираю материал"),
+    ("transcript", "📄 читаю расшифровку"),
+    ("channel", "📡 смотрю каналы"),
+    ("digest", "📡 собираю дайджест"),
+    ("finance", "💹 считаю финансы"),
+    ("expense", "💹 записываю расход"),
+    ("memory", "🧠 роюсь в памяти"),
+    ("deploy", "🚀 деплою"),
+)
+
+
+def _humanize_tool(name: str) -> str:
+    low = name.lower()
+    for marker, label in _PROGRESS_TOOL_LABELS:
+        if marker in low:
+            return label
+    return f"🔧 {name}"
+
+
+def _progress_label(event: str, payload: dict) -> str | None:
+    if event == "tool_call":
+        return f"{_humanize_tool(str(payload.get('name', '')))}…"
+    if event == "tool_approval_required":
+        return "⏸️ жду подтверждения…"
+    return None
+
+
+class _ProgressReporter:
+    """Edits a single throwaway 'draft' message with live tool progress.
+
+    Lazily materialized: the draft is only sent once there's something to
+    report, so fast (no-tool) replies don't flash a throwaway message. It is
+    deleted in finish() so the caller's normal send path (validation, approval
+    buttons, TTS, chunking) is untouched. All Telegram calls are best-effort —
+    progress must never break a real reply.
+    """
+
+    def __init__(self, chat_id: int, topic_id: int | None):
+        self._chat_id = chat_id
+        self._topic_id = topic_id
+        self._draft = None
+        self._shown = ""
+        self._pending: str | None = None
+        self._stop = asyncio.Event()
+        self._task: asyncio.Task | None = None
+
+    def start(self) -> "_ProgressReporter":
+        self._task = asyncio.create_task(self._run())
+        return self
+
+    def on_event(self, event: str, payload: dict) -> None:
+        # Sync callback invoked from the engine on each tool event.
+        label = _progress_label(event, payload)
+        if label:
+            self._pending = label
+
+    async def _run(self) -> None:
+        while not self._stop.is_set():
+            pending = self._pending
+            if pending and pending != self._shown:
+                self._shown = pending
+                await self._render(pending)
+                # Throttle edits to stay under Telegram's rate limit.
+                wait = _PROGRESS_THROTTLE_SECONDS
+            else:
+                # Nothing to show yet — poll often so the first event surfaces
+                # quickly instead of after a full throttle window.
+                wait = 0.1
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=wait)
+            except TimeoutError:
+                pass
+
+    async def _render(self, text: str) -> None:
+        try:
+            if self._draft is None:
+                kwargs = {"reply_to": self._topic_id} if self._topic_id else {}
+                self._draft = await _client.send_message(self._chat_id, text, **kwargs)
+            else:
+                await _client.edit_message(self._chat_id, self._draft, text)
+        except Exception as e:
+            log.debug("Progress render failed (non-fatal): %s", e)
+
+    async def finish(self) -> None:
+        self._stop.set()
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+        if self._draft is not None:
+            try:
+                await _client.delete_messages(self._chat_id, [self._draft])
+            except Exception as e:
+                log.debug("Progress draft delete failed (non-fatal): %s", e)
+
+
 async def _ask_agent(
     message: str,
     chat_id: int,
@@ -911,9 +1018,10 @@ async def _ask_agent(
     # Topic-aware thread isolation
     thread_id = f"{chat_id}:{topic_id}" if topic_id else str(chat_id)
 
-    # Start typing indicator
+    # Start typing indicator + live progress reporter
     stop_typing = asyncio.Event()
     typing_task = asyncio.create_task(_typing_loop(chat_id, stop_typing))
+    reporter = _ProgressReporter(chat_id, topic_id).start()
 
     start_ms = int(time.monotonic() * 1000)
     reply = None
@@ -928,6 +1036,7 @@ async def _ask_agent(
                 source_kind=source_kind,
                 persist_user_turn=persist_user_turn,
                 extra_system_context=extra_system_context,
+                on_tool_event=reporter.on_event,
             )
     except Exception as e:
         log.error("Agent error: %s", e)
@@ -935,6 +1044,7 @@ async def _ask_agent(
     finally:
         stop_typing.set()
         typing_task.cancel()
+        await reporter.finish()
 
     if not reply:
         reply = "Не удалось получить ответ от агента. Попробуй переформулировать запрос."

--- a/kronos/cron/reminders.py
+++ b/kronos/cron/reminders.py
@@ -1,0 +1,34 @@
+"""Fire due user-scheduled tasks (roadmap 4.2).
+
+Polled by the Scheduler each minute; every due task is delivered to its chat
+via the self-webhook, then completed (one-shot → done, recurring → next run).
+Delivery failures leave the task pending so the next cycle retries.
+"""
+
+import asyncio
+import logging
+
+from kronos import scheduled_tasks
+from kronos.config import settings
+from kronos.cron.notify import send_webhook
+
+log = logging.getLogger("kronos.cron.reminders")
+
+
+async def run_due_reminders() -> None:
+    tasks = scheduled_tasks.due_tasks(settings.agent_name)
+    if not tasks:
+        return
+    log.info("Firing %d due scheduled task(s)", len(tasks))
+    for task in tasks:
+        ok = await asyncio.to_thread(
+            send_webhook,
+            task["message"],
+            task["chat_id"],
+            None,  # parse_mode
+            task["topic_id"],
+        )
+        if ok:
+            scheduled_tasks.complete_task(task["id"], task["recur_seconds"], task["run_at"])
+        else:
+            log.warning("Reminder #%s delivery failed; will retry next cycle", task["id"])

--- a/kronos/cron/reminders.py
+++ b/kronos/cron/reminders.py
@@ -1,8 +1,10 @@
-"""Fire due user-scheduled tasks (roadmap 4.2).
+"""Fire due user-scheduled tasks (roadmap 4.2 + follow-ups 4.3).
 
-Polled by the Scheduler each minute; every due task is delivered to its chat
-via the self-webhook, then completed (one-shot → done, recurring → next run).
-Delivery failures leave the task pending so the next cycle retries.
+Polled by the Scheduler each minute. A "reminder" task delivers its message
+verbatim; a "followup" task runs the message as a prompt through the live agent
+and delivers the agent's result. Both go to the originating chat via the
+self-webhook; delivery/run failures leave the task pending so the next cycle
+retries. One-shot → done, recurring → next run.
 """
 
 import asyncio
@@ -15,20 +17,52 @@ from kronos.cron.notify import send_webhook
 log = logging.getLogger("kronos.cron.reminders")
 
 
+async def _run_followup(task: dict) -> str | None:
+    """Run the promised work through the live agent; return its reply text."""
+    from kronos.bridge import get_agent
+
+    agent = get_agent()
+    if agent is None:
+        log.warning("Follow-up #%s skipped: agent not ready", task["id"])
+        return None
+
+    prompt = (
+        "Отложенная задача, которую ты ранее пообещал выполнить: "
+        f"{task['message']}\n\nВыполни её сейчас и дай результат пользователю."
+    )
+    try:
+        return await agent.ainvoke(
+            message=prompt,
+            thread_id=task["thread_id"],
+            user_id="scheduler",
+            session_id=str(task["chat_id"]),
+            source_kind="user",
+            persist_user_turn=True,
+        )
+    except Exception as e:
+        log.error("Follow-up #%s agent run failed: %s", task["id"], e)
+        return None
+
+
+async def _fire_task(task: dict) -> bool:
+    if task.get("kind") == "followup":
+        text = await _run_followup(task)
+    else:
+        text = task["message"]
+    if not text:
+        return False
+    return await asyncio.to_thread(
+        send_webhook, text, task["chat_id"], None, task["topic_id"]
+    )
+
+
 async def run_due_reminders() -> None:
     tasks = scheduled_tasks.due_tasks(settings.agent_name)
     if not tasks:
         return
     log.info("Firing %d due scheduled task(s)", len(tasks))
     for task in tasks:
-        ok = await asyncio.to_thread(
-            send_webhook,
-            task["message"],
-            task["chat_id"],
-            None,  # parse_mode
-            task["topic_id"],
-        )
-        if ok:
+        if await _fire_task(task):
             scheduled_tasks.complete_task(task["id"], task["recur_seconds"], task["run_at"])
         else:
-            log.warning("Reminder #%s delivery failed; will retry next cycle", task["id"])
+            log.warning("Task #%s not delivered; will retry next cycle", task["id"])

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -35,6 +35,7 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     from kronos.cron.market_review import run_market_review
     from kronos.cron.news_monitor import run_news_monitor
     from kronos.cron.personal_observer import run_daily_scope, run_personal_observer
+    from kronos.cron.reminders import run_due_reminders
     from kronos.cron.self_improve import run_self_improve
     from kronos.cron.signal_ideas import run_ideas_digest
 
@@ -55,6 +56,9 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
 
     # Heartbeat — every 30 minutes (was: kronos-heartbeat.timer)
     scheduler.add_periodic("heartbeat", run_heartbeat, interval_seconds=1800)
+
+    # User-scheduled reminders / tasks — poll every minute (roadmap 4.2)
+    scheduler.add_periodic("user-reminders", run_due_reminders, interval_seconds=60)
 
     # News Monitor — daily at 00:00 UTC (was: kronos-news-monitor.timer)
     scheduler.add_daily("news-monitor", run_news_monitor, hour_utc=0)
@@ -152,5 +156,5 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
         scheduler.add_weekly("analytics-weekly", run_analytics_weekly, weekday=0, hour_utc=9)
         nexus_jobs_registered = 4
 
-    total = 14 + nexus_jobs_registered  # 18 base jobs; signal-jobs, travel insights, people-scout and group-digest paused
+    total = 15 + nexus_jobs_registered  # +user-reminders; signal-jobs, travel insights, people-scout and group-digest paused
     log.info("%d cron jobs registered for agent '%s'", total, me)

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -26,7 +26,13 @@ from langchain_core.tools import BaseTool
 
 from kronos.audit import log_tool_event, reset_tool_audit_context, set_tool_audit_context
 from kronos.config import settings
-from kronos.engine import AgentResult, execute_tool, react_loop, tool_requires_approval
+from kronos.engine import (
+    AgentResult,
+    ToolEventCallback,
+    execute_tool,
+    react_loop,
+    tool_requires_approval,
+)
 from kronos.llm import get_model
 from kronos.memory.context_engine import get_context_engine
 from kronos.memory.nodes import retrieve_memories, store_memories_background
@@ -243,10 +249,21 @@ class KronosAgent:
         messages: list[BaseMessage],
         source_message: str,
         react_loop_kwargs: dict[str, Any],
+        on_tool_event: ToolEventCallback | None = None,
     ) -> AgentResult:
-        """Run either the supervisor or direct model loop."""
+        """Run either the supervisor or direct model loop.
+
+        The agent-level callback handles audit/logging; a per-call callback
+        (e.g. live progress in the bridge) is layered on top so both fire.
+        """
+        emit = self._emit_tool_event
+        if on_tool_event is not None:
+            def emit(event: str, payload: dict[str, Any], _extra=on_tool_event) -> None:
+                self._emit_tool_event(event, payload)
+                _extra(event, payload)
+
         if self._supervisor:
-            return await self._supervisor(messages, **react_loop_kwargs)
+            return await self._supervisor(messages, on_tool_event=emit, **react_loop_kwargs)
 
         tier = classify_tier(source_message)
         model = get_model(tier)
@@ -255,7 +272,7 @@ class KronosAgent:
             messages=messages,
             tools=self._tools,
             system_prompt=self._get_system_prompt(),
-            on_tool_event=self._emit_tool_event,
+            on_tool_event=emit,
             **react_loop_kwargs,
         )
 
@@ -367,6 +384,7 @@ class KronosAgent:
         source_kind: str = "user",
         persist_user_turn: bool = True,
         extra_system_context: str = "",
+        on_tool_event: ToolEventCallback | None = None,
     ) -> str:
         """Process a message and return the response text.
 
@@ -474,6 +492,7 @@ class KronosAgent:
                     messages=working_history,
                     source_message=message,
                     react_loop_kwargs=react_loop_kwargs,
+                    on_tool_event=on_tool_event,
                 )
                 response_text = result.content
             except Exception as e:

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -127,6 +127,15 @@ class KronosAgent:
 
         self._tools.append(session_search)
 
+        # Scheduled tasks / reminders (roadmap 4.2)
+        from kronos.tools.reminders import (
+            cancel_scheduled_task,
+            list_scheduled_tasks,
+            schedule_task,
+        )
+
+        self._tools.extend([schedule_task, list_scheduled_tasks, cancel_scheduled_task])
+
         # Composio tools
         from kronos.tools.composio_integration import get_composio_tools
 

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -131,10 +131,13 @@ class KronosAgent:
         from kronos.tools.reminders import (
             cancel_scheduled_task,
             list_scheduled_tasks,
+            schedule_followup,
             schedule_task,
         )
 
-        self._tools.extend([schedule_task, list_scheduled_tasks, cancel_scheduled_task])
+        self._tools.extend(
+            [schedule_task, schedule_followup, list_scheduled_tasks, cancel_scheduled_task]
+        )
 
         # Composio tools
         from kronos.tools.composio_integration import get_composio_tools

--- a/kronos/scheduled_tasks.py
+++ b/kronos/scheduled_tasks.py
@@ -1,0 +1,110 @@
+"""Durable user-scheduled tasks — reminders and recurring prompts (roadmap 4.2).
+
+Backs the ``schedule_task`` tool. Rows are per-agent SQLite (survive restarts)
+and polled by the cron Scheduler, which fires each due task via the
+self-webhook. One-shot tasks flip to ``done``; recurring ones bump ``run_at``.
+"""
+
+import time
+
+from kronos.db import get_db
+
+# Human-friendly repeat presets → seconds. "none" = one-shot.
+RECUR_SECONDS: dict[str, int] = {
+    "none": 0,
+    "hourly": 3600,
+    "daily": 86400,
+    "weekly": 604800,
+}
+
+
+def _init_schema(conn) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS scheduled_tasks (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name    TEXT    NOT NULL,
+            chat_id       INTEGER NOT NULL,
+            topic_id      INTEGER,
+            thread_id     TEXT    NOT NULL,
+            run_at        REAL    NOT NULL,
+            recur_seconds INTEGER NOT NULL DEFAULT 0,
+            message       TEXT    NOT NULL,
+            status        TEXT    NOT NULL DEFAULT 'pending',
+            created_at    REAL    NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_sched_due
+            ON scheduled_tasks(status, agent_name, run_at);
+        """
+    )
+
+
+def _db():
+    db = get_db("scheduled_tasks")
+    db.init_schema(_init_schema)
+    return db
+
+
+def add_task(
+    *,
+    agent_name: str,
+    chat_id: int,
+    topic_id: int | None,
+    thread_id: str,
+    run_at: float,
+    message: str,
+    recur_seconds: int = 0,
+) -> int:
+    """Insert a pending task and return its id."""
+    cursor = _db().write(
+        "INSERT INTO scheduled_tasks "
+        "(agent_name, chat_id, topic_id, thread_id, run_at, recur_seconds, message, status, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)",
+        (agent_name, chat_id, topic_id, thread_id, run_at, recur_seconds, message, time.time()),
+    )
+    return int(cursor.lastrowid)
+
+
+def due_tasks(agent_name: str, now: float | None = None) -> list[dict]:
+    """Pending tasks for this agent whose run_at has passed."""
+    now = time.time() if now is None else now
+    rows = _db().read(
+        "SELECT * FROM scheduled_tasks "
+        "WHERE status='pending' AND agent_name=? AND run_at<=? ORDER BY run_at",
+        (agent_name, now),
+    )
+    return [dict(row) for row in rows]
+
+
+def complete_task(task_id: int, recur_seconds: int, run_at: float) -> None:
+    """One-shot → done; recurring → bump run_at by one interval."""
+    if recur_seconds and recur_seconds > 0:
+        _db().write(
+            "UPDATE scheduled_tasks SET run_at=? WHERE id=?",
+            (run_at + recur_seconds, task_id),
+        )
+    else:
+        _db().write(
+            "UPDATE scheduled_tasks SET status='done' WHERE id=?",
+            (task_id,),
+        )
+
+
+def cancel_task(task_id: int, agent_name: str) -> bool:
+    """Cancel a pending task owned by this agent. Returns True if one changed."""
+    cursor = _db().write(
+        "UPDATE scheduled_tasks SET status='cancelled' "
+        "WHERE id=? AND agent_name=? AND status='pending'",
+        (task_id, agent_name),
+    )
+    return cursor.rowcount > 0
+
+
+def list_pending(agent_name: str) -> list[dict]:
+    """All pending tasks for this agent, soonest first."""
+    rows = _db().read(
+        "SELECT * FROM scheduled_tasks "
+        "WHERE status='pending' AND agent_name=? ORDER BY run_at",
+        (agent_name,),
+    )
+    return [dict(row) for row in rows]

--- a/kronos/scheduled_tasks.py
+++ b/kronos/scheduled_tasks.py
@@ -30,6 +30,7 @@ def _init_schema(conn) -> None:
             run_at        REAL    NOT NULL,
             recur_seconds INTEGER NOT NULL DEFAULT 0,
             message       TEXT    NOT NULL,
+            kind          TEXT    NOT NULL DEFAULT 'reminder',
             status        TEXT    NOT NULL DEFAULT 'pending',
             created_at    REAL    NOT NULL
         );
@@ -37,6 +38,12 @@ def _init_schema(conn) -> None:
             ON scheduled_tasks(status, agent_name, run_at);
         """
     )
+    # Migrate DBs created before the kind column existed (roadmap 4.3).
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(scheduled_tasks)")}
+    if "kind" not in cols:
+        conn.execute(
+            "ALTER TABLE scheduled_tasks ADD COLUMN kind TEXT NOT NULL DEFAULT 'reminder'"
+        )
 
 
 def _db():
@@ -54,13 +61,18 @@ def add_task(
     run_at: float,
     message: str,
     recur_seconds: int = 0,
+    kind: str = "reminder",
 ) -> int:
-    """Insert a pending task and return its id."""
+    """Insert a pending task and return its id.
+
+    kind="reminder" delivers message verbatim; kind="followup" runs message as
+    an agent prompt when due and delivers the agent's result.
+    """
     cursor = _db().write(
         "INSERT INTO scheduled_tasks "
-        "(agent_name, chat_id, topic_id, thread_id, run_at, recur_seconds, message, status, created_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?)",
-        (agent_name, chat_id, topic_id, thread_id, run_at, recur_seconds, message, time.time()),
+        "(agent_name, chat_id, topic_id, thread_id, run_at, recur_seconds, message, kind, status, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)",
+        (agent_name, chat_id, topic_id, thread_id, run_at, recur_seconds, message, kind, time.time()),
     )
     return int(cursor.lastrowid)
 

--- a/kronos/tools/reminders.py
+++ b/kronos/tools/reminders.py
@@ -1,8 +1,9 @@
-"""schedule_task tool family — durable reminders / recurring tasks (roadmap 4.2).
+"""schedule_task / schedule_followup tool family (roadmap 4.2 + 4.3).
 
-The LLM converts the user's natural-language time to an absolute ISO timestamp
-and calls schedule_task; the cron Scheduler later delivers it to the chat the
-request came from (recovered via the tool audit context).
+The LLM converts the user's natural-language time to an absolute ISO timestamp;
+the cron Scheduler later delivers to the chat the request came from (recovered
+via the tool audit context). A "reminder" sends text; a "followup" re-runs the
+agent on the promised task and sends the result.
 """
 
 from datetime import UTC, datetime
@@ -21,9 +22,34 @@ def _recur_name(recur_seconds: int) -> str:
     return "custom"
 
 
+def _resolve_target() -> tuple[int, str, int | None] | None:
+    """(chat_id, thread_id, topic_id) for the current request, or None."""
+    ctx = get_tool_audit_context()
+    chat_raw = ctx.get("session_id", "")
+    thread_id = ctx.get("thread_id", "")
+    if not chat_raw:
+        return None
+    topic_id = None
+    _, sep, tail = thread_id.partition(":")
+    if sep and tail.isdigit():
+        topic_id = int(tail)
+    return int(chat_raw), thread_id, topic_id
+
+
+def _parse_future(when_iso: str) -> tuple[float | None, str]:
+    """Parse an ISO timestamp that must be in the future. (run_at, error_text)."""
+    try:
+        run_at = datetime.fromisoformat(when_iso).timestamp()
+    except ValueError:
+        return None, f"Неверный формат времени '{when_iso}'. Нужен ISO-8601, напр. 2026-07-11T18:00:00+08:00."
+    if run_at <= datetime.now(UTC).timestamp():
+        return None, "Это время уже прошло — укажи момент в будущем."
+    return run_at, ""
+
+
 @tool
 def schedule_task(when_iso: str, message: str, repeat: str = "none") -> str:
-    """Schedule a reminder or recurring task, delivered to THIS chat later.
+    """Schedule a reminder — send this text to THIS chat at a later time.
 
     Convert the user's natural-language time to an absolute ISO-8601 timestamp
     (with timezone) yourself and pass it as when_iso.
@@ -34,40 +60,66 @@ def schedule_task(when_iso: str, message: str, repeat: str = "none") -> str:
         message: the text to send to the chat when it fires.
         repeat: "none" (one-shot), "hourly", "daily", or "weekly".
     """
-    ctx = get_tool_audit_context()
-    chat_raw = ctx.get("session_id", "")
-    thread_id = ctx.get("thread_id", "")
-    if not chat_raw:
+    target = _resolve_target()
+    if target is None:
         return "Не удалось запланировать: неизвестен чат этого запроса."
+    chat_id, thread_id, topic_id = target
 
-    try:
-        run_at = datetime.fromisoformat(when_iso).timestamp()
-    except ValueError:
-        return f"Неверный формат времени '{when_iso}'. Нужен ISO-8601, напр. 2026-07-11T18:00:00+08:00."
-
-    if run_at <= datetime.now(UTC).timestamp():
-        return "Это время уже прошло — укажи момент в будущем."
+    run_at, error = _parse_future(when_iso)
+    if run_at is None:
+        return error
 
     repeat = repeat.lower().strip()
     if repeat not in scheduled_tasks.RECUR_SECONDS:
         return f"repeat должен быть одним из: {', '.join(scheduled_tasks.RECUR_SECONDS)}."
 
-    topic_id = None
-    _, sep, tail = thread_id.partition(":")
-    if sep and tail.isdigit():
-        topic_id = int(tail)
-
     task_id = scheduled_tasks.add_task(
         agent_name=settings.agent_name,
-        chat_id=int(chat_raw),
+        chat_id=chat_id,
         topic_id=topic_id,
         thread_id=thread_id,
         run_at=run_at,
         message=message,
         recur_seconds=scheduled_tasks.RECUR_SECONDS[repeat],
+        kind="reminder",
     )
     tail_txt = "" if repeat == "none" else f", повтор: {repeat}"
     return f"✅ Запланировал (#{task_id}) на {when_iso}{tail_txt}."
+
+
+@tool
+def schedule_followup(when_iso: str, task: str) -> str:
+    """Promise to come back later with a real result ("посмотрю позже").
+
+    Use when you can't answer now but commit to follow up. When the time comes
+    you (the agent) actually run `task` and send the user the result — not just
+    a reminder. Convert natural-language time to ISO-8601 (with timezone).
+
+    Args:
+        when_iso: when to run the task, ISO-8601 with timezone.
+        task: what to do then, phrased as an instruction to yourself
+            (e.g. "check the DEV-1698 status and summarize the outcome").
+    """
+    target = _resolve_target()
+    if target is None:
+        return "Не удалось запланировать follow-up: неизвестен чат этого запроса."
+    chat_id, thread_id, topic_id = target
+
+    run_at, error = _parse_future(when_iso)
+    if run_at is None:
+        return error
+
+    task_id = scheduled_tasks.add_task(
+        agent_name=settings.agent_name,
+        chat_id=chat_id,
+        topic_id=topic_id,
+        thread_id=thread_id,
+        run_at=run_at,
+        message=task,
+        recur_seconds=0,
+        kind="followup",
+    )
+    return f"🔔 Вернусь с результатом (#{task_id}) к {when_iso}."
 
 
 @tool
@@ -81,12 +133,13 @@ def list_scheduled_tasks() -> str:
         when = datetime.fromtimestamp(task["run_at"], tz=UTC).isoformat()
         recur = _recur_name(task["recur_seconds"])
         recur_txt = "" if recur == "none" else f" ({recur})"
-        lines.append(f"#{task['id']} @ {when}{recur_txt}: {task['message'][:80]}")
+        kind_txt = "↩︎ " if task.get("kind") == "followup" else ""
+        lines.append(f"#{task['id']} @ {when}{recur_txt}: {kind_txt}{task['message'][:80]}")
     return "\n".join(lines)
 
 
 @tool
 def cancel_scheduled_task(task_id: int) -> str:
-    """Cancel a pending scheduled task by its id."""
+    """Cancel a pending scheduled task or follow-up by its id."""
     ok = scheduled_tasks.cancel_task(task_id, settings.agent_name)
     return f"Отменил задачу #{task_id}." if ok else f"Задача #{task_id} не найдена или уже неактивна."

--- a/kronos/tools/reminders.py
+++ b/kronos/tools/reminders.py
@@ -1,0 +1,92 @@
+"""schedule_task tool family — durable reminders / recurring tasks (roadmap 4.2).
+
+The LLM converts the user's natural-language time to an absolute ISO timestamp
+and calls schedule_task; the cron Scheduler later delivers it to the chat the
+request came from (recovered via the tool audit context).
+"""
+
+from datetime import UTC, datetime
+
+from langchain_core.tools import tool
+
+from kronos import scheduled_tasks
+from kronos.audit import get_tool_audit_context
+from kronos.config import settings
+
+
+def _recur_name(recur_seconds: int) -> str:
+    for name, seconds in scheduled_tasks.RECUR_SECONDS.items():
+        if seconds == recur_seconds:
+            return name
+    return "custom"
+
+
+@tool
+def schedule_task(when_iso: str, message: str, repeat: str = "none") -> str:
+    """Schedule a reminder or recurring task, delivered to THIS chat later.
+
+    Convert the user's natural-language time to an absolute ISO-8601 timestamp
+    (with timezone) yourself and pass it as when_iso.
+
+    Args:
+        when_iso: when to fire, ISO-8601 with timezone
+            (e.g. "2026-07-11T18:00:00+08:00").
+        message: the text to send to the chat when it fires.
+        repeat: "none" (one-shot), "hourly", "daily", or "weekly".
+    """
+    ctx = get_tool_audit_context()
+    chat_raw = ctx.get("session_id", "")
+    thread_id = ctx.get("thread_id", "")
+    if not chat_raw:
+        return "Не удалось запланировать: неизвестен чат этого запроса."
+
+    try:
+        run_at = datetime.fromisoformat(when_iso).timestamp()
+    except ValueError:
+        return f"Неверный формат времени '{when_iso}'. Нужен ISO-8601, напр. 2026-07-11T18:00:00+08:00."
+
+    if run_at <= datetime.now(UTC).timestamp():
+        return "Это время уже прошло — укажи момент в будущем."
+
+    repeat = repeat.lower().strip()
+    if repeat not in scheduled_tasks.RECUR_SECONDS:
+        return f"repeat должен быть одним из: {', '.join(scheduled_tasks.RECUR_SECONDS)}."
+
+    topic_id = None
+    _, sep, tail = thread_id.partition(":")
+    if sep and tail.isdigit():
+        topic_id = int(tail)
+
+    task_id = scheduled_tasks.add_task(
+        agent_name=settings.agent_name,
+        chat_id=int(chat_raw),
+        topic_id=topic_id,
+        thread_id=thread_id,
+        run_at=run_at,
+        message=message,
+        recur_seconds=scheduled_tasks.RECUR_SECONDS[repeat],
+    )
+    tail_txt = "" if repeat == "none" else f", повтор: {repeat}"
+    return f"✅ Запланировал (#{task_id}) на {when_iso}{tail_txt}."
+
+
+@tool
+def list_scheduled_tasks() -> str:
+    """List pending reminders / scheduled tasks for this agent."""
+    pending = scheduled_tasks.list_pending(settings.agent_name)
+    if not pending:
+        return "Запланированных задач нет."
+    lines = []
+    for task in pending:
+        when = datetime.fromtimestamp(task["run_at"], tz=UTC).isoformat()
+        recur = _recur_name(task["recur_seconds"])
+        recur_txt = "" if recur == "none" else f" ({recur})"
+        lines.append(f"#{task['id']} @ {when}{recur_txt}: {task['message'][:80]}")
+    return "\n".join(lines)
+
+
+@tool
+def cancel_scheduled_task(task_id: int) -> str:
+    """Cancel a pending scheduled task by its id."""
+    ok = scheduled_tasks.cancel_task(task_id, settings.agent_name)
+    return f"Отменил задачу #{task_id}." if ok else f"Задача #{task_id} не найдена или уже неактивна."

--- a/tests/test_bridge_progress.py
+++ b/tests/test_bridge_progress.py
@@ -1,0 +1,71 @@
+"""Live progress reporter (roadmap 4.1).
+
+The reporter edits a throwaway draft message with tool progress. It must be
+lazy (no draft for fast no-tool replies) and best-effort (never break a reply).
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from kronos import bridge
+
+
+def test_humanize_tool_maps_known_and_unknown():
+    assert "ищу" in bridge._humanize_tool("brave_web_search")
+    assert "читаю" in bridge._humanize_tool("fetch_url")
+    assert bridge._humanize_tool("weird_custom") == "🔧 weird_custom"
+
+
+def test_progress_label_only_for_actionable_events():
+    assert bridge._progress_label("tool_call", {"name": "brave"}) is not None
+    assert bridge._progress_label("tool_result", {"name": "brave"}) is None
+    assert bridge._progress_label("tool_approval_required", {}) == "⏸️ жду подтверждения…"
+
+
+async def test_reporter_lazy_no_draft_without_events(monkeypatch):
+    client = SimpleNamespace(
+        send_message=AsyncMock(),
+        edit_message=AsyncMock(),
+        delete_messages=AsyncMock(),
+    )
+    monkeypatch.setattr(bridge, "_client", client)
+
+    reporter = bridge._ProgressReporter(chat_id=1, topic_id=None).start()
+    await asyncio.sleep(0.03)  # no events fired
+    await reporter.finish()
+
+    client.send_message.assert_not_called()  # no throwaway message flashed
+    client.delete_messages.assert_not_called()
+
+
+async def test_reporter_sends_draft_on_event_then_deletes(monkeypatch):
+    draft = SimpleNamespace(id=555)
+    client = SimpleNamespace(
+        send_message=AsyncMock(return_value=draft),
+        edit_message=AsyncMock(),
+        delete_messages=AsyncMock(),
+    )
+    monkeypatch.setattr(bridge, "_client", client)
+
+    reporter = bridge._ProgressReporter(chat_id=1, topic_id=None).start()
+    reporter.on_event("tool_call", {"name": "brave_search"})
+    await asyncio.sleep(0.25)  # let the poll pick it up and render
+    await reporter.finish()
+
+    client.send_message.assert_awaited()  # draft materialized on first event
+    client.delete_messages.assert_awaited_with(1, [draft])  # cleaned up
+
+
+async def test_reporter_render_failure_never_raises(monkeypatch):
+    client = SimpleNamespace(
+        send_message=AsyncMock(side_effect=RuntimeError("telegram down")),
+        edit_message=AsyncMock(),
+        delete_messages=AsyncMock(),
+    )
+    monkeypatch.setattr(bridge, "_client", client)
+
+    reporter = bridge._ProgressReporter(chat_id=1, topic_id=None).start()
+    reporter.on_event("tool_call", {"name": "brave"})
+    await asyncio.sleep(0.25)
+    await reporter.finish()  # must not raise despite send_message failing

--- a/tests/test_durable_turns.py
+++ b/tests/test_durable_turns.py
@@ -413,3 +413,36 @@ async def test_agent_remove_tool_executes_without_approval(tmp_path: Path, monke
         "remove server",
         "removed",
     ]
+
+
+async def test_ainvoke_forwards_per_call_tool_events(tmp_path: Path, monkeypatch) -> None:
+    # roadmap 4.1: a per-call on_tool_event (bridge live progress) must receive
+    # tool events, alongside the agent-level audit callback.
+    monkeypatch.setattr(settings, "tool_approvals_enabled", False)
+    store = SessionStore(str(tmp_path / "session.db"))
+    events: list[tuple[str, str]] = []
+
+    async def do_thing() -> str:
+        return "ok"
+
+    tool = StructuredTool.from_function(
+        coroutine=do_thing, name="do_thing", description="a tool"
+    )
+    model = _make_model(
+        [_ai_with_tool_call("do_thing", tool_call_id="c1"), AIMessage(content="done")]
+    )
+    agent = _minimal_agent(store)
+    agent._tools = [tool]
+
+    with patch("kronos.graph.get_model", return_value=model):
+        reply = await agent.ainvoke(
+            message="go",
+            thread_id="thread",
+            user_id="u",
+            session_id="s",
+            on_tool_event=lambda ev, payload: events.append((ev, payload.get("name"))),
+        )
+
+    assert reply == "done"
+    assert ("tool_call", "do_thing") in events
+    assert ("tool_result", "do_thing") in events

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -136,3 +136,83 @@ async def test_run_due_reminders_keeps_pending_on_failure(isolated_db, monkeypat
 
     # delivery failed → still pending for retry
     assert len(scheduled_tasks.list_pending("kronos")) == 1
+
+
+def test_schedule_followup_tool_adds_followup_kind(isolated_db):
+    from kronos.tools.reminders import schedule_followup
+
+    token = set_tool_audit_context(agent="kronos", thread_id="42", session_id="42")
+    try:
+        future = (datetime.now(UTC) + timedelta(hours=2)).isoformat()
+        result = schedule_followup.invoke({"when_iso": future, "task": "check DEV-1698"})
+    finally:
+        reset_tool_audit_context(token)
+
+    assert "Вернусь" in result
+    pending = scheduled_tasks.list_pending("kronos")
+    assert len(pending) == 1
+    assert pending[0]["kind"] == "followup"
+    assert pending[0]["message"] == "check DEV-1698"
+
+
+async def test_run_due_followup_invokes_agent_and_sends_result(isolated_db, monkeypatch):
+    from kronos.cron import reminders as cron_reminders
+
+    now = time.time()
+    scheduled_tasks.add_task(
+        agent_name="kronos", chat_id=7, topic_id=None, thread_id="7",
+        run_at=now - 1, message="do the thing", recur_seconds=0, kind="followup",
+    )
+
+    class FakeAgent:
+        async def ainvoke(self, message, **kwargs):
+            return f"result for: {message[:12]}"
+
+    monkeypatch.setattr("kronos.bridge._agent", FakeAgent())
+    sent: list[str] = []
+    monkeypatch.setattr(
+        cron_reminders, "send_webhook",
+        lambda text, *a, **k: sent.append(text) or True,
+    )
+
+    await cron_reminders.run_due_reminders()
+
+    assert sent and sent[0].startswith("result for:")
+    assert scheduled_tasks.list_pending("kronos") == []  # completed
+
+
+async def test_run_due_followup_retries_when_agent_not_ready(isolated_db, monkeypatch):
+    from kronos.cron import reminders as cron_reminders
+
+    now = time.time()
+    scheduled_tasks.add_task(
+        agent_name="kronos", chat_id=7, topic_id=None, thread_id="7",
+        run_at=now - 1, message="x", recur_seconds=0, kind="followup",
+    )
+    monkeypatch.setattr("kronos.bridge._agent", None)
+    sent: list[int] = []
+    monkeypatch.setattr(cron_reminders, "send_webhook", lambda *a, **k: sent.append(1) or True)
+
+    await cron_reminders.run_due_reminders()
+
+    assert sent == []  # nothing delivered
+    assert len(scheduled_tasks.list_pending("kronos")) == 1  # still pending
+
+
+def test_kind_column_migration_on_legacy_db(isolated_db):
+    import kronos.db as db_mod
+
+    db = db_mod.get_db("scheduled_tasks")
+    # Simulate a DB created before the kind column existed.
+    db.write("DROP TABLE IF EXISTS scheduled_tasks")
+    db.write(
+        "CREATE TABLE scheduled_tasks ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, agent_name TEXT NOT NULL, "
+        "chat_id INTEGER NOT NULL, topic_id INTEGER, thread_id TEXT NOT NULL, "
+        "run_at REAL NOT NULL, recur_seconds INTEGER NOT NULL DEFAULT 0, "
+        "message TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'pending', "
+        "created_at REAL NOT NULL)"
+    )
+    db.init_schema(scheduled_tasks._init_schema)
+    cols = {row[1] for row in db.read("PRAGMA table_info(scheduled_tasks)")}
+    assert "kind" in cols

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -1,0 +1,138 @@
+"""Durable scheduled tasks / reminders (roadmap 4.2)."""
+
+import time
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+import kronos.db as _db
+from kronos import scheduled_tasks
+from kronos.audit import reset_tool_audit_context, set_tool_audit_context
+from kronos.config import settings
+
+
+@pytest.fixture
+def isolated_db(tmp_path, monkeypatch):
+    db_dir = tmp_path / "agent"
+    db_dir.mkdir()
+    monkeypatch.setattr(settings, "db_dir", str(db_dir))
+    monkeypatch.setattr(settings, "agent_name", "kronos")
+    _db._instances.clear()
+    yield
+    _db._instances.clear()
+
+
+def _add(run_at, message="ping", recur=0, agent="kronos", chat=42):
+    return scheduled_tasks.add_task(
+        agent_name=agent, chat_id=chat, topic_id=None, thread_id=str(chat),
+        run_at=run_at, message=message, recur_seconds=recur,
+    )
+
+
+def test_add_and_due_filters_future(isolated_db):
+    now = time.time()
+    _add(now - 10, "past-due")
+    _add(now + 3600, "future")
+    due = scheduled_tasks.due_tasks("kronos", now=now)
+    assert [t["message"] for t in due] == ["past-due"]
+
+
+def test_complete_oneshot_marks_done(isolated_db):
+    now = time.time()
+    tid = _add(now - 1)
+    scheduled_tasks.complete_task(tid, 0, now - 1)
+    assert scheduled_tasks.due_tasks("kronos", now=now) == []
+    assert scheduled_tasks.list_pending("kronos") == []
+
+
+def test_complete_recurring_bumps_run_at(isolated_db):
+    now = time.time()
+    tid = _add(now - 1, "daily", recur=86400)
+    scheduled_tasks.complete_task(tid, 86400, now - 1)
+    pending = scheduled_tasks.list_pending("kronos")
+    assert len(pending) == 1
+    assert pending[0]["id"] == tid
+    assert pending[0]["run_at"] > now  # rescheduled, not done
+
+
+def test_cancel_is_idempotent(isolated_db):
+    tid = _add(time.time() + 100)
+    assert scheduled_tasks.cancel_task(tid, "kronos") is True
+    assert scheduled_tasks.cancel_task(tid, "kronos") is False  # already cancelled
+    assert scheduled_tasks.list_pending("kronos") == []
+
+
+def test_due_is_scoped_per_agent(isolated_db):
+    now = time.time()
+    _add(now - 1, "kronos-task", agent="kronos")
+    assert scheduled_tasks.due_tasks("nexus", now=now) == []
+
+
+def test_schedule_task_tool_adds_with_chat_and_topic(isolated_db):
+    from kronos.tools.reminders import schedule_task
+
+    token = set_tool_audit_context(agent="kronos", thread_id="42:7", session_id="42")
+    try:
+        future = (datetime.now(UTC) + timedelta(hours=2)).isoformat()
+        result = schedule_task.invoke({"when_iso": future, "message": "buy milk"})
+    finally:
+        reset_tool_audit_context(token)
+
+    assert "Запланировал" in result
+    pending = scheduled_tasks.list_pending("kronos")
+    assert len(pending) == 1
+    assert pending[0]["chat_id"] == 42
+    assert pending[0]["topic_id"] == 7  # parsed from thread_id "42:7"
+    assert pending[0]["message"] == "buy milk"
+
+
+def test_schedule_task_tool_rejects_past_time(isolated_db):
+    from kronos.tools.reminders import schedule_task
+
+    token = set_tool_audit_context(agent="kronos", thread_id="42", session_id="42")
+    try:
+        past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        result = schedule_task.invoke({"when_iso": past, "message": "x"})
+    finally:
+        reset_tool_audit_context(token)
+
+    assert "прошл" in result.lower()
+    assert scheduled_tasks.list_pending("kronos") == []
+
+
+def test_schedule_task_tool_without_chat_context(isolated_db):
+    from kronos.tools.reminders import schedule_task
+
+    future = (datetime.now(UTC) + timedelta(hours=2)).isoformat()
+    result = schedule_task.invoke({"when_iso": future, "message": "x"})  # no audit context
+    assert "неизвестен чат" in result.lower()
+
+
+async def test_run_due_reminders_fires_and_completes(isolated_db, monkeypatch):
+    from kronos.cron import reminders as cron_reminders
+
+    now = time.time()
+    _add(now - 1, "ring", chat=99)
+    sent = []
+
+    def fake_send(text, chat_id=None, parse_mode=None, topic_id=None):
+        sent.append((text, chat_id))
+        return True
+
+    monkeypatch.setattr(cron_reminders, "send_webhook", fake_send)
+    await cron_reminders.run_due_reminders()
+
+    assert ("ring", 99) in sent
+    assert scheduled_tasks.list_pending("kronos") == []  # one-shot completed
+
+
+async def test_run_due_reminders_keeps_pending_on_failure(isolated_db, monkeypatch):
+    from kronos.cron import reminders as cron_reminders
+
+    now = time.time()
+    _add(now - 1, "ring")
+    monkeypatch.setattr(cron_reminders, "send_webhook", lambda *a, **k: False)
+    await cron_reminders.run_due_reminders()
+
+    # delivery failed → still pending for retry
+    assert len(scheduled_tasks.list_pending("kronos")) == 1


### PR DESCRIPTION
Roadmap phase 4 — make the agent feel alive. 3 commits, all tests green without LLM keys.

## 4.1 — Live progress instead of a static "typing…"
A 25-turn ReAct cycle left the user staring at the typing indicator for minutes. A per-call `on_tool_event` is now threaded through `ainvoke → _run_model_loop → react_loop/supervisor` (on top of the agent-level audit callback), and a `_ProgressReporter` edits one throwaway draft message with humanized tool status ("🔍 ищу в вебе…", "📄 читаю источник…"). Lazily materialized (no draft for fast no-tool replies) and deleted before returning, so the send path (validation/buttons/TTS/chunking) is untouched. Best-effort, throttled.

## 4.2 — Durable scheduled tasks & reminders
Cron was static, so "remind me Friday about X" needed a code change. New per-agent SQLite store (`scheduled_tasks.py`) + tools `schedule_task`/`list_scheduled_tasks`/`cancel_scheduled_task`. The LLM converts natural-language time to ISO; the tool recovers the originating chat/topic from the tool audit context. A 60s cron job delivers each due task via the self-webhook (one-shot → done, recurring → next run; delivery failure retries).

## 4.3 — Follow-ups that keep promises
"посмотрю позже" now means the agent actually comes back with a result. `scheduled_tasks` gains a `kind` column (reminder|followup, migrated). `schedule_followup` promises deferred work; when due, cron re-invokes the live agent on that task and delivers its result. Routing by kind; agent-not-ready or run failure leaves the task pending to retry.

## Tests
613 passed, 40 deselected (integration), 0 failures — verified without LLM keys. ruff clean. New tests: progress reporter lazy/lifecycle, per-call event forwarding, scheduled-task store + tool + cron runner, follow-up execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)