### PR TITLE
Swarm 2.0: hand-off, council, cross-agent memory (roadmap phase 5)

### DIFF
--- a/kronos/cron/council.py
+++ b/kronos/cron/council.py
@@ -1,0 +1,91 @@
+"""Council intake — contribute positions and synthesize (roadmap 5.2).
+
+Polled by the Scheduler. Each agent plays two roles against the shared ledger:
+  1. participant — answer councils it's invited to, independently;
+  2. initiator — once all positions are in, synthesize one answer for the chat.
+Synthesis is claimed under an IMMEDIATE transaction so it fires exactly once.
+"""
+
+import asyncio
+import logging
+
+from kronos.config import settings
+from kronos.cron.notify import send_webhook
+from kronos.swarm_store import get_swarm
+
+log = logging.getLogger("kronos.cron.council")
+
+_MAX_PER_POLL = 3
+
+
+async def _submit_position(agent, swarm, session: dict) -> None:
+    framing = (
+        "Идёт консилиум агентов. Дай СВОЮ независимую позицию по вопросу по своей "
+        "специализации — кратко и по делу. Не синтезируй чужие мнения, только своя "
+        "точка зрения."
+    )
+    try:
+        position = await agent.ainvoke(
+            message=session["question"],
+            thread_id=session["thread_id"],
+            user_id="council",
+            session_id=str(session["chat_id"]),
+            source_kind="peer_reaction",  # ephemeral — not the user's turn
+            persist_user_turn=False,
+            extra_system_context=framing,
+        )
+    except Exception as e:
+        log.error("Council #%s position failed: %s", session["id"], e)
+        return
+    if position:
+        swarm.submit_position(session["id"], settings.agent_name, position)
+
+
+async def _synthesize(agent, swarm, session: dict) -> bool:
+    positions = swarm.get_positions(session["id"])
+    joined = "\n\n".join(f"[{p['agent_name']}]: {p['position']}" for p in positions)
+    framing = (
+        "Ты инициатор консилиума. Ниже независимые позиции коллег-агентов. "
+        "Синтезируй ОДИН связный ответ пользователю: где согласие, где расхождения "
+        "и твой итоговый вывод. Не описывай саму механику консилиума."
+    )
+    prompt = f"Вопрос: {session['question']}\n\nПозиции агентов:\n{joined}"
+    try:
+        answer = await agent.ainvoke(
+            message=prompt,
+            thread_id=session["thread_id"],
+            user_id="council",
+            session_id=str(session["chat_id"]),
+            source_kind="user",
+            persist_user_turn=True,
+            extra_system_context=framing,
+        )
+    except Exception as e:
+        log.error("Council #%s synthesis failed: %s", session["id"], e)
+        return False
+    return bool(answer) and await asyncio.to_thread(
+        send_webhook, answer, session["chat_id"], None, session["topic_id"] or None
+    )
+
+
+async def run_council_intake() -> None:
+    from kronos.bridge import get_agent
+
+    agent = get_agent()
+    if agent is None:
+        return
+    swarm = get_swarm()
+    me = settings.agent_name
+
+    # Role 1: contribute a position to councils this agent is invited to.
+    for session in swarm.pending_council_tasks(me)[:_MAX_PER_POLL]:
+        await _submit_position(agent, swarm, session)
+
+    # Role 2: synthesize councils this agent initiated, once all positions are in.
+    for session in swarm.councils_awaiting_synthesis(me)[:_MAX_PER_POLL]:
+        claimed = swarm.claim_synthesis(session["id"], me)
+        if claimed is None:
+            continue  # not everyone has answered yet
+        ok = await _synthesize(agent, swarm, claimed)
+        swarm.complete_council(claimed["id"], success=ok)
+        swarm.incr_metric("councils_completed" if ok else "councils_failed")

--- a/kronos/cron/handoff.py
+++ b/kronos/cron/handoff.py
@@ -1,0 +1,66 @@
+"""Cross-agent hand-off intake (roadmap 5.1).
+
+Polled by the Scheduler. Atomically claims each pending hand-off addressed to
+this agent, runs it through the local agent (its own expertise), and delivers
+the result to the originating chat. Rows are claimed one at a time under an
+IMMEDIATE transaction, so overlapping polls never double-process.
+"""
+
+import asyncio
+import logging
+
+from kronos.config import settings
+from kronos.cron.notify import send_webhook
+from kronos.swarm_store import get_swarm
+
+log = logging.getLogger("kronos.cron.handoff")
+
+# Safety bound per poll so a flood of hand-offs can't monopolize a cycle.
+_MAX_PER_POLL = 5
+
+
+async def _run_handoff(agent, handoff: dict) -> str | None:
+    """Answer a handed-off request with this agent's expertise."""
+    framing = (
+        f"Другой агент ({handoff['from_agent']}) передал тебе этот запрос как "
+        "профильному. Ответь по своей специализации; не упоминай саму механику "
+        "передачи."
+    )
+    try:
+        return await agent.ainvoke(
+            message=handoff["context"],
+            thread_id=handoff["thread_id"],
+            user_id="handoff",
+            session_id=str(handoff["chat_id"]),
+            source_kind="user",
+            persist_user_turn=True,
+            extra_system_context=framing,
+        )
+    except Exception as e:
+        log.error("Hand-off #%s agent run failed: %s", handoff["id"], e)
+        return None
+
+
+async def run_handoff_intake() -> None:
+    from kronos.bridge import get_agent
+
+    agent = get_agent()
+    if agent is None:
+        return  # not ready — leave pending hand-offs for the next poll
+
+    swarm = get_swarm()
+    processed = 0
+    while processed < _MAX_PER_POLL:
+        handoff = swarm.accept_next_handoff(settings.agent_name)
+        if handoff is None:
+            break
+        processed += 1
+
+        reply = await _run_handoff(agent, handoff)
+        ok = bool(reply) and await asyncio.to_thread(
+            send_webhook, reply, handoff["chat_id"], None, handoff["topic_id"] or None
+        )
+        swarm.complete_handoff(handoff["id"], success=ok)
+        swarm.incr_metric("handoffs_completed" if ok else "handoffs_failed")
+        if not ok:
+            log.warning("Hand-off #%s not delivered", handoff["id"])

--- a/kronos/cron/memory_ask.py
+++ b/kronos/cron/memory_ask.py
@@ -1,0 +1,66 @@
+"""Cross-agent memory query intake (roadmap 5.3).
+
+Polled by the Scheduler. Claims each pending memory query addressed to this
+agent (atomically), recalls from its own memory via the live agent, and shares
+the result in the originating chat. Claim marks the row done immediately, so
+overlapping polls never double-answer.
+"""
+
+import asyncio
+import logging
+
+from kronos.config import settings
+from kronos.cron.notify import send_webhook
+from kronos.swarm_store import get_swarm
+
+log = logging.getLogger("kronos.cron.memory_ask")
+
+_MAX_PER_POLL = 5
+
+
+async def _answer_memory(agent, req: dict) -> str | None:
+    framing = (
+        f"Коллега-агент ({req['from_agent']}) спрашивает, что у тебя есть в памяти "
+        "по этому вопросу. Поделись только тем, что реально знаешь из своей памяти "
+        "и опыта; если ничего нет — так и скажи коротко."
+    )
+    try:
+        return await agent.ainvoke(
+            message=req["query"],
+            thread_id=req["thread_id"],
+            user_id="memory-ask",
+            session_id=str(req["chat_id"]),
+            source_kind="peer_reaction",  # ephemeral — don't pollute my memory
+            persist_user_turn=False,
+            extra_system_context=framing,
+        )
+    except Exception as e:
+        log.error("Memory request #%s failed: %s", req["id"], e)
+        return None
+
+
+async def run_memory_intake() -> None:
+    from kronos.bridge import get_agent
+
+    agent = get_agent()
+    if agent is None:
+        return
+
+    swarm = get_swarm()
+    processed = 0
+    while processed < _MAX_PER_POLL:
+        req = swarm.accept_next_memory_request(settings.agent_name)
+        if req is None:
+            break
+        processed += 1
+
+        answer = await _answer_memory(agent, req)
+        ok = bool(answer) and await asyncio.to_thread(
+            send_webhook, answer, req["chat_id"], None, req["topic_id"] or None
+        )
+        if ok:
+            swarm.incr_metric("memory_requests_answered")
+        else:
+            swarm.complete_memory_request(req["id"], success=False)
+            swarm.incr_metric("memory_requests_failed")
+            log.warning("Memory request #%s not delivered", req["id"])

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -35,6 +35,7 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     from kronos.cron.handoff import run_handoff_intake
     from kronos.cron.heartbeat import run_heartbeat
     from kronos.cron.market_review import run_market_review
+    from kronos.cron.memory_ask import run_memory_intake
     from kronos.cron.news_monitor import run_news_monitor
     from kronos.cron.personal_observer import run_daily_scope, run_personal_observer
     from kronos.cron.reminders import run_due_reminders
@@ -67,6 +68,9 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
 
     # Council intake — contribute positions + synthesize, poll every 30s (5.2)
     scheduler.add_periodic("council-intake", run_council_intake, interval_seconds=30)
+
+    # Cross-agent memory query intake — poll every 30s (roadmap 5.3)
+    scheduler.add_periodic("memory-intake", run_memory_intake, interval_seconds=30)
 
     # News Monitor — daily at 00:00 UTC (was: kronos-news-monitor.timer)
     scheduler.add_daily("news-monitor", run_news_monitor, hour_utc=0)
@@ -164,5 +168,5 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
         scheduler.add_weekly("analytics-weekly", run_analytics_weekly, weekday=0, hour_utc=9)
         nexus_jobs_registered = 4
 
-    total = 17 + nexus_jobs_registered  # +user-reminders +handoff-intake +council-intake; signal-jobs, travel insights, people-scout and group-digest paused
+    total = 18 + nexus_jobs_registered  # +user-reminders +handoff/council/memory intake; signal-jobs, travel insights, people-scout and group-digest paused
     log.info("%d cron jobs registered for agent '%s'", total, me)

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -31,6 +31,7 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
 
     # DISABLED 2026-07-07: group-digest paused — duplicate of news-monitor on Digest:News.
     # from kronos.cron.group_digest import run_group_digest
+    from kronos.cron.handoff import run_handoff_intake
     from kronos.cron.heartbeat import run_heartbeat
     from kronos.cron.market_review import run_market_review
     from kronos.cron.news_monitor import run_news_monitor
@@ -59,6 +60,9 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
 
     # User-scheduled reminders / tasks — poll every minute (roadmap 4.2)
     scheduler.add_periodic("user-reminders", run_due_reminders, interval_seconds=60)
+
+    # Cross-agent hand-off intake — poll every 30s (roadmap 5.1)
+    scheduler.add_periodic("handoff-intake", run_handoff_intake, interval_seconds=30)
 
     # News Monitor — daily at 00:00 UTC (was: kronos-news-monitor.timer)
     scheduler.add_daily("news-monitor", run_news_monitor, hour_utc=0)
@@ -156,5 +160,5 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
         scheduler.add_weekly("analytics-weekly", run_analytics_weekly, weekday=0, hour_utc=9)
         nexus_jobs_registered = 4
 
-    total = 15 + nexus_jobs_registered  # +user-reminders; signal-jobs, travel insights, people-scout and group-digest paused
+    total = 16 + nexus_jobs_registered  # +user-reminders +handoff-intake; signal-jobs, travel insights, people-scout and group-digest paused
     log.info("%d cron jobs registered for agent '%s'", total, me)

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -26,11 +26,12 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     from kronos.cron.analytics_alerts import run_analytics_alerts
     from kronos.cron.analytics_pulse import run_analytics_pulse
     from kronos.cron.analytics_weekly import run_analytics_weekly
-    from kronos.cron.expense_digest import run_expense_digest
-    from kronos.cron.expenses.processor import run_email_expenses
 
     # DISABLED 2026-07-07: group-digest paused — duplicate of news-monitor on Digest:News.
     # from kronos.cron.group_digest import run_group_digest
+    from kronos.cron.council import run_council_intake
+    from kronos.cron.expense_digest import run_expense_digest
+    from kronos.cron.expenses.processor import run_email_expenses
     from kronos.cron.handoff import run_handoff_intake
     from kronos.cron.heartbeat import run_heartbeat
     from kronos.cron.market_review import run_market_review
@@ -63,6 +64,9 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
 
     # Cross-agent hand-off intake — poll every 30s (roadmap 5.1)
     scheduler.add_periodic("handoff-intake", run_handoff_intake, interval_seconds=30)
+
+    # Council intake — contribute positions + synthesize, poll every 30s (5.2)
+    scheduler.add_periodic("council-intake", run_council_intake, interval_seconds=30)
 
     # News Monitor — daily at 00:00 UTC (was: kronos-news-monitor.timer)
     scheduler.add_daily("news-monitor", run_news_monitor, hour_utc=0)
@@ -160,5 +164,5 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
         scheduler.add_weekly("analytics-weekly", run_analytics_weekly, weekday=0, hour_utc=9)
         nexus_jobs_registered = 4
 
-    total = 16 + nexus_jobs_registered  # +user-reminders +handoff-intake; signal-jobs, travel insights, people-scout and group-digest paused
+    total = 17 + nexus_jobs_registered  # +user-reminders +handoff-intake +council-intake; signal-jobs, travel insights, people-scout and group-digest paused
     log.info("%d cron jobs registered for agent '%s'", total, me)

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -139,6 +139,11 @@ class KronosAgent:
             [schedule_task, schedule_followup, list_scheduled_tasks, cancel_scheduled_task]
         )
 
+        # Cross-agent hand-off (roadmap 5.1)
+        from kronos.tools.handoff import handoff_to_agent
+
+        self._tools.append(handoff_to_agent)
+
         # Composio tools
         from kronos.tools.composio_integration import get_composio_tools
 

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -139,11 +139,12 @@ class KronosAgent:
             [schedule_task, schedule_followup, list_scheduled_tasks, cancel_scheduled_task]
         )
 
-        # Cross-agent hand-off (roadmap 5.1) + council (5.2)
+        # Swarm collaboration: hand-off (5.1) + council (5.2) + memory query (5.3)
         from kronos.tools.council import convene_council
         from kronos.tools.handoff import handoff_to_agent
+        from kronos.tools.memory_ask import ask_agent_memory
 
-        self._tools.extend([handoff_to_agent, convene_council])
+        self._tools.extend([handoff_to_agent, convene_council, ask_agent_memory])
 
         # Composio tools
         from kronos.tools.composio_integration import get_composio_tools

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -139,10 +139,11 @@ class KronosAgent:
             [schedule_task, schedule_followup, list_scheduled_tasks, cancel_scheduled_task]
         )
 
-        # Cross-agent hand-off (roadmap 5.1)
+        # Cross-agent hand-off (roadmap 5.1) + council (5.2)
+        from kronos.tools.council import convene_council
         from kronos.tools.handoff import handoff_to_agent
 
-        self._tools.append(handoff_to_agent)
+        self._tools.extend([handoff_to_agent, convene_council])
 
         # Composio tools
         from kronos.tools.composio_integration import get_composio_tools

--- a/kronos/swarm_store.py
+++ b/kronos/swarm_store.py
@@ -237,6 +237,23 @@ def _schema(conn) -> None:
             created_at REAL NOT NULL,
             UNIQUE (session_id, agent_name)
         );
+
+        -- Cross-agent memory queries (roadmap 5.3): each agent has a private
+        -- Mem0/FTS, so one agent asks another "what do you have on X" and the
+        -- target shares from its own memory. Fire-and-forget into the chat.
+        CREATE TABLE IF NOT EXISTS memory_requests (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chat_id INTEGER NOT NULL,
+            topic_id INTEGER NOT NULL DEFAULT 0,
+            thread_id TEXT NOT NULL,
+            from_agent TEXT NOT NULL,
+            to_agent TEXT NOT NULL,
+            query TEXT NOT NULL,
+            state TEXT NOT NULL CHECK (state IN ('pending','done','failed')),
+            created_at REAL NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_memory_requests_intake
+            ON memory_requests(to_agent, state, created_at);
         """
     )
     columns = {
@@ -700,6 +717,69 @@ class SwarmStore:
             "UPDATE council_sessions SET state = ? WHERE id = ?",
             ("done" if success else "failed", session_id),
         )
+
+    # ------------------------------------------------------------------
+    # Cross-agent memory queries (roadmap 5.3)
+    # ------------------------------------------------------------------
+
+    def create_memory_request(
+        self,
+        *,
+        chat_id: int,
+        topic_id: int | None,
+        thread_id: str,
+        from_agent: str,
+        to_agent: str,
+        query: str,
+    ) -> int:
+        """Queue a memory query for another agent. Returns its id."""
+        cursor = self._db.write(
+            """
+            INSERT INTO memory_requests
+                (chat_id, topic_id, thread_id, from_agent, to_agent,
+                 query, state, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)
+            """,
+            (chat_id, topic_id or 0, thread_id, from_agent, to_agent, query, time.time()),
+        )
+        return int(cursor.lastrowid)
+
+    def accept_next_memory_request(self, to_agent: str) -> dict | None:
+        """Atomically claim the oldest pending memory query for this agent."""
+
+        def _tx(conn):
+            row = conn.execute(
+                """
+                SELECT * FROM memory_requests
+                WHERE to_agent = ? AND state = 'pending'
+                ORDER BY created_at ASC
+                LIMIT 1
+                """,
+                (to_agent,),
+            ).fetchone()
+            if row is None:
+                return None
+            conn.execute(
+                "UPDATE memory_requests SET state = 'done' WHERE id = ?",
+                (row["id"],),
+            )
+            return dict(row)
+
+        return self._db.write_tx(_tx)
+
+    def complete_memory_request(self, request_id: int, *, success: bool = True) -> None:
+        self._db.write(
+            "UPDATE memory_requests SET state = ? WHERE id = ?",
+            ("done" if success else "failed", request_id),
+        )
+
+    def pending_memory_requests(self, to_agent: str) -> list[dict]:
+        rows = self._db.read(
+            "SELECT * FROM memory_requests WHERE to_agent = ? AND state = 'pending' "
+            "ORDER BY created_at",
+            (to_agent,),
+        )
+        return [dict(row) for row in rows]
 
     # ------------------------------------------------------------------
     # Metrics

--- a/kronos/swarm_store.py
+++ b/kronos/swarm_store.py
@@ -193,6 +193,24 @@ def _schema(conn) -> None:
             ON feedback(agent_name, created_at DESC);
         CREATE INDEX IF NOT EXISTS idx_feedback_reaction
             ON feedback(reaction, created_at DESC);
+
+        -- Cross-agent hand-off queue (roadmap 5.1): agent A routes a request it
+        -- deems out of its domain to profile agent B, who polls its pending
+        -- rows and answers — instead of A going silent or replying worse.
+        CREATE TABLE IF NOT EXISTS handoffs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chat_id INTEGER NOT NULL,
+            topic_id INTEGER NOT NULL DEFAULT 0,
+            thread_id TEXT NOT NULL,
+            from_agent TEXT NOT NULL,
+            to_agent TEXT NOT NULL,
+            context TEXT NOT NULL,
+            state TEXT NOT NULL CHECK (state IN ('pending','accepted','done','failed')),
+            created_at REAL NOT NULL,
+            accepted_at REAL
+        );
+        CREATE INDEX IF NOT EXISTS idx_handoffs_intake
+            ON handoffs(to_agent, state, created_at);
         """
     )
     columns = {
@@ -480,6 +498,73 @@ class SwarmStore:
             (chat_id, topic_id or 0, root_msg_id),
         )
         return int(row["c"]) if row else 0
+
+    # ------------------------------------------------------------------
+    # Cross-agent hand-offs (roadmap 5.1)
+    # ------------------------------------------------------------------
+
+    def create_handoff(
+        self,
+        *,
+        chat_id: int,
+        topic_id: int | None,
+        thread_id: str,
+        from_agent: str,
+        to_agent: str,
+        context: str,
+    ) -> int:
+        """Queue a hand-off from one agent to another. Returns its id."""
+        cursor = self._db.write(
+            """
+            INSERT INTO handoffs
+                (chat_id, topic_id, thread_id, from_agent, to_agent,
+                 context, state, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)
+            """,
+            (chat_id, topic_id or 0, thread_id, from_agent, to_agent, context, time.time()),
+        )
+        return int(cursor.lastrowid)
+
+    def accept_next_handoff(self, to_agent: str) -> dict | None:
+        """Atomically claim the oldest pending hand-off for this agent.
+
+        Runs under an IMMEDIATE transaction so overlapping intake polls never
+        process the same row twice. Returns the row as a dict, or None.
+        """
+
+        def _tx(conn):
+            row = conn.execute(
+                """
+                SELECT * FROM handoffs
+                WHERE to_agent = ? AND state = 'pending'
+                ORDER BY created_at ASC
+                LIMIT 1
+                """,
+                (to_agent,),
+            ).fetchone()
+            if row is None:
+                return None
+            conn.execute(
+                "UPDATE handoffs SET state = 'accepted', accepted_at = ? WHERE id = ?",
+                (time.time(), row["id"]),
+            )
+            return dict(row)
+
+        return self._db.write_tx(_tx)
+
+    def complete_handoff(self, handoff_id: int, *, success: bool = True) -> None:
+        self._db.write(
+            "UPDATE handoffs SET state = ? WHERE id = ?",
+            ("done" if success else "failed", handoff_id),
+        )
+
+    def pending_handoffs(self, to_agent: str) -> list[dict]:
+        rows = self._db.read(
+            "SELECT * FROM handoffs WHERE to_agent = ? AND state = 'pending' "
+            "ORDER BY created_at",
+            (to_agent,),
+        )
+        return [dict(row) for row in rows]
 
     # ------------------------------------------------------------------
     # Metrics

--- a/kronos/swarm_store.py
+++ b/kronos/swarm_store.py
@@ -211,6 +211,32 @@ def _schema(conn) -> None:
         );
         CREATE INDEX IF NOT EXISTS idx_handoffs_intake
             ON handoffs(to_agent, state, created_at);
+
+        -- Council sessions (roadmap 5.2): a structured multi-agent debate. The
+        -- initiator convenes N participants who each submit an independent
+        -- position; once all are in, the initiator synthesizes one answer.
+        CREATE TABLE IF NOT EXISTS council_sessions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chat_id INTEGER NOT NULL,
+            topic_id INTEGER NOT NULL DEFAULT 0,
+            thread_id TEXT NOT NULL,
+            initiator TEXT NOT NULL,
+            question TEXT NOT NULL,
+            participants TEXT NOT NULL,
+            state TEXT NOT NULL CHECK (state IN ('gathering','synthesizing','done','failed')),
+            created_at REAL NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_council_state
+            ON council_sessions(state, initiator);
+
+        CREATE TABLE IF NOT EXISTS council_positions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id INTEGER NOT NULL,
+            agent_name TEXT NOT NULL,
+            position TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            UNIQUE (session_id, agent_name)
+        );
         """
     )
     columns = {
@@ -565,6 +591,115 @@ class SwarmStore:
             (to_agent,),
         )
         return [dict(row) for row in rows]
+
+    # ------------------------------------------------------------------
+    # Council sessions (roadmap 5.2)
+    # ------------------------------------------------------------------
+
+    def create_council(
+        self,
+        *,
+        chat_id: int,
+        topic_id: int | None,
+        thread_id: str,
+        initiator: str,
+        question: str,
+        participants: list[str],
+    ) -> int:
+        """Open a council gathering positions from participants. Returns its id."""
+        cursor = self._db.write(
+            """
+            INSERT INTO council_sessions
+                (chat_id, topic_id, thread_id, initiator, question,
+                 participants, state, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, 'gathering', ?)
+            """,
+            (
+                chat_id, topic_id or 0, thread_id, initiator, question,
+                ",".join(participants), time.time(),
+            ),
+        )
+        return int(cursor.lastrowid)
+
+    def pending_council_tasks(self, agent_name: str) -> list[dict]:
+        """Gathering sessions where this agent is a participant but hasn't
+        submitted a position yet."""
+        rows = self._db.read(
+            "SELECT * FROM council_sessions WHERE state = 'gathering' ORDER BY created_at"
+        )
+        result = []
+        for row in rows:
+            participants = [p for p in row["participants"].split(",") if p]
+            if agent_name not in participants:
+                continue
+            already = self._db.read_one(
+                "SELECT 1 FROM council_positions WHERE session_id = ? AND agent_name = ?",
+                (row["id"], agent_name),
+            )
+            if already is None:
+                result.append(dict(row))
+        return result
+
+    def submit_position(self, session_id: int, agent_name: str, position: str) -> None:
+        """Record an agent's independent position. Idempotent per participant."""
+        self._db.write(
+            "INSERT OR IGNORE INTO council_positions "
+            "(session_id, agent_name, position, created_at) VALUES (?, ?, ?, ?)",
+            (session_id, agent_name, position, time.time()),
+        )
+
+    def councils_awaiting_synthesis(self, initiator: str) -> list[dict]:
+        """Gathering sessions initiated by this agent (synthesis poll targets)."""
+        rows = self._db.read(
+            "SELECT * FROM council_sessions "
+            "WHERE state = 'gathering' AND initiator = ? ORDER BY created_at",
+            (initiator,),
+        )
+        return [dict(row) for row in rows]
+
+    def claim_synthesis(self, session_id: int, initiator: str) -> dict | None:
+        """If all participants have submitted and the session is still gathering,
+        atomically flip it to 'synthesizing' and return it. Otherwise None.
+
+        Runs under an IMMEDIATE transaction so only one synthesis fires.
+        """
+
+        def _tx(conn):
+            row = conn.execute(
+                "SELECT * FROM council_sessions "
+                "WHERE id = ? AND initiator = ? AND state = 'gathering'",
+                (session_id, initiator),
+            ).fetchone()
+            if row is None:
+                return None
+            participants = [p for p in row["participants"].split(",") if p]
+            (count,) = conn.execute(
+                "SELECT COUNT(*) FROM council_positions WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            if count < len(participants):
+                return None  # still gathering
+            conn.execute(
+                "UPDATE council_sessions SET state = 'synthesizing' WHERE id = ?",
+                (session_id,),
+            )
+            return dict(row)
+
+        return self._db.write_tx(_tx)
+
+    def get_positions(self, session_id: int) -> list[dict]:
+        rows = self._db.read(
+            "SELECT agent_name, position FROM council_positions "
+            "WHERE session_id = ? ORDER BY created_at",
+            (session_id,),
+        )
+        return [dict(row) for row in rows]
+
+    def complete_council(self, session_id: int, *, success: bool = True) -> None:
+        self._db.write(
+            "UPDATE council_sessions SET state = ? WHERE id = ?",
+            ("done" if success else "failed", session_id),
+        )
 
     # ------------------------------------------------------------------
     # Metrics

--- a/kronos/tools/council.py
+++ b/kronos/tools/council.py
@@ -1,0 +1,77 @@
+"""convene_council tool — structured multi-agent debate (roadmap 5.2).
+
+The initiator convenes 2-3 agents who each answer the question independently via
+the shared ledger; once all positions are in, the initiator's intake poll
+synthesizes them into one answer for the chat.
+"""
+
+from langchain_core.tools import tool
+
+from kronos.audit import get_tool_audit_context
+from kronos.config import settings
+from kronos.group_router import AGENT_PROFILES
+from kronos.swarm_store import get_swarm
+
+
+@tool
+def convene_council(question: str, participants: list[str]) -> str:
+    """Convene a council: gather independent positions from 2-3 agents, then synthesize.
+
+    Use for a hard or cross-domain question, or when the user asks to "discuss" /
+    "обсудите". Each named agent answers the question independently with its own
+    expertise; once all have, you synthesize one combined answer for the chat.
+
+    Known agents and domains:
+    - kronos: strategic advisor — priorities, planning, multi-model analysis
+    - nexus: data analyst — metrics, SEO, competitive intelligence
+    - lacuna: creative director — brand, meaning, naming, creative vision
+    - resonant: UX advocate — user experience, culture, tone of voice
+    - keystone: quality engineer — architecture, standards, technical debt
+    - impulse: action catalyst — momentum, quick wins, ideation
+    Pick 2-3 whose domains fit; don't include yourself.
+
+    Args:
+        question: the question each participant answers independently — make it
+            self-contained (they don't see this chat).
+        participants: 2-3 agent names to convene.
+    """
+    me = settings.agent_name
+
+    if isinstance(participants, str):
+        participants = participants.replace(" ", ",").split(",")
+    names = [p.strip().lower() for p in participants if p and p.strip()]
+    names = [p for p in dict.fromkeys(names) if p != me]  # dedup, drop self
+
+    unknown = [p for p in names if p not in AGENT_PROFILES]
+    if unknown:
+        return f"Неизвестные агенты: {', '.join(unknown)}. Доступны: {', '.join(sorted(AGENT_PROFILES))}."
+    if len(names) < 2:
+        return "Для консилиума нужно минимум 2 участника (кроме тебя)."
+    if len(names) > 4:
+        return "Слишком много участников — максимум 4."
+
+    ctx = get_tool_audit_context()
+    chat_raw = ctx.get("session_id", "")
+    thread_id = ctx.get("thread_id", "")
+    if not chat_raw:
+        return "Не удалось созвать консилиум: неизвестен чат этого запроса."
+
+    topic_id = None
+    _, sep, tail = thread_id.partition(":")
+    if sep and tail.isdigit():
+        topic_id = int(tail)
+
+    swarm = get_swarm()
+    session_id = swarm.create_council(
+        chat_id=int(chat_raw),
+        topic_id=topic_id,
+        thread_id=thread_id,
+        initiator=me,
+        question=question,
+        participants=names,
+    )
+    swarm.incr_metric("councils_convened")
+    return (
+        f"🏛 Созвал консилиум #{session_id}: {', '.join(names)}. "
+        "Соберу их позиции и синтезирую единый ответ здесь."
+    )

--- a/kronos/tools/handoff.py
+++ b/kronos/tools/handoff.py
@@ -1,0 +1,69 @@
+"""handoff_to_agent tool — route a request to a better-suited swarm agent (5.1).
+
+The agent decides a request is outside its domain and hands it to the profile
+agent via the shared swarm ledger; that agent's intake poll picks it up and
+answers with its own expertise, instead of this agent going silent or replying
+worse.
+"""
+
+from langchain_core.tools import tool
+
+from kronos.audit import get_tool_audit_context
+from kronos.config import settings
+from kronos.group_router import AGENT_PROFILES
+from kronos.swarm_store import get_swarm
+
+
+@tool
+def handoff_to_agent(to_agent: str, why: str) -> str:
+    """Hand this request to a better-suited swarm agent when it's outside your domain.
+
+    Use when the user's request clearly belongs to another agent's specialty —
+    hand it off instead of answering worse yourself or staying silent. The
+    target agent picks it up and replies here with its own expertise.
+
+    Known agents and their domains:
+    - kronos: strategic advisor — priorities, planning, multi-model analysis
+    - nexus: data analyst — business metrics, SEO, competitive intelligence
+    - lacuna: creative director — brand, product meaning, naming, creative vision
+    - resonant: UX advocate — user experience, culture, tone of voice, onboarding
+    - keystone: quality engineer — code architecture, standards, technical debt
+    - impulse: action catalyst — momentum, quick wins, ideation
+
+    Args:
+        to_agent: the agent to hand off to (one of the names above).
+        why: a self-contained brief for that agent — what the user needs plus any
+            context, since they don't see this chat's framing.
+    """
+    me = settings.agent_name
+    to_agent = to_agent.strip().lower()
+    if to_agent not in AGENT_PROFILES:
+        return f"Неизвестный агент '{to_agent}'. Доступны: {', '.join(sorted(AGENT_PROFILES))}."
+    if to_agent == me:
+        return "Нельзя передать запрос самому себе."
+
+    ctx = get_tool_audit_context()
+    chat_raw = ctx.get("session_id", "")
+    thread_id = ctx.get("thread_id", "")
+    if not chat_raw:
+        return "Не удалось передать: неизвестен чат этого запроса."
+
+    topic_id = None
+    _, sep, tail = thread_id.partition(":")
+    if sep and tail.isdigit():
+        topic_id = int(tail)
+
+    swarm = get_swarm()
+    handoff_id = swarm.create_handoff(
+        chat_id=int(chat_raw),
+        topic_id=topic_id,
+        thread_id=thread_id,
+        from_agent=me,
+        to_agent=to_agent,
+        context=why,
+    )
+    swarm.incr_metric("handoffs_created")
+
+    role = AGENT_PROFILES[to_agent].get("role", "")
+    role_txt = f" ({role})" if role else ""
+    return f"↪️ Передал запрос агенту {to_agent}{role_txt} — он ответит здесь. #{handoff_id}"

--- a/kronos/tools/memory_ask.py
+++ b/kronos/tools/memory_ask.py
@@ -1,0 +1,57 @@
+"""ask_agent_memory tool — query another agent's private memory (roadmap 5.3).
+
+Each agent keeps its own Mem0/FTS, so a colleague may know things this agent
+doesn't. The target agent looks in its memory and shares relevant knowledge in
+the chat — making the swarm smarter than any single agent.
+"""
+
+from langchain_core.tools import tool
+
+from kronos.audit import get_tool_audit_context
+from kronos.config import settings
+from kronos.group_router import AGENT_PROFILES
+from kronos.swarm_store import get_swarm
+
+
+@tool
+def ask_agent_memory(to_agent: str, query: str) -> str:
+    """Ask another agent what it knows about something from its own memory.
+
+    Use when a colleague's private memory likely holds context you lack. The
+    target agent recalls from its memory and shares here in the chat.
+
+    Known agents: kronos, nexus, lacuna, resonant, keystone, impulse.
+
+    Args:
+        to_agent: the agent to ask.
+        query: what you want them to recall (e.g. "что мы решили про нейминг X").
+    """
+    me = settings.agent_name
+    to_agent = to_agent.strip().lower()
+    if to_agent not in AGENT_PROFILES:
+        return f"Неизвестный агент '{to_agent}'. Доступны: {', '.join(sorted(AGENT_PROFILES))}."
+    if to_agent == me:
+        return "Свою память спрашивать не нужно — она у тебя уже под рукой."
+
+    ctx = get_tool_audit_context()
+    chat_raw = ctx.get("session_id", "")
+    thread_id = ctx.get("thread_id", "")
+    if not chat_raw:
+        return "Не удалось спросить: неизвестен чат этого запроса."
+
+    topic_id = None
+    _, sep, tail = thread_id.partition(":")
+    if sep and tail.isdigit():
+        topic_id = int(tail)
+
+    swarm = get_swarm()
+    request_id = swarm.create_memory_request(
+        chat_id=int(chat_raw),
+        topic_id=topic_id,
+        thread_id=thread_id,
+        from_agent=me,
+        to_agent=to_agent,
+        query=query,
+    )
+    swarm.incr_metric("memory_requests_created")
+    return f"🧠 Спросил {to_agent}, что у него есть про это — он поделится здесь. #{request_id}"

--- a/tests/test_council.py
+++ b/tests/test_council.py
@@ -1,0 +1,184 @@
+"""Council — structured multi-agent debate (roadmap 5.2)."""
+
+import pytest
+
+from kronos.audit import reset_tool_audit_context, set_tool_audit_context
+from kronos.config import settings
+
+
+@pytest.fixture
+def swarm(tmp_path, monkeypatch):
+    swarm_path = tmp_path / "swarm.db"
+    db_dir = tmp_path / "agent"
+    db_dir.mkdir()
+    monkeypatch.setattr(settings, "swarm_db_path", str(swarm_path))
+    monkeypatch.setattr(settings, "db_dir", str(db_dir))
+    monkeypatch.setattr(settings, "db_path", str(db_dir / "session.db"))
+    monkeypatch.setattr(settings, "agent_name", "kronos")
+
+    # Pin profiles so other modules' global mutation can't leak in.
+    from kronos.group_router import AGENT_PROFILES
+
+    original = {name: dict(prof) for name, prof in AGENT_PROFILES.items()}
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update({
+        "kronos": {"username": "kronosagnt", "aliases": ["kronos"], "role": "strategist"},
+        "nexus": {"username": "nexusagnt", "aliases": ["nexus"], "role": "analyst"},
+        "lacuna": {"username": "lacunaagnt", "aliases": ["lacuna"], "role": "creative"},
+    })
+
+    from kronos import db as _db
+
+    _db._instances.clear()
+    import kronos.swarm_store as ss
+
+    ss._singleton = None
+    from kronos.swarm_store import get_swarm
+
+    yield get_swarm()
+
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update(original)
+
+
+def _council(swarm, initiator="kronos", participants=("nexus", "lacuna"), chat=1):
+    return swarm.create_council(
+        chat_id=chat, topic_id=None, thread_id=str(chat), initiator=initiator,
+        question="what to build next?", participants=list(participants),
+    )
+
+
+def test_participant_sees_task_initiator_and_outsider_do_not(swarm):
+    _council(swarm, participants=("nexus", "lacuna"))
+    assert len(swarm.pending_council_tasks("nexus")) == 1
+    assert len(swarm.pending_council_tasks("lacuna")) == 1
+    assert swarm.pending_council_tasks("kronos") == []  # initiator, not a participant
+    assert swarm.pending_council_tasks("resonant") == []  # not invited
+
+
+def test_submit_position_removes_from_pending(swarm):
+    sid = _council(swarm, participants=("nexus", "lacuna"))
+    swarm.submit_position(sid, "nexus", "focus on metrics")
+    assert swarm.pending_council_tasks("nexus") == []
+    assert len(swarm.pending_council_tasks("lacuna")) == 1
+
+
+def test_synthesis_claimed_only_when_all_positions_in(swarm):
+    sid = _council(swarm, participants=("nexus", "lacuna"))
+    swarm.submit_position(sid, "nexus", "A")
+    assert swarm.claim_synthesis(sid, "kronos") is None  # lacuna still missing
+
+    swarm.submit_position(sid, "lacuna", "B")
+    claimed = swarm.claim_synthesis(sid, "kronos")
+    assert claimed is not None
+    # A second poll must not synthesize again.
+    assert swarm.claim_synthesis(sid, "kronos") is None
+    assert {p["agent_name"] for p in swarm.get_positions(sid)} == {"nexus", "lacuna"}
+
+
+def test_convene_tool_creates_session(swarm):
+    from kronos.tools.council import convene_council
+
+    token = set_tool_audit_context(agent="kronos", thread_id="9:2", session_id="9")
+    try:
+        result = convene_council.invoke(
+            {"question": "strategy?", "participants": ["nexus", "lacuna"]}
+        )
+    finally:
+        reset_tool_audit_context(token)
+    assert "консилиум" in result.lower()
+    tasks = swarm.pending_council_tasks("nexus")
+    assert len(tasks) == 1
+    assert tasks[0]["chat_id"] == 9
+    assert tasks[0]["topic_id"] == 2
+
+
+def test_convene_tool_rejects_too_few_participants(swarm):
+    from kronos.tools.council import convene_council
+
+    token = set_tool_audit_context(agent="kronos", thread_id="9", session_id="9")
+    try:
+        result = convene_council.invoke({"question": "q", "participants": ["nexus"]})
+    finally:
+        reset_tool_audit_context(token)
+    assert "минимум 2" in result
+
+
+def test_convene_tool_drops_self_from_participants(swarm):
+    from kronos.tools.council import convene_council
+
+    token = set_tool_audit_context(agent="kronos", thread_id="9", session_id="9")
+    try:
+        # kronos (self) is filtered out → only nexus left → too few
+        result = convene_council.invoke(
+            {"question": "q", "participants": ["kronos", "nexus"]}
+        )
+    finally:
+        reset_tool_audit_context(token)
+    assert "минимум 2" in result
+
+
+async def test_intake_participant_submits_position(swarm, monkeypatch):
+    from kronos.cron import council as cron_council
+
+    monkeypatch.setattr(settings, "agent_name", "nexus")  # this process = nexus
+    sid = _council(swarm, initiator="kronos", participants=("nexus", "lacuna"), chat=5)
+
+    class FakeAgent:
+        async def ainvoke(self, message, **kwargs):
+            return "nexus position"
+
+    monkeypatch.setattr("kronos.bridge._agent", FakeAgent())
+
+    await cron_council.run_council_intake()
+
+    positions = swarm.get_positions(sid)
+    assert any(
+        p["agent_name"] == "nexus" and p["position"] == "nexus position" for p in positions
+    )
+
+
+async def test_intake_initiator_synthesizes_when_ready(swarm, monkeypatch):
+    from kronos.cron import council as cron_council
+
+    monkeypatch.setattr(settings, "agent_name", "kronos")  # this process = initiator
+    sid = _council(swarm, initiator="kronos", participants=("nexus", "lacuna"), chat=5)
+    swarm.submit_position(sid, "nexus", "A")
+    swarm.submit_position(sid, "lacuna", "B")
+
+    class FakeAgent:
+        async def ainvoke(self, message, **kwargs):
+            return f"synthesis of: {message[:20]}"
+
+    monkeypatch.setattr("kronos.bridge._agent", FakeAgent())
+    sent: list[str] = []
+    monkeypatch.setattr(
+        cron_council, "send_webhook", lambda text, *a, **k: sent.append(text) or True
+    )
+
+    await cron_council.run_council_intake()
+
+    assert sent and sent[0].startswith("synthesis of:")
+    assert swarm.councils_awaiting_synthesis("kronos") == []  # session done
+
+
+async def test_intake_initiator_waits_until_all_positions_in(swarm, monkeypatch):
+    from kronos.cron import council as cron_council
+
+    monkeypatch.setattr(settings, "agent_name", "kronos")
+    _council(swarm, initiator="kronos", participants=("nexus", "lacuna"), chat=5)
+    # only one of two positions submitted
+
+    class FakeAgent:
+        async def ainvoke(self, message, **kwargs):
+            return "x"
+
+    monkeypatch.setattr("kronos.bridge._agent", FakeAgent())
+    swarm.submit_position(swarm.councils_awaiting_synthesis("kronos")[0]["id"], "nexus", "A")
+    sent: list[int] = []
+    monkeypatch.setattr(cron_council, "send_webhook", lambda *a, **k: sent.append(1) or True)
+
+    await cron_council.run_council_intake()
+
+    assert sent == []  # nothing synthesized yet
+    assert len(swarm.councils_awaiting_synthesis("kronos")) == 1  # still gathering

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -1,0 +1,149 @@
+"""Cross-agent hand-off (roadmap 5.1)."""
+
+import pytest
+
+from kronos.audit import reset_tool_audit_context, set_tool_audit_context
+from kronos.config import settings
+
+
+@pytest.fixture
+def swarm(tmp_path, monkeypatch):
+    swarm_path = tmp_path / "swarm.db"
+    db_dir = tmp_path / "agent"
+    db_dir.mkdir()
+    monkeypatch.setattr(settings, "swarm_db_path", str(swarm_path))
+    monkeypatch.setattr(settings, "db_dir", str(db_dir))
+    monkeypatch.setattr(settings, "db_path", str(db_dir / "session.db"))
+    monkeypatch.setattr(settings, "agent_name", "kronos")
+
+    # Pin agent profiles: other test modules (test_group_router) replace the
+    # global AGENT_PROFILES at import time, so we install a known set and
+    # restore it, keeping this test immune to that leak.
+    from kronos.group_router import AGENT_PROFILES
+
+    original_profiles = {name: dict(prof) for name, prof in AGENT_PROFILES.items()}
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update({
+        "kronos": {"username": "kronosagnt", "aliases": ["kronos"], "role": "strategic advisor"},
+        "nexus": {"username": "nexusagnt", "aliases": ["nexus"], "role": "data analyst"},
+        "lacuna": {"username": "lacunaagnt", "aliases": ["lacuna"], "role": "creative director"},
+    })
+
+    from kronos import db as _db
+
+    _db._instances.clear()
+    import kronos.swarm_store as ss
+
+    ss._singleton = None
+    from kronos.swarm_store import get_swarm
+
+    yield get_swarm()
+
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update(original_profiles)
+
+
+def _create(swarm, to_agent="nexus", context="analyze metrics", chat=1):
+    return swarm.create_handoff(
+        chat_id=chat, topic_id=None, thread_id=str(chat),
+        from_agent="kronos", to_agent=to_agent, context=context,
+    )
+
+
+def test_accept_is_atomic_single_delivery(swarm):
+    _create(swarm)
+    assert len(swarm.pending_handoffs("nexus")) == 1
+
+    accepted = swarm.accept_next_handoff("nexus")
+    assert accepted is not None
+    assert accepted["context"] == "analyze metrics"
+    # A second poll must not re-claim the same row.
+    assert swarm.accept_next_handoff("nexus") is None
+    assert swarm.pending_handoffs("nexus") == []
+
+
+def test_handoff_scoped_to_target_agent(swarm):
+    _create(swarm, to_agent="nexus")
+    assert swarm.accept_next_handoff("lacuna") is None  # not addressed to lacuna
+
+
+def test_complete_handoff_clears_pending(swarm):
+    hid = _create(swarm)
+    swarm.accept_next_handoff("nexus")
+    swarm.complete_handoff(hid, success=True)
+    assert swarm.pending_handoffs("nexus") == []
+
+
+def test_tool_creates_handoff_with_chat_and_topic(swarm):
+    from kronos.tools.handoff import handoff_to_agent
+
+    token = set_tool_audit_context(agent="kronos", thread_id="55:3", session_id="55")
+    try:
+        result = handoff_to_agent.invoke({"to_agent": "nexus", "why": "analyze churn"})
+    finally:
+        reset_tool_audit_context(token)
+
+    assert "Передал" in result and "nexus" in result
+    pending = swarm.pending_handoffs("nexus")
+    assert len(pending) == 1
+    assert pending[0]["chat_id"] == 55
+    assert pending[0]["topic_id"] == 3
+    assert pending[0]["from_agent"] == "kronos"
+    assert pending[0]["context"] == "analyze churn"
+
+
+def test_tool_rejects_unknown_agent(swarm):
+    from kronos.tools.handoff import handoff_to_agent
+
+    token = set_tool_audit_context(agent="kronos", thread_id="55", session_id="55")
+    try:
+        result = handoff_to_agent.invoke({"to_agent": "ghost", "why": "x"})
+    finally:
+        reset_tool_audit_context(token)
+    assert "неизвестн" in result.lower()
+    assert swarm.pending_handoffs("ghost") == []
+
+
+def test_tool_rejects_self_handoff(swarm):
+    from kronos.tools.handoff import handoff_to_agent
+
+    token = set_tool_audit_context(agent="kronos", thread_id="55", session_id="55")
+    try:
+        result = handoff_to_agent.invoke({"to_agent": "kronos", "why": "x"})
+    finally:
+        reset_tool_audit_context(token)
+    assert "самому себе" in result.lower()
+
+
+async def test_intake_runs_agent_and_delivers(swarm, monkeypatch):
+    from kronos.cron import handoff as cron_handoff
+
+    monkeypatch.setattr(settings, "agent_name", "nexus")  # this process is nexus
+    _create(swarm, to_agent="nexus", context="analyze", chat=7)
+
+    class FakeAgent:
+        async def ainvoke(self, message, **kwargs):
+            return f"analysis: {message}"
+
+    monkeypatch.setattr("kronos.bridge._agent", FakeAgent())
+    sent: list[str] = []
+    monkeypatch.setattr(
+        cron_handoff, "send_webhook", lambda text, *a, **k: sent.append(text) or True
+    )
+
+    await cron_handoff.run_handoff_intake()
+
+    assert sent and sent[0].startswith("analysis:")
+    assert swarm.pending_handoffs("nexus") == []  # completed
+
+
+async def test_intake_leaves_pending_when_agent_not_ready(swarm, monkeypatch):
+    from kronos.cron import handoff as cron_handoff
+
+    monkeypatch.setattr(settings, "agent_name", "nexus")
+    _create(swarm, to_agent="nexus", chat=7)
+    monkeypatch.setattr("kronos.bridge._agent", None)
+
+    await cron_handoff.run_handoff_intake()
+
+    assert len(swarm.pending_handoffs("nexus")) == 1  # untouched, retried next poll

--- a/tests/test_memory_ask.py
+++ b/tests/test_memory_ask.py
@@ -1,0 +1,137 @@
+"""Cross-agent memory queries (roadmap 5.3)."""
+
+import pytest
+
+from kronos.audit import reset_tool_audit_context, set_tool_audit_context
+from kronos.config import settings
+
+
+@pytest.fixture
+def swarm(tmp_path, monkeypatch):
+    swarm_path = tmp_path / "swarm.db"
+    db_dir = tmp_path / "agent"
+    db_dir.mkdir()
+    monkeypatch.setattr(settings, "swarm_db_path", str(swarm_path))
+    monkeypatch.setattr(settings, "db_dir", str(db_dir))
+    monkeypatch.setattr(settings, "db_path", str(db_dir / "session.db"))
+    monkeypatch.setattr(settings, "agent_name", "kronos")
+
+    from kronos.group_router import AGENT_PROFILES
+
+    original = {name: dict(prof) for name, prof in AGENT_PROFILES.items()}
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update({
+        "kronos": {"username": "kronosagnt", "aliases": ["kronos"], "role": "strategist"},
+        "nexus": {"username": "nexusagnt", "aliases": ["nexus"], "role": "analyst"},
+        "lacuna": {"username": "lacunaagnt", "aliases": ["lacuna"], "role": "creative"},
+    })
+
+    from kronos import db as _db
+
+    _db._instances.clear()
+    import kronos.swarm_store as ss
+
+    ss._singleton = None
+    from kronos.swarm_store import get_swarm
+
+    yield get_swarm()
+
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update(original)
+
+
+def _req(swarm, to_agent="nexus", query="what about X", chat=1):
+    return swarm.create_memory_request(
+        chat_id=chat, topic_id=None, thread_id=str(chat),
+        from_agent="kronos", to_agent=to_agent, query=query,
+    )
+
+
+def test_accept_is_atomic_single_answer(swarm):
+    _req(swarm)
+    assert len(swarm.pending_memory_requests("nexus")) == 1
+    accepted = swarm.accept_next_memory_request("nexus")
+    assert accepted is not None
+    assert accepted["query"] == "what about X"
+    assert swarm.accept_next_memory_request("nexus") is None  # not re-claimed
+    assert swarm.pending_memory_requests("nexus") == []
+
+
+def test_scoped_per_target_agent(swarm):
+    _req(swarm, to_agent="nexus")
+    assert swarm.accept_next_memory_request("lacuna") is None
+
+
+def test_tool_creates_request_with_chat_and_topic(swarm):
+    from kronos.tools.memory_ask import ask_agent_memory
+
+    token = set_tool_audit_context(agent="kronos", thread_id="8:4", session_id="8")
+    try:
+        result = ask_agent_memory.invoke(
+            {"to_agent": "nexus", "query": "past decisions on pricing"}
+        )
+    finally:
+        reset_tool_audit_context(token)
+
+    assert "Спросил" in result and "nexus" in result
+    pending = swarm.pending_memory_requests("nexus")
+    assert len(pending) == 1
+    assert pending[0]["chat_id"] == 8
+    assert pending[0]["topic_id"] == 4
+    assert pending[0]["query"] == "past decisions on pricing"
+
+
+def test_tool_rejects_unknown_agent(swarm):
+    from kronos.tools.memory_ask import ask_agent_memory
+
+    token = set_tool_audit_context(agent="kronos", thread_id="8", session_id="8")
+    try:
+        result = ask_agent_memory.invoke({"to_agent": "ghost", "query": "x"})
+    finally:
+        reset_tool_audit_context(token)
+    assert "неизвестн" in result.lower()
+
+
+def test_tool_rejects_self(swarm):
+    from kronos.tools.memory_ask import ask_agent_memory
+
+    token = set_tool_audit_context(agent="kronos", thread_id="8", session_id="8")
+    try:
+        result = ask_agent_memory.invoke({"to_agent": "kronos", "query": "x"})
+    finally:
+        reset_tool_audit_context(token)
+    assert "свою память" in result.lower()
+
+
+async def test_intake_answers_from_memory_and_delivers(swarm, monkeypatch):
+    from kronos.cron import memory_ask as cron_mem
+
+    monkeypatch.setattr(settings, "agent_name", "nexus")  # this process = nexus
+    _req(swarm, to_agent="nexus", query="pricing history", chat=7)
+
+    class FakeAgent:
+        async def ainvoke(self, message, **kwargs):
+            return f"from memory: {message}"
+
+    monkeypatch.setattr("kronos.bridge._agent", FakeAgent())
+    sent: list[str] = []
+    monkeypatch.setattr(
+        cron_mem, "send_webhook", lambda text, *a, **k: sent.append(text) or True
+    )
+
+    await cron_mem.run_memory_intake()
+
+    assert sent and sent[0].startswith("from memory:")
+    assert swarm.pending_memory_requests("nexus") == []
+
+
+async def test_intake_leaves_pending_when_agent_not_ready(swarm, monkeypatch):
+    from kronos.cron import memory_ask as cron_mem
+
+    monkeypatch.setattr(settings, "agent_name", "nexus")
+    _req(swarm, to_agent="nexus", chat=7)
+    monkeypatch.setattr("kronos.bridge._agent", None)
+
+    await cron_mem.run_memory_intake()
+
+    assert len(swarm.pending_memory_requests("nexus")) == 1  # untouched, retried


### PR DESCRIPTION
Roadmap phase 5 — turn six agents that don't interfere into a swarm that collaborates. 3 commits, all tests green without LLM keys.

**Stacked on #11 (phase 4).** Base is `roadmap/phase-4-ux`; merge #11 first, then this retargets to main cleanly.

## 5.1 — Cross-agent hand-off
An agent that judges a request out of its domain now routes it to the profile agent instead of answering worse or going silent. New `handoffs` table + `accept_next_handoff` (atomic claim under IMMEDIATE tx). `handoff_to_agent` tool (LLM picks the target from the roster, writes a self-contained brief); a 30s intake poll runs it through the target's live agent and delivers the result.

## 5.2 — Council on demand
For hard/cross-domain questions (or "обсудите"), an agent convenes 2–4 others. Each submits an independent position (`council_sessions` + `council_positions`); once all are in, `claim_synthesis` flips the session under an IMMEDIATE tx so the initiator synthesizes exactly one combined answer. `convene_council` tool + `run_council_intake` playing both participant and synthesizer roles.

## 5.3 — Cross-agent memory queries
Each agent has a private Mem0/FTS, so one may know what another doesn't. `ask_agent_memory` lets an agent query a colleague's memory via a `memory_requests` table; the target recalls (ephemeral turn, no self-pollution) and shares in the chat. Fire-and-forget, no RPC/pub-sub — in keeping with the swarm architecture.

## Tests
637 passed, 40 deselected (integration), 0 failures — without LLM keys. ruff clean. New tests cover each store's atomic claim, the tools' validation, and both intake roles. Also fixed a test-isolation trap surfaced along the way (a module pinning global AGENT_PROFILES) by pinning profiles locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)