### PR TITLE
Capabilities: document ingest, /stats + budgets, self-improvement loop (roadmap phase 6)

### DIFF
--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -495,6 +495,88 @@ def _compose_image_agent_message(caption: str, image_analysis: str) -> str:
     )
 
 
+# --- Document ingest (roadmap 6.1) ---
+
+_DOC_EXTENSIONS = (".pdf", ".docx", ".txt", ".md", ".markdown")
+
+
+def _document_info(event) -> tuple[str, str]:
+    """(filename, mime_type) for a document attachment, or ("", "")."""
+    doc = getattr(getattr(event.message, "media", None), "document", None)
+    if doc is None:
+        return "", ""
+    from telethon.tl.types import DocumentAttributeFilename
+
+    filename = ""
+    for attr in getattr(doc, "attributes", []):
+        if isinstance(attr, DocumentAttributeFilename):
+            filename = attr.file_name
+            break
+    return filename, str(getattr(doc, "mime_type", "") or "")
+
+
+def _is_document_message(event) -> bool:
+    """A non-image, non-voice document we can ingest (by extension or mime)."""
+    if not getattr(event.message, "media", None):
+        return False
+    if _is_image_message(event) or _is_voice_message(event):
+        return False
+    filename, mime = _document_info(event)
+    low = filename.lower()
+    return (
+        low.endswith(_DOC_EXTENSIONS)
+        or "pdf" in mime
+        or "wordprocessingml" in mime
+        or mime.startswith("text/")
+    )
+
+
+async def _download_document_bytes(event) -> bytes:
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp_path = tmp.name
+        await event.message.download_media(file=tmp_path)
+        with open(tmp_path, "rb") as f:
+            return f.read()
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+
+async def _extract_document_message(event) -> tuple[str, str]:
+    """Download + extract text; archive raw text to notes/inbox. (text, error)."""
+    from kronos.documents.extract import extract_text
+    from kronos.workspace import ws
+
+    filename, mime = _document_info(event)
+    data = await _download_document_bytes(event)
+    text, error = extract_text(data, filename, mime)
+    if error:
+        return "", error
+
+    # Archive raw text to the inbox for later processing / provenance.
+    try:
+        ws.inbox_dir.mkdir(parents=True, exist_ok=True)
+        stamp = time.strftime("%Y%m%d-%H%M%S")
+        safe = "".join(c for c in (filename or "document") if c.isalnum() or c in "-_.") or "document"
+        (ws.inbox_dir / f"{stamp}-{safe}.txt").write_text(text, encoding="utf-8")
+    except Exception as e:
+        log.warning("Failed to archive document to inbox: %s", e)
+
+    return text, ""
+
+
+def _compose_document_agent_message(caption: str, filename: str, text: str) -> str:
+    caption = caption.strip()
+    user_request = caption or f"Пользователь прислал документ «{filename}»."
+    return (
+        f"{user_request}\n\n"
+        f"[Документ: {filename}]\n{text}\n\n"
+        "Дай краткое саммари документа и выдели ключевые факты и action items."
+    )
+
+
 def _message_timestamp(event) -> str:
     value = getattr(getattr(event, "message", None), "date", None)
     if hasattr(value, "isoformat"):
@@ -1478,8 +1560,9 @@ async def run_bridge(agent: KronosAgent) -> None:
         is_dm = event.is_private
         voice = _is_voice_message(event)
         image = _is_image_message(event)
+        document = _is_document_message(event)
 
-        if not text and not voice and not image:
+        if not text and not voice and not image and not document:
             return
 
         # Swarm ledger ingress: record every observed group message before
@@ -1689,6 +1772,14 @@ async def run_bridge(agent: KronosAgent) -> None:
                 )
                 await _send_to_chat(event.chat_id, reply, topic_id=_extract_topic_id(event))
                 return
+        elif document:
+            clean_text = _strip_mention(text) if not is_dm else text
+            document_text, doc_error = await _extract_document_message(event)
+            if doc_error:
+                await _send_to_chat(
+                    event.chat_id, f"📄 {doc_error}", topic_id=_extract_topic_id(event)
+                )
+                return
         else:
             clean_text = _strip_mention(text) if not is_dm else text
 
@@ -1697,7 +1788,15 @@ async def run_bridge(agent: KronosAgent) -> None:
         # into session history — it disappears after the current LLM call.
         # This is what prevents peer text from being echoed back verbatim.
         group_extra_context = ""
-        invoke_message = _compose_image_agent_message(clean_text, image_analysis) if image else clean_text
+        if image:
+            invoke_message = _compose_image_agent_message(clean_text, image_analysis)
+        elif document:
+            doc_filename, _ = _document_info(event)
+            invoke_message = _compose_document_agent_message(
+                clean_text, doc_filename, document_text
+            )
+        else:
+            invoke_message = clean_text
         invoke_source_kind = "user"
         invoke_persist = True
 

--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -1008,6 +1008,7 @@ async def _ask_agent(
     source_kind: str = "user",
     persist_user_turn: bool = True,
     extra_system_context: str = "",
+    force_tier: str | None = None,
 ) -> str | None:
     """Send message to KronosAgent and return response text.
 
@@ -1046,6 +1047,7 @@ async def _ask_agent(
                 persist_user_turn=persist_user_turn,
                 extra_system_context=extra_system_context,
                 on_tool_event=reporter.on_event,
+                force_tier=force_tier,
             )
     except Exception as e:
         log.error("Agent error: %s", e)
@@ -1242,6 +1244,46 @@ async def _start_webhook_server() -> None:
             webhook_host,
         )
     log.info("Webhook server listening on %s:%d", webhook_host, webhook_port)
+
+
+# --- /stats command handler (roadmap 6.2) ---
+
+
+async def _handle_stats_command(text: str) -> str | None:
+    """Handle /stats [today|week]. Returns reply text, or None if not /stats."""
+    if not text.startswith("/stats"):
+        return None
+
+    from kronos.security.cost_stats import cost_report, swarm_cost_by_agent
+
+    parts = text.split()
+    period = "week" if len(parts) > 1 and parts[1].lower().startswith("week") else "today"
+    period_ru = "неделя" if period == "week" else "сегодня"
+
+    report = cost_report(period)
+    total = report["total"]
+    status = get_guardian().get_status()
+
+    lines = [f"📊 Расходы ({period_ru}) — {settings.agent_name}"]
+    if total["requests"] == 0:
+        lines.append("Запросов пока нет.")
+    else:
+        for tier, stats in sorted(report["by_tier"].items()):
+            lines.append(f"• {tier}: {stats['requests']} зпр · ${stats['cost']:.4f}")
+        lines.append(f"• Итого: {total['requests']} зпр · ${total['cost']:.4f}")
+
+    daily = status["daily_cost"]
+    limit = status["daily_limit"] or 0
+    pct = (daily / limit * 100) if limit else 0
+    lines.append(f"\nДневной бюджет: ${daily:.2f} / ${limit:.2f} ({pct:.0f}%)")
+
+    swarm = swarm_cost_by_agent(period)
+    if len(swarm) > 1:
+        lines.append(f"\nПо агентам ({period_ru}):")
+        for agent, cost in sorted(swarm.items(), key=lambda kv: -kv[1]):
+            lines.append(f"• {agent}: ${cost:.4f}")
+
+    return "\n".join(lines)
 
 
 # --- ASO command handler ---
@@ -1767,6 +1809,8 @@ async def run_bridge(agent: KronosAgent) -> None:
             if not observer_reply:
                 return
             reply = observer_reply
+        elif (stats_reply := await _handle_stats_command(clean_text)) is not None:
+            reply = stats_reply
         elif _is_osint_command(clean_text) and not is_dm:
             log.info("Ignoring /osint command outside DM")
             return
@@ -1789,6 +1833,9 @@ async def run_bridge(agent: KronosAgent) -> None:
                     return
                 reply = osint_reply
             else:
+                # Soft cost degradation: once daily spend crosses the degrade
+                # threshold, force the lite tier instead of blocking.
+                degrade_tier = "lite" if guardian.should_degrade() else None
                 # Call agent with new contract: raw user text as message,
                 # group metadata as transient extra_system_context only.
                 reply = await _ask_agent(
@@ -1799,6 +1846,7 @@ async def run_bridge(agent: KronosAgent) -> None:
                     source_kind=invoke_source_kind,
                     persist_user_turn=invoke_persist,
                     extra_system_context=group_extra_context,
+                    force_tier=degrade_tier,
                 )
 
         # Peer-reaction "PASS" protocol: the agent is instructed to reply

--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -1328,6 +1328,44 @@ async def _start_webhook_server() -> None:
     log.info("Webhook server listening on %s:%d", webhook_host, webhook_port)
 
 
+# --- /persona command handler (roadmap 6.3) ---
+
+
+async def _handle_persona_command(text: str) -> str | None:
+    """Handle /persona [list | approve <id> | reject <id>]. Returns reply or None."""
+    if not text.startswith("/persona"):
+        return None
+
+    from kronos import evolution
+
+    parts = text.split()
+    action = parts[1].lower() if len(parts) > 1 else "list"
+    agent = settings.agent_name
+
+    if action == "list":
+        pending = evolution.list_pending(agent)
+        if not pending:
+            return "🧬 Нет предложений эволюции персоны."
+        lines = ["🧬 Предложения эволюции персоны:"]
+        for proposal in pending:
+            lines.append(f"#{proposal['id']} → {proposal['target']}: {proposal['rationale'][:80]}")
+        lines.append("\n/persona approve <id> · /persona reject <id>")
+        return "\n".join(lines)
+
+    if action in ("approve", "reject") and len(parts) > 2 and parts[2].isdigit():
+        pid = int(parts[2])
+        decided = evolution.decide_proposal(pid, agent, approved=(action == "approve"))
+        if decided is None:
+            return f"Предложение #{pid} не найдено или уже обработано."
+        if action == "reject":
+            return f"❌ Отклонил предложение #{pid}."
+        path = evolution.apply_proposal(decided)
+        get_swarm().incr_metric("persona_proposals_approved")
+        return f"✅ Применил предложение #{pid} к {decided['target'].upper()}\n{path}"
+
+    return "Использование: /persona [list | approve <id> | reject <id>]"
+
+
 # --- /stats command handler (roadmap 6.2) ---
 
 
@@ -1908,6 +1946,8 @@ async def run_bridge(agent: KronosAgent) -> None:
             if not observer_reply:
                 return
             reply = observer_reply
+        elif (persona_reply := await _handle_persona_command(clean_text)) is not None:
+            reply = persona_reply
         elif (stats_reply := await _handle_stats_command(clean_text)) is not None:
             reply = stats_reply
         elif _is_osint_command(clean_text) and not is_dm:

--- a/kronos/cron/persona_evolve.py
+++ b/kronos/cron/persona_evolve.py
@@ -1,0 +1,108 @@
+"""Weekly persona evolution — propose a persona edit from feedback (roadmap 6.3).
+
+Reads the week's satisfaction + negative feedback, asks the LLM for ONE concrete
+edit to SOUL or IDENTITY, stores it as a pending proposal, and notifies the user
+in Telegram to approve/reject via /persona. Nothing is applied without approval.
+"""
+
+import logging
+
+from langchain_core.messages import HumanMessage
+
+from kronos import evolution
+from kronos.config import settings
+from kronos.cron.notify import TOPIC_GENERAL, send_bot_api
+from kronos.llm import ModelTier, get_model
+from kronos.swarm_store import get_swarm
+
+log = logging.getLogger("kronos.cron.persona_evolve")
+
+_MIN_FEEDBACK = 3  # need at least some signal before proposing
+
+
+def _parse_proposal(reply: str):
+    """Parse the LLM's TARGET/RATIONALE/PROPOSAL block. Returns tuple or None."""
+    text = reply.strip()
+    if text.upper().startswith("SKIP"):
+        return None
+    target = None
+    rationale = ""
+    proposal_lines: list[str] = []
+    mode = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        upper = stripped.upper()
+        if upper.startswith("TARGET:"):
+            val = stripped.split(":", 1)[1].strip().lower()
+            target = val if val in evolution.VALID_TARGETS else None
+            mode = None
+        elif upper.startswith("RATIONALE:"):
+            rationale = stripped.split(":", 1)[1].strip()
+            mode = None
+        elif upper.startswith("PROPOSAL:"):
+            first = stripped.split(":", 1)[1].strip()
+            if first:
+                proposal_lines.append(first)
+            mode = "proposal"
+        elif mode == "proposal":
+            proposal_lines.append(line)
+    proposal = "\n".join(proposal_lines).strip()
+    if not target or not rationale or not proposal:
+        return None
+    return target, rationale, proposal
+
+
+async def run_persona_evolution() -> None:
+    swarm = get_swarm()
+    agent = settings.agent_name
+
+    satisfaction = swarm.get_satisfaction_rate(agent_name=agent, days=7)
+    total = satisfaction.get("total", 0)
+    if total < _MIN_FEEDBACK:
+        log.info("Persona evolution: only %d feedback signals, skipping", total)
+        return
+
+    positive = satisfaction.get("positive", 0)
+    rate = positive / total if total else 0
+    negative = swarm.get_feedback(agent_name=agent, reaction="negative", days=7, limit=15)
+    neg_text = "\n".join(
+        f"- {f.get('emoji', '')} on msg {f.get('msg_id')}" for f in negative
+    ) or "нет явного негатива"
+
+    prompt = f"""Ты — агент {agent}. На основе фидбека за неделю предложи ОДНО конкретное
+изменение к своей персоне (SOUL или IDENTITY), которое улучшит реакцию пользователя.
+
+Satisfaction: {rate:.0%} (положительных {positive} из {total}).
+Негативные реакции:
+{neg_text}
+
+Ответь СТРОГО в формате:
+TARGET: soul|identity
+RATIONALE: <одно предложение — почему это изменение>
+PROPOSAL: <конкретный текст, готовый к вставке в файл — 2-5 строк>
+
+Если менять нечего — ответь одним словом: SKIP."""
+
+    model = get_model(ModelTier.STANDARD)
+    response = model.invoke([HumanMessage(content=prompt)])
+    reply = response.content if isinstance(response.content, str) else str(response.content)
+
+    parsed = _parse_proposal(reply)
+    if parsed is None:
+        log.info("Persona evolution: nothing to propose")
+        return
+
+    target, rationale, proposal = parsed
+    pid = evolution.create_proposal(
+        agent_name=agent, target=target, rationale=rationale, proposal=proposal
+    )
+    swarm.incr_metric("persona_proposals_created")
+
+    send_bot_api(
+        f"🧬 Предложение эволюции персоны #{pid} → {target.upper()}\n\n"
+        f"Почему: {rationale}\n\n"
+        f"Изменение:\n{proposal}\n\n"
+        f"Применить: /persona approve {pid} · Отклонить: /persona reject {pid}",
+        topic_id=TOPIC_GENERAL,
+    )
+    log.info("Persona proposal #%s created for %s", pid, target)

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -37,6 +37,7 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     from kronos.cron.market_review import run_market_review
     from kronos.cron.memory_ask import run_memory_intake
     from kronos.cron.news_monitor import run_news_monitor
+    from kronos.cron.persona_evolve import run_persona_evolution
     from kronos.cron.personal_observer import run_daily_scope, run_personal_observer
     from kronos.cron.reminders import run_due_reminders
     from kronos.cron.self_improve import run_self_improve
@@ -112,6 +113,10 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     # Skill Improve — weekly Sunday 20:00 UTC (was: kronos-skill-improve.timer)
     scheduler.add_weekly("skill-improve", run_skill_improve, weekday=6, hour_utc=20)
 
+    # Persona Evolution — weekly Sunday 21:00 UTC. Proposes a SOUL/IDENTITY edit
+    # from the week's feedback; applied only on /persona approve (roadmap 6.3).
+    scheduler.add_weekly("persona-evolution", run_persona_evolution, weekday=6, hour_utc=21)
+
     # People Scout — weekly Sunday 02:00 UTC (was: kronos-people-scout.timer).
     # DISABLED 2026-07-05: paused — LinkedIn profile discovery is not needed for
     # now. The runner, focus rotation, criteria and SEEN.md tracking stay intact.
@@ -168,5 +173,5 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
         scheduler.add_weekly("analytics-weekly", run_analytics_weekly, weekday=0, hour_utc=9)
         nexus_jobs_registered = 4
 
-    total = 18 + nexus_jobs_registered  # +user-reminders +handoff/council/memory intake; signal-jobs, travel insights, people-scout and group-digest paused
+    total = 19 + nexus_jobs_registered  # +reminders +handoff/council/memory intake +persona-evolution; signal-jobs, travel insights, people-scout and group-digest paused
     log.info("%d cron jobs registered for agent '%s'", total, me)

--- a/kronos/documents/extract.py
+++ b/kronos/documents/extract.py
@@ -1,0 +1,62 @@
+"""Document text extraction for ingest (roadmap 6.1).
+
+PDF/DOCX need optional deps (pip install kronos-agent-os[documents]); .txt/.md
+work without them. All extractors fail soft — a missing dep or unreadable file
+returns a user-facing hint, never an exception.
+"""
+
+import io
+
+# Cap extracted text so a huge document can't blow up LLM context / cost.
+MAX_EXTRACT_CHARS = 40_000
+
+
+def extract_text(data: bytes, filename: str, mime_type: str = "") -> tuple[str, str]:
+    """Extract plain text from a document. Returns (text, error).
+
+    error is a non-empty user-facing hint when extraction isn't possible.
+    """
+    lower = filename.lower()
+    mime = mime_type.lower()
+
+    if lower.endswith(".pdf") or "pdf" in mime:
+        text, error = _extract_pdf(data)
+    elif lower.endswith(".docx") or "wordprocessingml" in mime:
+        text, error = _extract_docx(data)
+    elif lower.endswith((".txt", ".md", ".markdown")) or mime.startswith("text/"):
+        text, error = data.decode("utf-8", errors="replace"), ""
+    else:
+        return "", f"Неподдерживаемый тип документа: {filename or mime or 'unknown'}."
+
+    if error:
+        return "", error
+    text = text.strip()
+    if not text:
+        return "", "Не удалось извлечь текст (документ пустой или отсканирован как картинка)."
+    if len(text) > MAX_EXTRACT_CHARS:
+        text = text[:MAX_EXTRACT_CHARS] + "\n…[обрезано]"
+    return text, ""
+
+
+def _extract_pdf(data: bytes) -> tuple[str, str]:
+    try:
+        import pypdf
+    except ImportError:
+        return "", "PDF-инжест недоступен: pip install kronos-agent-os[documents]."
+    try:
+        reader = pypdf.PdfReader(io.BytesIO(data))
+        return "\n".join(page.extract_text() or "" for page in reader.pages), ""
+    except Exception as e:
+        return "", f"Не удалось прочитать PDF: {e}"
+
+
+def _extract_docx(data: bytes) -> tuple[str, str]:
+    try:
+        import docx
+    except ImportError:
+        return "", "DOCX-инжест недоступен: pip install kronos-agent-os[documents]."
+    try:
+        document = docx.Document(io.BytesIO(data))
+        return "\n".join(p.text for p in document.paragraphs), ""
+    except Exception as e:
+        return "", f"Не удалось прочитать DOCX: {e}"

--- a/kronos/evolution.py
+++ b/kronos/evolution.py
@@ -1,0 +1,113 @@
+"""Persona-evolution proposals (roadmap 6.3).
+
+Weekly self-improvement proposes a concrete edit to SOUL/IDENTITY based on
+feedback; the user approves or rejects in Telegram, and approval appends the
+change to the target persona file with provenance. Proposals are per-agent.
+"""
+
+import time
+from datetime import UTC, datetime
+
+from kronos.db import get_db
+
+# Which persona files a proposal may target.
+VALID_TARGETS = ("soul", "identity")
+
+
+def _init_schema(conn) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS persona_proposals (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name  TEXT    NOT NULL,
+            target      TEXT    NOT NULL,
+            rationale   TEXT    NOT NULL,
+            proposal    TEXT    NOT NULL,
+            state       TEXT    NOT NULL DEFAULT 'pending',
+            created_at  REAL    NOT NULL,
+            decided_at  REAL
+        );
+        CREATE INDEX IF NOT EXISTS idx_persona_proposals_pending
+            ON persona_proposals(agent_name, state, created_at);
+        """
+    )
+
+
+def _db():
+    db = get_db("persona_proposals")
+    db.init_schema(_init_schema)
+    return db
+
+
+def create_proposal(*, agent_name: str, target: str, rationale: str, proposal: str) -> int:
+    """Insert a pending proposal and return its id."""
+    cursor = _db().write(
+        "INSERT INTO persona_proposals "
+        "(agent_name, target, rationale, proposal, state, created_at) "
+        "VALUES (?, ?, ?, ?, 'pending', ?)",
+        (agent_name, target, rationale, proposal, time.time()),
+    )
+    return int(cursor.lastrowid)
+
+
+def list_pending(agent_name: str) -> list[dict]:
+    rows = _db().read(
+        "SELECT * FROM persona_proposals "
+        "WHERE agent_name=? AND state='pending' ORDER BY created_at",
+        (agent_name,),
+    )
+    return [dict(row) for row in rows]
+
+
+def get_proposal(proposal_id: int, agent_name: str) -> dict | None:
+    row = _db().read_one(
+        "SELECT * FROM persona_proposals WHERE id=? AND agent_name=?",
+        (proposal_id, agent_name),
+    )
+    return dict(row) if row else None
+
+
+def decide_proposal(proposal_id: int, agent_name: str, *, approved: bool) -> dict | None:
+    """Atomically move a pending proposal to approved/rejected. Returns it or None.
+
+    IMMEDIATE transaction so a proposal is decided exactly once.
+    """
+
+    def _tx(conn):
+        row = conn.execute(
+            "SELECT * FROM persona_proposals "
+            "WHERE id=? AND agent_name=? AND state='pending'",
+            (proposal_id, agent_name),
+        ).fetchone()
+        if row is None:
+            return None
+        conn.execute(
+            "UPDATE persona_proposals SET state=?, decided_at=? WHERE id=?",
+            ("approved" if approved else "rejected", time.time(), proposal_id),
+        )
+        return dict(row)
+
+    return _db().write_tx(_tx)
+
+
+def apply_proposal(proposal: dict) -> str:
+    """Append an approved proposal to its target persona file. Returns the path.
+
+    Append-only (never rewrites) so an accepted change can't corrupt the file;
+    each edit is stamped with its rationale for provenance.
+    """
+    import kronos.workspace as _workspace
+
+    ws = _workspace.ws
+    targets = {"soul": ws.soul, "identity": ws.identity}
+    target_file = targets[proposal["target"]]
+    stamp = datetime.now(UTC).strftime("%Y-%m-%d")
+    section = (
+        f"\n\n## Evolution {stamp} (approved)\n"
+        f"_{proposal['rationale']}_\n\n"
+        f"{proposal['proposal']}\n"
+    )
+    target_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(target_file, "a", encoding="utf-8") as handle:
+        handle.write(section)
+    return str(target_file)

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -269,11 +269,13 @@ class KronosAgent:
         source_message: str,
         react_loop_kwargs: dict[str, Any],
         on_tool_event: ToolEventCallback | None = None,
+        force_tier: str | None = None,
     ) -> AgentResult:
         """Run either the supervisor or direct model loop.
 
         The agent-level callback handles audit/logging; a per-call callback
         (e.g. live progress in the bridge) is layered on top so both fire.
+        force_tier overrides tier classification (cost-guardian degradation).
         """
         emit = self._emit_tool_event
         if on_tool_event is not None:
@@ -284,7 +286,7 @@ class KronosAgent:
         if self._supervisor:
             return await self._supervisor(messages, on_tool_event=emit, **react_loop_kwargs)
 
-        tier = classify_tier(source_message)
+        tier = force_tier or classify_tier(source_message)
         model = get_model(tier)
         return await react_loop(
             model=model,
@@ -404,6 +406,7 @@ class KronosAgent:
         persist_user_turn: bool = True,
         extra_system_context: str = "",
         on_tool_event: ToolEventCallback | None = None,
+        force_tier: str | None = None,
     ) -> str:
         """Process a message and return the response text.
 
@@ -512,6 +515,7 @@ class KronosAgent:
                     source_message=message,
                     react_loop_kwargs=react_loop_kwargs,
                     on_tool_event=on_tool_event,
+                    force_tier=force_tier,
                 )
                 response_text = result.content
             except Exception as e:

--- a/kronos/security/cost_guardian.py
+++ b/kronos/security/cost_guardian.py
@@ -15,6 +15,10 @@ log = logging.getLogger("kronos.security.cost_guardian")
 DEFAULT_DAILY_LIMIT_USD = 5.0
 DEFAULT_SESSION_LIMIT_USD = 1.0
 
+# Once daily spend crosses this fraction of the limit, degrade to the lite tier
+# (soft) instead of blocking — the hard block stays at 100%.
+DEGRADE_RATIO = 0.8
+
 
 @dataclass
 class CostGuardian:
@@ -68,6 +72,15 @@ class CostGuardian:
         """Record a cost for a session."""
         if session_id:
             self._session_costs[session_id] = self._session_costs.get(session_id, 0) + cost_usd
+
+    def should_degrade(self) -> bool:
+        """True once daily spend crosses DEGRADE_RATIO — prefer the lite tier.
+
+        Soft degradation: keep answering (cheaper) instead of blocking, until
+        the hard daily limit in check_budget kicks in.
+        """
+        daily_cost = get_daily_cost().get("cost_usd", 0)
+        return daily_cost >= self.daily_limit * DEGRADE_RATIO
 
     def get_status(self) -> dict:
         """Get current cost status."""

--- a/kronos/security/cost_stats.py
+++ b/kronos/security/cost_stats.py
@@ -1,0 +1,75 @@
+"""Cost aggregation for the /stats command (roadmap 6.2).
+
+Reads the per-agent cost.jsonl written by kronos.audit. Provides this agent's
+breakdown by tier and a swarm-wide breakdown by agent (sibling data dirs).
+"""
+
+import json
+import time
+from collections import defaultdict
+from pathlib import Path
+
+from kronos.audit import _get_audit_dir
+from kronos.config import settings
+
+
+def _cutoff(period: str) -> str:
+    """Earliest YYYY-MM-DD date (inclusive) counted for the period."""
+    if period == "week":
+        return time.strftime("%Y-%m-%d", time.gmtime(time.time() - 7 * 86400))
+    return time.strftime("%Y-%m-%d")  # today
+
+
+def _aggregate(cost_file: Path, cutoff: str) -> dict:
+    by_tier: dict[str, dict] = defaultdict(
+        lambda: {"requests": 0, "cost": 0.0, "input_tokens": 0, "output_tokens": 0}
+    )
+    total = {"requests": 0, "cost": 0.0, "input_tokens": 0, "output_tokens": 0}
+    if not cost_file.exists():
+        return {"total": total, "by_tier": {}}
+
+    with open(cost_file, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except Exception:
+                continue
+            if entry.get("ts", "")[:10] < cutoff:
+                continue
+            tier = entry.get("tier", "unknown")
+            cost = float(entry.get("cost_usd", 0) or 0)
+            it = int(entry.get("input_tokens", 0) or 0)
+            ot = int(entry.get("output_tokens", 0) or 0)
+            for bucket in (by_tier[tier], total):
+                bucket["requests"] += 1
+                bucket["cost"] += cost
+                bucket["input_tokens"] += it
+                bucket["output_tokens"] += ot
+    return {"total": total, "by_tier": dict(by_tier)}
+
+
+def cost_report(period: str = "today") -> dict:
+    """This agent's cost breakdown for the period (by tier + total)."""
+    result = _aggregate(_get_audit_dir() / "cost.jsonl", _cutoff(period))
+    return {"period": period, **result}
+
+
+def swarm_cost_by_agent(period: str = "today") -> dict[str, float]:
+    """Total cost per agent across the swarm (sibling data/<agent>/logs dirs)."""
+    cutoff = _cutoff(period)
+    data_root = Path(settings.db_dir).parent
+    out: dict[str, float] = {}
+    if not data_root.exists():
+        return out
+    for agent_dir in sorted(data_root.iterdir()):
+        cost_file = agent_dir / "logs" / "cost.jsonl"
+        if not cost_file.exists():
+            continue
+        agg = _aggregate(cost_file, cutoff)
+        cost = agg["total"]["cost"]
+        if cost > 0 or agg["total"]["requests"] > 0:
+            out[agent_dir.name] = round(cost, 4)
+    return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ seo_geo = [
     "google-api-python-client>=2.140",
     "google-auth>=2.34",
 ]
+documents = [
+    # PDF/DOCX ingest (roadmap 6.1). Optional — .txt/.md work without them.
+    "pypdf>=4.0",
+    "python-docx>=1.1",
+]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -284,8 +284,9 @@ else
       echo "Skipping systemd unit install (KAOS_MANAGE_SYSTEMD=false)."
     fi
 
-    # Reinstall package (in case deps changed)
-    app/.venv/bin/python -m pip install -e "app/." --quiet 2>/dev/null || true
+    # Reinstall package (in case deps changed). Includes the [documents] extra
+    # so PDF/DOCX ingest (roadmap 6.1) works on the host.
+    app/.venv/bin/python -m pip install -e "app/.[documents]" --quiet 2>/dev/null || true
 
     # Restart all agents (systemd unit names from KAOS_SERVICES, which may
     # differ from the agent_name list used for the safety checks above).

--- a/tests/test_cost_stats.py
+++ b/tests/test_cost_stats.py
@@ -1,0 +1,105 @@
+"""Cost /stats aggregation + budget degradation (roadmap 6.2)."""
+
+import json
+import time
+
+import pytest
+
+from kronos.config import settings
+
+
+@pytest.fixture
+def cost_env(tmp_path, monkeypatch):
+    db_dir = tmp_path / "kronos"
+    (db_dir / "logs").mkdir(parents=True)
+    monkeypatch.setattr(settings, "db_path", str(db_dir / "session.db"))
+    monkeypatch.setattr(settings, "db_dir", str(db_dir))
+    monkeypatch.setattr(settings, "agent_name", "kronos")
+
+    import kronos.audit as audit
+
+    audit._audit_dir = None  # force re-resolution to the tmp path
+    return db_dir
+
+
+def _write_costs(db_dir, entries):
+    with open(db_dir / "logs" / "cost.jsonl", "a") as handle:
+        for entry in entries:
+            handle.write(json.dumps(entry) + "\n")
+
+
+def _now():
+    return time.strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def test_cost_report_aggregates_by_tier(cost_env):
+    from kronos.security.cost_stats import cost_report
+
+    _write_costs(cost_env, [
+        {"ts": _now(), "tier": "standard", "cost_usd": 0.02, "input_tokens": 100, "output_tokens": 50},
+        {"ts": _now(), "tier": "lite", "cost_usd": 0.005, "input_tokens": 20, "output_tokens": 10},
+        {"ts": _now(), "tier": "lite", "cost_usd": 0.005, "input_tokens": 20, "output_tokens": 10},
+    ])
+    report = cost_report("today")
+    assert report["total"]["requests"] == 3
+    assert abs(report["total"]["cost"] - 0.03) < 1e-6
+    assert report["by_tier"]["lite"]["requests"] == 2
+    assert report["by_tier"]["standard"]["requests"] == 1
+
+
+def test_cost_report_today_excludes_old_entries(cost_env):
+    from kronos.security.cost_stats import cost_report
+
+    _write_costs(cost_env, [
+        {"ts": "2020-01-01T00:00:00", "tier": "standard", "cost_usd": 1.0, "input_tokens": 1, "output_tokens": 1},
+        {"ts": _now(), "tier": "lite", "cost_usd": 0.01, "input_tokens": 1, "output_tokens": 1},
+    ])
+    report = cost_report("today")
+    assert report["total"]["requests"] == 1  # 2020 entry excluded
+
+
+def test_swarm_cost_by_agent(cost_env):
+    from kronos.security.cost_stats import swarm_cost_by_agent
+
+    _write_costs(cost_env, [
+        {"ts": _now(), "tier": "lite", "cost_usd": 0.01, "input_tokens": 1, "output_tokens": 1},
+    ])
+    nexus = cost_env.parent / "nexus"
+    (nexus / "logs").mkdir(parents=True)
+    with open(nexus / "logs" / "cost.jsonl", "w") as handle:
+        handle.write(json.dumps(
+            {"ts": _now(), "tier": "standard", "cost_usd": 0.05, "input_tokens": 1, "output_tokens": 1}
+        ) + "\n")
+
+    breakdown = swarm_cost_by_agent("today")
+    assert breakdown["kronos"] == 0.01
+    assert breakdown["nexus"] == 0.05
+
+
+def test_should_degrade_crosses_threshold(monkeypatch):
+    from kronos.security import cost_guardian
+
+    guardian = cost_guardian.CostGuardian(daily_limit=5.0)
+    monkeypatch.setattr(cost_guardian, "get_daily_cost", lambda: {"cost_usd": 4.5})  # 90%
+    assert guardian.should_degrade() is True
+    monkeypatch.setattr(cost_guardian, "get_daily_cost", lambda: {"cost_usd": 1.0})  # 20%
+    assert guardian.should_degrade() is False
+
+
+async def test_stats_command_formats_report(cost_env):
+    from kronos.bridge import _handle_stats_command
+
+    _write_costs(cost_env, [
+        {"ts": _now(), "tier": "lite", "cost_usd": 0.01, "input_tokens": 5, "output_tokens": 5},
+    ])
+    result = await _handle_stats_command("/stats")
+    assert result is not None
+    assert "Расходы" in result
+    assert "lite" in result
+    assert "Дневной бюджет" in result
+
+
+async def test_stats_command_ignores_non_stats_text(cost_env):
+    from kronos.bridge import _handle_stats_command
+
+    assert await _handle_stats_command("привет") is None

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,0 +1,76 @@
+"""Document ingest — text extraction (roadmap 6.1)."""
+
+from types import SimpleNamespace
+
+from telethon.tl.types import DocumentAttributeFilename
+
+from kronos.bridge import _compose_document_agent_message, _is_document_message
+from kronos.documents.extract import MAX_EXTRACT_CHARS, extract_text
+
+
+def test_extract_txt_and_md():
+    text, err = extract_text(b"line one\nline two", "note.txt", "text/plain")
+    assert err == "" and text == "line one\nline two"
+    text, err = extract_text(b"# Title", "doc.md", "")
+    assert err == "" and "Title" in text
+
+
+def test_extract_by_mime_without_extension():
+    text, err = extract_text(b"plain body", "attachment", "text/plain")
+    assert err == "" and text == "plain body"
+
+
+def test_extract_pdf_without_dep_gives_hint():
+    text, err = extract_text(b"%PDF-1.4 ...", "report.pdf", "application/pdf")
+    assert text == ""
+    assert "documents" in err.lower()  # install-extra hint
+
+
+def test_extract_docx_without_dep_gives_hint():
+    text, err = extract_text(b"PK\x03\x04", "report.docx", "")
+    assert text == ""
+    assert "documents" in err.lower()
+
+
+def test_extract_unsupported_type():
+    text, err = extract_text(b"data", "archive.zip", "application/zip")
+    assert text == ""
+    assert "Неподдерживаемый" in err
+
+
+def test_extract_empty_document():
+    text, err = extract_text(b"   \n  ", "empty.txt", "text/plain")
+    assert text == ""
+    assert "извлечь" in err.lower()
+
+
+def test_extract_truncates_huge_document():
+    big = b"x" * (MAX_EXTRACT_CHARS + 1000)
+    text, err = extract_text(big, "big.txt", "text/plain")
+    assert err == ""
+    assert "обрезано" in text
+    assert len(text) <= MAX_EXTRACT_CHARS + 20
+
+
+def test_compose_document_agent_message():
+    msg = _compose_document_agent_message("что тут важного?", "contract.pdf", "текст договора")
+    assert "contract.pdf" in msg
+    assert "текст договора" in msg
+    assert "что тут важного?" in msg
+
+
+def _doc_event(filename: str, mime: str):
+    doc = SimpleNamespace(
+        attributes=[DocumentAttributeFilename(file_name=filename)],
+        mime_type=mime,
+    )
+    media = SimpleNamespace(document=doc)
+    return SimpleNamespace(message=SimpleNamespace(media=media, photo=None))
+
+
+def test_is_document_message_detection():
+    assert _is_document_message(_doc_event("report.pdf", "application/pdf")) is True
+    assert _is_document_message(_doc_event("notes.txt", "text/plain")) is True
+    assert _is_document_message(_doc_event("song.mp3", "audio/mpeg")) is False
+    # no media at all
+    assert _is_document_message(SimpleNamespace(message=SimpleNamespace(media=None))) is False

--- a/tests/test_durable_turns.py
+++ b/tests/test_durable_turns.py
@@ -446,3 +446,28 @@ async def test_ainvoke_forwards_per_call_tool_events(tmp_path: Path, monkeypatch
     assert reply == "done"
     assert ("tool_call", "do_thing") in events
     assert ("tool_result", "do_thing") in events
+
+
+async def test_force_tier_overrides_classification(tmp_path: Path, monkeypatch) -> None:
+    # roadmap 6.2: cost-guardian degradation forces the lite tier regardless of
+    # what classify_tier would otherwise pick for the message.
+    monkeypatch.setattr(settings, "tool_approvals_enabled", False)
+    store = SessionStore(str(tmp_path / "session.db"))
+    agent = _minimal_agent(store)
+    captured: dict[str, str] = {}
+    model = _make_model([AIMessage(content="ok")])
+
+    def fake_get_model(tier):
+        captured["tier"] = tier
+        return model
+
+    with patch("kronos.graph.get_model", side_effect=fake_get_model):
+        await agent.ainvoke(
+            message="сделай глубокий аналитический разбор рынка",
+            thread_id="thread",
+            user_id="u",
+            session_id="s",
+            force_tier="lite",
+        )
+
+    assert captured["tier"] == "lite"

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -1,0 +1,127 @@
+"""Persona evolution proposals + /persona command (roadmap 6.3)."""
+
+import pytest
+
+from kronos.config import settings
+
+
+@pytest.fixture
+def evo_env(tmp_path, monkeypatch):
+    db_dir = tmp_path / "kronos"
+    db_dir.mkdir(parents=True)
+    monkeypatch.setattr(settings, "db_dir", str(db_dir))
+    monkeypatch.setattr(settings, "db_path", str(db_dir / "session.db"))
+    monkeypatch.setattr(settings, "swarm_db_path", str(tmp_path / "swarm.db"))
+    monkeypatch.setattr(settings, "agent_name", "kronos")
+
+    import kronos.db as _db
+
+    _db._instances.clear()
+    import kronos.swarm_store as ss
+
+    ss._singleton = None
+
+    # Isolated workspace so apply_proposal writes to a temp SOUL/IDENTITY.
+    import kronos.workspace as _ws
+
+    monkeypatch.setattr(_ws, "ws", _ws.Workspace(str(tmp_path / "workspace")))
+
+    yield tmp_path
+    _db._instances.clear()
+
+
+def test_create_list_and_get(evo_env):
+    from kronos import evolution
+
+    pid = evolution.create_proposal(
+        agent_name="kronos", target="soul", rationale="be warmer", proposal="Add warmth."
+    )
+    assert pid > 0
+    pending = evolution.list_pending("kronos")
+    assert len(pending) == 1
+    assert pending[0]["target"] == "soul"
+    assert evolution.get_proposal(pid, "kronos")["proposal"] == "Add warmth."
+
+
+def test_decide_is_atomic(evo_env):
+    from kronos import evolution
+
+    pid = evolution.create_proposal(agent_name="kronos", target="soul", rationale="x", proposal="y")
+    assert evolution.decide_proposal(pid, "kronos", approved=True) is not None
+    # A second decision on the same proposal must not succeed.
+    assert evolution.decide_proposal(pid, "kronos", approved=True) is None
+    assert evolution.list_pending("kronos") == []
+
+
+def test_decide_scoped_per_agent(evo_env):
+    from kronos import evolution
+
+    pid = evolution.create_proposal(agent_name="kronos", target="soul", rationale="x", proposal="y")
+    assert evolution.decide_proposal(pid, "nexus", approved=True) is None  # not nexus's
+
+
+def test_apply_proposal_appends_to_soul(evo_env):
+    import kronos.workspace as _ws
+    from kronos import evolution
+
+    path = evolution.apply_proposal(
+        {"target": "soul", "rationale": "be warmer", "proposal": "Add a warm greeting."}
+    )
+    content = _ws.ws.soul.read_text(encoding="utf-8")
+    assert "Add a warm greeting." in content
+    assert "Evolution" in content and "be warmer" in content
+    assert path.endswith("SOUL.md")
+
+
+def test_parse_proposal_valid_multiline():
+    from kronos.cron.persona_evolve import _parse_proposal
+
+    reply = "TARGET: soul\nRATIONALE: be more concise\nPROPOSAL: Prefer short answers.\nSecond line."
+    target, rationale, proposal = _parse_proposal(reply)
+    assert target == "soul"
+    assert rationale == "be more concise"
+    assert "Prefer short answers." in proposal and "Second line." in proposal
+
+
+def test_parse_proposal_skip_and_invalid():
+    from kronos.cron.persona_evolve import _parse_proposal
+
+    assert _parse_proposal("SKIP") is None
+    assert _parse_proposal("TARGET: unknown\nRATIONALE: x\nPROPOSAL: y") is None  # bad target
+    assert _parse_proposal("RATIONALE: x\nPROPOSAL: y") is None  # missing target
+
+
+async def test_persona_command_list_approve_flow(evo_env):
+    import kronos.workspace as _ws
+    from kronos import evolution
+    from kronos.bridge import _handle_persona_command
+
+    assert "Нет предложений" in await _handle_persona_command("/persona list")
+
+    pid = evolution.create_proposal(
+        agent_name="kronos", target="soul", rationale="warmer", proposal="Be warm."
+    )
+    assert f"#{pid}" in await _handle_persona_command("/persona")  # default = list
+
+    result = await _handle_persona_command(f"/persona approve {pid}")
+    assert "Применил" in result
+    assert "Be warm." in _ws.ws.soul.read_text(encoding="utf-8")
+    # Re-approving a decided proposal is rejected.
+    assert "уже обработано" in await _handle_persona_command(f"/persona approve {pid}")
+
+
+async def test_persona_command_reject(evo_env):
+    from kronos import evolution
+    from kronos.bridge import _handle_persona_command
+
+    pid = evolution.create_proposal(
+        agent_name="kronos", target="identity", rationale="x", proposal="y"
+    )
+    assert "Отклонил" in await _handle_persona_command(f"/persona reject {pid}")
+    assert evolution.list_pending("kronos") == []
+
+
+async def test_persona_command_ignores_non_persona(evo_env):
+    from kronos.bridge import _handle_persona_command
+
+    assert await _handle_persona_command("привет") is None

--- a/tests/test_observer_bridge_capture.py
+++ b/tests/test_observer_bridge_capture.py
@@ -135,6 +135,9 @@ async def test_non_capture_dm_calls_agent_as_before(monkeypatch):
         def check_budget(self, session_id=""):
             return True, ""
 
+        def should_degrade(self):
+            return False
+
     monkeypatch.setattr(bridge, "_ask_agent", fake_ask_agent)
     monkeypatch.setattr(bridge, "record_capture", lambda *args, **kwargs: record_calls.append((args, kwargs)))
     monkeypatch.setattr(bridge, "get_guardian", lambda: FakeGuardian())


### PR DESCRIPTION
Roadmap phase 6 — new capabilities. 3 commits, all tests green without LLM keys. Completes the roadmap (phases 0–6).

## 6.1 — Document ingest (PDF/DOCX/text)
Vision handled images; now the bridge ingests documents too. `documents/extract.py` pulls text from PDF (pypdf), DOCX (python-docx), and .txt/.md — optional deps in a new `[documents]` extra, with a graceful install hint when absent (never an exception), output capped to bound LLM cost. The bridge detects a document attachment, extracts, archives the raw text to `notes/inbox/`, and passes it to the agent framed for a summary + key facts.

## 6.2 — /stats + soft budget degradation
`cost_stats.py` aggregates the per-agent cost.jsonl by tier plus a swarm-wide breakdown by agent. `/stats [today|week]` shows spend by tier, daily-budget %, and per-agent totals — and runs before the cost guardian so it works even when the budget is exhausted. `should_degrade()` (spend past 80% of the limit) forces the lite tier via a new `force_tier`, instead of jumping straight to the hard block at 100%.

## 6.3 — Persona self-improvement loop
Closes the feedback loop: a weekly job reads the week's satisfaction + negative feedback and asks the LLM for ONE concrete SOUL/IDENTITY edit (or SKIP), stored as a pending proposal. Nothing changes without `/persona approve <id>` — which appends the edit (append-only + rationale stamp) to the target file. `decide_proposal` is atomic (decided once).

## Tests
662 passed, 40 deselected (integration), 0 failures — without LLM keys. ruff clean. New tests cover extraction (incl. missing-dep hints), cost aggregation + degradation threshold, and the proposal store + /persona flow.

## Decisions (from the roadmap author's calls)
- 6.1 deps as an optional `[documents]` extra, not core.
- 6.3 approval via a `/persona` command rather than inline buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)