### PR TITLE
Security fixes from code review: injection, approval binding, skill self-modification

### DIFF
--- a/kronos/cron/skill_improve.py
+++ b/kronos/cron/skill_improve.py
@@ -6,6 +6,7 @@ proposes minimal improvements to SKILL.md files with versioned backups.
 
 import json
 import logging
+import re
 import time
 from collections import defaultdict
 from datetime import datetime
@@ -33,8 +34,6 @@ SKILL_KEYWORDS = {
 
 
 def _tokenize_skill_text(text: str) -> set[str]:
-    import re
-
     return {
         token
         for token in re.findall(r"[a-zA-Zа-яА-Я0-9]{4,}", text.lower())
@@ -110,6 +109,12 @@ async def run_skill_improve() -> None:
     from langchain_core.messages import HumanMessage
 
     for skill_name, interactions in candidates.items():
+        # skill_name is derived from matched interaction text and feeds a
+        # filesystem path below. Require a plain slug so a crafted name can
+        # never traverse out of the skills directory (path injection).
+        if not re.fullmatch(r"[a-z0-9][a-z0-9_-]*", skill_name):
+            log.warning("Skipping skill with unsafe name: %r", skill_name)
+            continue
         from kronos.workspace import ws
         skill = skill_store.get(skill_name)
         skill_path = skill.path if skill else ws.skill_path(skill_name)

--- a/kronos/cron/skill_improve.py
+++ b/kronos/cron/skill_improve.py
@@ -6,7 +6,6 @@ proposes minimal improvements to SKILL.md files with versioned backups.
 
 import json
 import logging
-import shutil
 import time
 from collections import defaultdict
 from datetime import datetime
@@ -158,20 +157,29 @@ async def run_skill_improve() -> None:
         if "без изменений" in reply.lower():
             continue
 
-        # Backup current version
-        versions_dir = skill_path.parent / ".versions"
-        versions_dir.mkdir(exist_ok=True)
-        existing = list(versions_dir.glob("SKILL.v*.md"))
-        next_version = len(existing) + 1
-        shutil.copy2(skill_path, versions_dir / f"SKILL.v{next_version}.md")
-
-        # Write updated skill
-        skill_path.write_text(reply, encoding="utf-8")
-        improvements.append(f"**{skill_name}** — updated (v{next_version} backup)")
-        log.info("Skill improved: %s (v%d backup)", skill_name, next_version)
+        # Do NOT auto-activate. An LLM rewriting its own live SKILL.md from
+        # interaction logs is persistent self-modification and a channel for
+        # locking in prompt injection — a hostile interaction in the audit log
+        # could steer the rewrite, which then becomes system context for every
+        # future call. Save the suggestion next to the skill for human review;
+        # the active SKILL.md is never overwritten automatically.
+        proposal_path = skill_path.parent / "SKILL.proposed.md"
+        proposal_path.write_text(reply, encoding="utf-8")
+        improvements.append(
+            f"**{skill_name}** — предложение на review: {proposal_path.name}"
+        )
+        log.info(
+            "Skill improvement proposed (NOT applied): %s → %s",
+            skill_name,
+            proposal_path,
+        )
 
     if improvements:
-        text = "🔧 Skill Improvement\n\n" + "\n".join(f"• {i}" for i in improvements)
+        text = (
+            "🔧 Skill Improvement — предложения на ручном review "
+            "(активные skill-файлы НЕ изменены):\n\n"
+            + "\n".join(f"• {i}" for i in improvements)
+        )
         send_bot_api(text, topic_id=TOPIC_GENERAL)
     else:
         log.info("No skill improvements needed")

--- a/kronos/cron/skill_improve.py
+++ b/kronos/cron/skill_improve.py
@@ -6,6 +6,7 @@ proposes minimal improvements to SKILL.md files with versioned backups.
 
 import json
 import logging
+import os
 import re
 import time
 from collections import defaultdict
@@ -109,19 +110,23 @@ async def run_skill_improve() -> None:
     from langchain_core.messages import HumanMessage
 
     for skill_name, interactions in candidates.items():
-        # skill_name is derived from matched interaction text and feeds a
-        # filesystem path below. Require a plain slug so a crafted name can
-        # never traverse out of the skills directory (path injection).
-        if not re.fullmatch(r"[a-z0-9][a-z0-9_-]*", skill_name):
-            log.warning("Skipping skill with unsafe name: %r", skill_name)
-            continue
         from kronos.workspace import ws
         skill = skill_store.get(skill_name)
         skill_path = skill.path if skill else ws.skill_path(skill_name)
         if not skill_path.exists():
             continue
 
-        current_content = skill_path.read_text(encoding="utf-8")
+        # Containment guard: skill_name is derived from matched interaction
+        # text, so confirm the resolved path stays inside a known skills root
+        # before we read or write alongside it — otherwise a crafted name
+        # could traverse out of the skills tree (path injection).
+        resolved = skill_path.resolve()
+        roots = [str(root.resolve()) for root in skill_store.skills_roots]
+        if not any(os.path.commonpath([root, str(resolved)]) == root for root in roots):
+            log.warning("Skipping skill outside skills root: %s", resolved)
+            continue
+
+        current_content = resolved.read_text(encoding="utf-8")
         recent = interactions[-10:]
         interactions_text = "\n".join(
             f"- [{e.get('tier', '?')}] {e.get('input_preview', '')[:80]}"
@@ -168,7 +173,7 @@ async def run_skill_improve() -> None:
         # could steer the rewrite, which then becomes system context for every
         # future call. Save the suggestion next to the skill for human review;
         # the active SKILL.md is never overwritten automatically.
-        proposal_path = skill_path.parent / "SKILL.proposed.md"
+        proposal_path = resolved.parent / "SKILL.proposed.md"
         proposal_path.write_text(reply, encoding="utf-8")
         improvements.append(
             f"**{skill_name}** — предложение на review: {proposal_path.name}"

--- a/kronos/engine.py
+++ b/kronos/engine.py
@@ -287,6 +287,39 @@ async def execute_tool(
     )
 
 
+def _deferred_tool_messages(
+    tool_calls: list[dict], awaiting: dict
+) -> list["ToolMessage"]:
+    """Placeholder results for tool_calls that follow the one now awaiting approval.
+
+    When the loop returns mid-batch for approval, every OTHER tool_call in the
+    same AIMessage still needs a ToolMessage — otherwise the resumed history
+    has an assistant turn whose tool_calls aren't all answered, which is a hard
+    protocol error on the next LLM call. The awaiting call is filled in on
+    resume; the ones after it get these deferred placeholders now, and the
+    model re-issues them if it still needs the results.
+    """
+    awaiting_id = awaiting.get("id", "")
+    deferred: list[ToolMessage] = []
+    seen_awaiting = False
+    for tc in tool_calls:
+        if tc.get("id", "") == awaiting_id:
+            seen_awaiting = True
+            continue
+        if seen_awaiting:
+            deferred.append(
+                ToolMessage(
+                    content=(
+                        "[deferred] A prior tool call in this batch is awaiting "
+                        "approval, so this call was not executed. Re-issue it if "
+                        "you still need the result."
+                    ),
+                    tool_call_id=tc.get("id", ""),
+                )
+            )
+    return deferred
+
+
 async def react_loop(
     model: BaseChatModel,
     messages: list[BaseMessage],
@@ -467,6 +500,18 @@ async def react_loop(
                                 messages.extend(tool_messages)
                                 call_messages.extend(tool_messages)
                                 await emit_message_delta(tool_messages)
+                            # Tool calls after this one in the same response are
+                            # not executed in this pass. Emit deferred results
+                            # for them so the resumed history has a ToolMessage
+                            # for every tool_call except the one being approved
+                            # (which is filled in on resume) — otherwise the
+                            # next LLM call fails with an unanswered-tool_call
+                            # protocol error.
+                            deferred = _deferred_tool_messages(response.tool_calls, tc)
+                            if deferred:
+                                messages.extend(deferred)
+                                call_messages.extend(deferred)
+                                await emit_message_delta(deferred)
                             content = (
                                 "⚠️ Нужно подтверждение перед выполнением tool-call.\n"
                                 f"Tool: `{tool_name}`\n"

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -11,6 +11,7 @@ Memory integration (Mem0):
 """
 
 import asyncio
+import json
 import logging
 from collections.abc import Callable
 from typing import Any
@@ -214,6 +215,7 @@ class KronosAgent:
         turn_id: str,
         thread_id: str,
         approved_tool_name: str | None = None,
+        approved_tool_args: dict | None = None,
     ) -> dict[str, Any]:
         """Build journal/cache/approval callbacks for a durable turn."""
         if not self._session_store:
@@ -252,9 +254,21 @@ class KronosAgent:
             "request_tool_approval": request_tool_approval,
         }
         if approved_tool_name:
+            # The exemption must match the EXACT call the user approved, not
+            # just the tool name. Binding to the name alone let an approved
+            # restart_service("x") wave through restart_service("y") during the
+            # resume. Compare canonical (sorted) args so only the approved call
+            # skips a fresh approval; any other args re-prompt.
+            approved_args_key = json.dumps(
+                approved_tool_args or {}, sort_keys=True, default=str
+            )
 
             async def approval_scope(tool: BaseTool, args: dict) -> bool:
-                if tool.name == approved_tool_name:
+                same_call = tool.name == approved_tool_name and (
+                    json.dumps(args or {}, sort_keys=True, default=str)
+                    == approved_args_key
+                )
+                if same_call:
                     return False
                 return tool_requires_approval(tool, args)
 
@@ -363,6 +377,7 @@ class KronosAgent:
             turn_id=turn_id,
             thread_id=thread_id,
             approved_tool_name=tool_name if approved else None,
+            approved_tool_args=(pending.get("args", {}) or {}) if approved else None,
         )
         audit_token = set_tool_audit_context(
             agent=settings.agent_name,

--- a/kronos/session.py
+++ b/kronos/session.py
@@ -9,6 +9,7 @@ import json
 import logging
 import uuid
 from contextlib import asynccontextmanager
+from datetime import UTC, datetime
 
 import aiosqlite
 from langchain_core.messages import (
@@ -25,6 +26,24 @@ log = logging.getLogger("kronos.session")
 # Keep small — large history causes LLM to copy prior patterns
 # (including hallucinated tool calls) instead of using tools.
 MAX_HISTORY = 30
+
+# A pending tool approval older than this is treated as stale: claiming it
+# returns nothing and marks it expired. Stops a long-forgotten "restart the
+# server?" prompt from firing hours later, in a context that no longer holds.
+APPROVAL_TTL_SECONDS = 3600
+
+
+def _approval_is_stale(requested_at: object) -> bool:
+    """True if a pending approval's requested_at is older than the TTL."""
+    if not requested_at:
+        return False
+    try:
+        requested_dt = datetime.fromisoformat(str(requested_at))
+    except (ValueError, TypeError):
+        return False
+    if requested_dt.tzinfo is None:
+        requested_dt = requested_dt.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - requested_dt).total_seconds() > APPROVAL_TTL_SECONDS
 
 
 def _session_fts_fingerprint(
@@ -406,6 +425,18 @@ class SessionStore:
             )
             row = await cursor.fetchone()
             if not row:
+                await db.commit()
+                return None
+
+            # Expire stale approvals instead of resuming them: a pending row
+            # older than the TTL must not fire a (possibly mutating) tool long
+            # after the prompt was shown, in a context that no longer holds.
+            if _approval_is_stale(row[7]):
+                await db.execute(
+                    "UPDATE pending_approvals SET status = 'expired' "
+                    "WHERE approval_id = ? AND status = 'pending'",
+                    (approval_id,),
+                )
                 await db.commit()
                 return None
 

--- a/kronos/skills/store.py
+++ b/kronos/skills/store.py
@@ -195,6 +195,18 @@ class SkillStore:
                 review_required=review_required,
             )
 
+    @property
+    def skills_roots(self) -> list[Path]:
+        """Directories a skill file may legitimately live under.
+
+        Used to confirm a resolved skill path has not traversed outside the
+        skills tree before reading or writing alongside it.
+        """
+        roots = [self._skills_dir]
+        if self._shared_skills_dir is not None:
+            roots.append(self._shared_skills_dir)
+        return roots
+
     def list_skills(self) -> list[Skill]:
         return list(self._skills.values())
 

--- a/kronos/tools/server_ops.py
+++ b/kronos/tools/server_ops.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 import os
 import re
+import shlex
 
 import asyncssh
 import yaml
@@ -109,10 +110,15 @@ async def _ssh_run(
     command: str,
     username: str = "deploy",
     timeout: int = _SSH_TIMEOUT,
+    input_data: str | None = None,
 ) -> str:
     """Execute a command over SSH and return stdout.
 
     Uses key-based auth from the agent's SSH key (~/.ssh/id_ed25519 or id_rsa).
+
+    ``input_data`` is fed to the remote command's stdin (and stdin is then
+    closed). Use it to pass untrusted payloads — e.g. an SQL query — WITHOUT
+    interpolating them into ``command``, which would be a shell-injection hole.
     """
     try:
         async with asyncssh.connect(
@@ -122,7 +128,7 @@ async def _ssh_run(
             connect_timeout=timeout,
         ) as conn:
             result = await asyncio.wait_for(
-                conn.run(command, check=False),
+                conn.run(command, check=False, input=input_data),
                 timeout=timeout,
             )
             output = (result.stdout or "").strip()
@@ -303,15 +309,26 @@ async def server_query_swarm(
     if not normalized.startswith("SELECT"):
         return "[BLOCKED] Only SELECT queries are allowed on swarm.db."
 
-    # Block dangerous keywords even in SELECT
+    # Reject sqlite3 dot-commands (.shell, .system, .import, .output, .load…).
+    # They run against the host shell / filesystem even on a read-only
+    # database, so they must never reach the sqlite3 CLI via stdin.
+    if re.search(r"(?m)^\s*\.", query):
+        return "[BLOCKED] Dot-commands are not allowed."
+
+    # Block dangerous keywords as an extra layer (the read-only DB below
+    # already refuses any write at the engine level).
     dangerous = ["DROP", "DELETE", "INSERT", "UPDATE", "ALTER", "CREATE", "ATTACH", "DETACH"]
     for keyword in dangerous:
         if keyword in normalized:
             return f"[BLOCKED] Query contains forbidden keyword: {keyword}"
 
     db_path = f"{srv['data_path']}/swarm.db"
-    cmd = f'sqlite3 -header -column "{db_path}" "{query}" 2>&1 | head -100'
-    return await _ssh_run(srv["host"], cmd, srv["username"])
+    # The SQL is passed via stdin (never interpolated into the shell command),
+    # and the database is opened read-only so the engine itself rejects any
+    # mutation. This closes the shell-injection hole where a crafted query
+    # could break out of the quotes and run arbitrary commands on the host.
+    cmd = f"sqlite3 -readonly -header -column {shlex.quote(db_path)} 2>&1 | head -100"
+    return await _ssh_run(srv["host"], cmd, srv["username"], input_data=query)
 
 
 @tool

--- a/tests/test_durable_turns.py
+++ b/tests/test_durable_turns.py
@@ -471,3 +471,71 @@ async def test_force_tier_overrides_classification(tmp_path: Path, monkeypatch) 
         )
 
     assert captured["tier"] == "lite"
+
+
+@pytest.mark.asyncio
+async def test_approval_exemption_binds_to_exact_args(tmp_path: Path, monkeypatch) -> None:
+    # An approval must exempt only the EXACT call the user approved. Binding to
+    # the tool name alone let an approved restart_service("web") wave through
+    # restart_service("db") during the same resume.
+    monkeypatch.setattr(settings, "tool_approvals_enabled", True)
+    store = SessionStore(str(tmp_path / "session.db"))
+    agent = _minimal_agent(store)
+
+    class _Tool:
+        name = "restart_service"
+        metadata = {"needs_approval": True}
+
+    tool = _Tool()
+    kwargs = agent._build_durable_react_loop_kwargs(
+        turn_id="t1",
+        thread_id="thread",
+        approved_tool_name="restart_service",
+        approved_tool_args={"name": "web"},
+    )
+    scope = kwargs["needs_tool_approval"]
+
+    # The exact approved call resumes without re-prompting…
+    assert await scope(tool, {"name": "web"}) is False
+    # …but the same tool with different args must ask again.
+    assert await scope(tool, {"name": "db"}) is True
+
+
+@pytest.mark.asyncio
+async def test_stale_approval_expires_instead_of_resuming(tmp_path: Path) -> None:
+    from kronos.session import APPROVAL_TTL_SECONDS
+
+    db_path = tmp_path / "session.db"
+    store = SessionStore(str(db_path))
+    turn_id = await store.begin_turn("thread", "mutate")
+    approval_id = await store.create_pending_approval(
+        turn_id=turn_id,
+        thread_id="thread",
+        tool_call_id="call_1",
+        tool_name="restart_service",
+        args={"name": "web"},
+    )
+
+    # Age the request well past the TTL.
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "UPDATE pending_approvals SET requested_at = datetime('now', ?) "
+            "WHERE approval_id = ?",
+            (f"-{APPROVAL_TTL_SECONDS + 120} seconds", approval_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    claimed = await store.claim_pending_approval(
+        approval_id=approval_id,
+        decision="approved",
+        decided_by="42",
+    )
+
+    # Not resumed, and left as expired rather than pending.
+    assert claimed is None
+    pending = await store.get_pending_approval(approval_id)
+    assert pending is not None
+    assert pending["status"] == "expired"

--- a/tests/test_durable_turns.py
+++ b/tests/test_durable_turns.py
@@ -539,3 +539,64 @@ async def test_stale_approval_expires_instead_of_resuming(tmp_path: Path) -> Non
     pending = await store.get_pending_approval(approval_id)
     assert pending is not None
     assert pending["status"] == "expired"
+
+
+@pytest.mark.asyncio
+async def test_approval_midbatch_defers_following_tool_calls(monkeypatch) -> None:
+    # When a tool call in the middle of a batch needs approval, the loop
+    # returns immediately. Every OTHER tool_call in that AIMessage must still
+    # get a ToolMessage, or the resumed history has unanswered tool_calls — a
+    # hard LLM protocol error. The approved call is answered on resume; the
+    # ones after it get deferred placeholders now.
+    monkeypatch.setattr(settings, "tool_approvals_enabled", True)
+
+    async def safe_tool() -> str:
+        return "did-safe"
+
+    async def risky_tool() -> str:
+        return "did-risky"
+
+    async def after_tool() -> str:
+        return "did-after"
+
+    tools = [
+        StructuredTool.from_function(coroutine=safe_tool, name="safe", description="safe"),
+        StructuredTool.from_function(coroutine=risky_tool, name="risky", description="risky"),
+        StructuredTool.from_function(coroutine=after_tool, name="after", description="after"),
+    ]
+    response = AIMessage(
+        content="",
+        tool_calls=[
+            {"name": "safe", "args": {}, "id": "c_safe"},
+            {"name": "risky", "args": {}, "id": "c_risky"},
+            {"name": "after", "args": {}, "id": "c_after"},
+        ],
+    )
+    model = _make_model([response])
+
+    async def needs_approval(tool, args):
+        return tool.name == "risky"
+
+    async def request_approval(tool, tool_call):
+        return "appr-xyz"
+
+    result = await react_loop(
+        model,
+        [HumanMessage(content="do batch")],
+        tools=tools,
+        needs_tool_approval=needs_approval,
+        request_tool_approval=request_approval,
+    )
+
+    assert result.waiting_approval is True
+    assert result.approval_id == "appr-xyz"
+
+    tms = {m.tool_call_id: m for m in result.messages if isinstance(m, ToolMessage)}
+    # Ran before the approval → real result.
+    assert tms["c_safe"].content == "did-safe"
+    # After the approval → deferred placeholder, not executed.
+    assert "deferred" in tms["c_after"].content.lower()
+    # The approval call itself is answered on resume, not here.
+    assert "c_risky" not in tms
+    # Every tool_call is accounted for (c_risky on resume) → protocol-valid.
+    assert set(tms) | {"c_risky"} == {"c_safe", "c_risky", "c_after"}

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -1,0 +1,117 @@
+"""Security tests for server_ops.server_query_swarm.
+
+Focus: the SQL query must never be interpolated into the remote shell
+command (shell-injection hole), and dangerous inputs are rejected before
+any SSH call is made.
+"""
+
+import pytest
+
+from kronos.tools import server_ops
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    reg = {
+        "primary": {
+            "host": "10.0.0.9",
+            "username": "deploy",
+            "data_path": "/opt/kaos/data",
+            "description": "test host",
+            "services": ["kaos"],
+        }
+    }
+    monkeypatch.setattr(server_ops, "SERVER_REGISTRY", reg)
+    return reg
+
+
+@pytest.fixture
+def captured_ssh(monkeypatch):
+    """Replace _ssh_run with a recorder so tests never touch the network."""
+    calls = []
+
+    async def fake_ssh_run(
+        host,
+        command,
+        username="deploy",
+        timeout=server_ops._SSH_TIMEOUT,
+        input_data=None,
+    ):
+        calls.append(
+            {
+                "host": host,
+                "command": command,
+                "username": username,
+                "input_data": input_data,
+            }
+        )
+        return "(fake output)"
+
+    monkeypatch.setattr(server_ops, "_ssh_run", fake_ssh_run)
+    return calls
+
+
+async def _run(query, server_name="primary"):
+    return await server_ops.server_query_swarm.ainvoke(
+        {"query": query, "server_name": server_name}
+    )
+
+
+async def test_valid_select_passes_sql_via_stdin(registry, captured_ssh):
+    out = await _run("SELECT agent_name FROM reply_claims")
+
+    assert out == "(fake output)"
+    assert len(captured_ssh) == 1
+    call = captured_ssh[0]
+    # SQL travels through stdin, opened read-only…
+    assert call["input_data"] == "SELECT agent_name FROM reply_claims"
+    assert "sqlite3 -readonly" in call["command"]
+    # …and never appears inside the shell command itself.
+    assert "reply_claims" not in call["command"]
+    assert "SELECT" not in call["command"]
+
+
+async def test_injection_payload_never_reaches_shell(registry, captured_ssh):
+    # Passes the SELECT/keyword/dot filters, but tries to break out of the
+    # old `"{query}"` quoting to run a host command.
+    payload = "SELECT body FROM swarm_messages WHERE body = 'x'; touch /tmp/pwned; --'"
+    out = await _run(payload)
+
+    assert out == "(fake output)"
+    call = captured_ssh[0]
+    # The whole payload is confined to stdin; the shell command is fixed.
+    assert call["input_data"] == payload
+    assert "touch /tmp/pwned" not in call["command"]
+    assert "/tmp/pwned" not in call["command"]
+
+
+async def test_dot_command_blocked(registry, captured_ssh):
+    out = await _run(".shell echo pwned")
+    assert out.startswith("[BLOCKED]")
+    assert captured_ssh == []
+
+
+async def test_dot_command_blocked_on_second_line(registry, captured_ssh):
+    # A SELECT prefix must not smuggle a dot-command on a later line.
+    out = await _run("SELECT 1;\n.shell rm -rf /")
+    assert out.startswith("[BLOCKED]")
+    assert captured_ssh == []
+
+
+async def test_non_select_blocked(registry, captured_ssh):
+    out = await _run("PRAGMA table_info(reply_claims)")
+    assert out.startswith("[BLOCKED]")
+    assert captured_ssh == []
+
+
+async def test_dangerous_keyword_blocked(registry, captured_ssh):
+    out = await _run("SELECT 1; DROP TABLE reply_claims")
+    assert out.startswith("[BLOCKED]")
+    assert "DROP" in out
+    assert captured_ssh == []
+
+
+async def test_unknown_server(registry, captured_ssh):
+    out = await _run("SELECT 1", server_name="ghost")
+    assert "Unknown server" in out
+    assert captured_ssh == []

--- a/tests/test_server_ops.py
+++ b/tests/test_server_ops.py
@@ -74,15 +74,15 @@ async def test_valid_select_passes_sql_via_stdin(registry, captured_ssh):
 async def test_injection_payload_never_reaches_shell(registry, captured_ssh):
     # Passes the SELECT/keyword/dot filters, but tries to break out of the
     # old `"{query}"` quoting to run a host command.
-    payload = "SELECT body FROM swarm_messages WHERE body = 'x'; touch /tmp/pwned; --'"
+    payload = "SELECT body FROM swarm_messages WHERE body = 'x'; touch HACKED; --'"
     out = await _run(payload)
 
     assert out == "(fake output)"
     call = captured_ssh[0]
     # The whole payload is confined to stdin; the shell command is fixed.
     assert call["input_data"] == payload
-    assert "touch /tmp/pwned" not in call["command"]
-    assert "/tmp/pwned" not in call["command"]
+    assert "touch HACKED" not in call["command"]
+    assert "HACKED" not in call["command"]
 
 
 async def test_dot_command_blocked(registry, captured_ssh):

--- a/tests/test_skill_create.py
+++ b/tests/test_skill_create.py
@@ -156,3 +156,66 @@ def test_skill_improve_matches_auto_created_skill_by_metadata():
     ]
 
     assert _match_skill("Please run the competitive intelligence workflow again", skills) == "research-workflow"
+
+
+@pytest.mark.asyncio
+async def test_skill_improve_proposes_without_overwriting_active(
+    skill_workspace, tmp_path, monkeypatch
+):
+    """The weekly improver must never overwrite a live SKILL.md.
+
+    It writes a SKILL.proposed.md next to the skill for human review; the
+    active file stays byte-for-byte unchanged. This is the guard against
+    persistent self-modification / prompt-injection lock-in.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    import kronos.cron.skill_improve as skill_improve
+    import kronos.swarm_store as swarm_store
+    from kronos.config import settings
+
+    # Active skill on disk with known content.
+    active = skill_workspace.skill_path("deep-research")
+    active.parent.mkdir(parents=True, exist_ok=True)
+    original = "# deep-research\nORIGINAL ACTIVE CONTENT — do not touch\n"
+    active.write_text(original, encoding="utf-8")
+
+    # Audit log with enough recent interactions that match "deep-research".
+    # Keep the text free of other skills' keywords ("market" → investment).
+    now = datetime.now(UTC)
+    entries = [
+        {"ts": (now - timedelta(hours=i)).isoformat(), "tier": "T1",
+         "input_preview": f"research this topic deeply, iteration {i}"}
+        for i in range(skill_improve.MIN_INTERACTIONS)
+    ]
+    data_dir = tmp_path / "data"
+    (data_dir / "logs").mkdir(parents=True)
+    (data_dir / "logs" / "audit.jsonl").write_text(
+        "\n".join(json.dumps(e) for e in entries), encoding="utf-8"
+    )
+    monkeypatch.setattr(settings, "db_path", str(data_dir / "session.db"))
+
+    class FakeSwarm:
+        def get_satisfaction_rate(self, agent_name, days):
+            return {"positive": 3, "negative": 0, "satisfaction_rate": 100}
+
+    monkeypatch.setattr(swarm_store, "get_swarm", lambda: FakeSwarm())
+    monkeypatch.setattr(
+        skill_improve, "get_model",
+        lambda _tier: FakeModel("# deep-research\nPROPOSED REWRITE\n"),
+    )
+    sent = []
+    monkeypatch.setattr(
+        skill_improve, "send_bot_api",
+        lambda text, topic_id=None: sent.append((text, topic_id)),
+    )
+
+    await skill_improve.run_skill_improve()
+
+    # Active file untouched…
+    assert active.read_text(encoding="utf-8") == original
+    # …and the suggestion landed in a proposal file for review.
+    proposal = active.parent / "SKILL.proposed.md"
+    assert proposal.exists()
+    assert "PROPOSED REWRITE" in proposal.read_text(encoding="utf-8")
+    assert sent and "НЕ изменены" in sent[0][0]


### PR DESCRIPTION
## Summary

Four independent, tested fixes surfaced by a code review, all on trust
boundaries. No changes to live swarm coordination or memory behavior —
those are riskier and will be separate PRs.

## Fixes

- **P0 — shell injection in `server_query_swarm`** (`server_ops.py`): the SQL
  query was interpolated into the remote shell command, so a crafted query
  could break out of the quotes and run arbitrary commands on the host. Now
  passed via stdin (never the command line), DB opened `-readonly`, and
  sqlite3 dot-commands rejected.
- **P1 — skill self-modification** (`skill_improve.py`): the weekly improver
  rewrote the live `SKILL.md` in place with LLM output derived from audit
  logs — persistent self-modification and a prompt-injection lock-in channel.
  Now writes `SKILL.proposed.md` for human review; the active file is never
  auto-overwritten.
- **P1 — approval re-use** (`graph.py`, `session.py`): an approval was bound to
  the tool name only, so approving `restart_service("web")` waved through
  `restart_service("db")` on resume. Now bound to name + canonical args, plus a
  TTL that expires stale approvals instead of resuming them.
- **P1 — approval protocol bug** (`engine.py`): when a multi-call batch paused
  for approval, the following tool_calls were left without a ToolMessage,
  breaking the resumed history (unanswered tool_calls → LLM protocol error).
  Now emits deferred placeholders so every tool_call is answered.

## Tests

+11 tests. Full non-integration suite green: **686 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)