### PR TITLE
swarm: executing-lease so a long invoke isn't answered twice

### DIFF
--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -1975,6 +1975,17 @@ async def run_bridge(agent: KronosAgent) -> None:
                 # Soft cost degradation: once daily spend crosses the degrade
                 # threshold, force the lite tier instead of blocking.
                 degrade_tier = "lite" if guardian.should_degrade() else None
+                # Acquire the executing lease right before the (possibly slow)
+                # invoke: this flips our winning claim to 'executing' so a peer
+                # can't see the 120s 'claimed' expiry mid-run and answer the
+                # same message. Owner/DM/command paths keep the short expiry.
+                if not is_dm and swarm is not None and decision is not None:
+                    swarm.begin_executing(
+                        chat_id=event.chat_id,
+                        topic_id=topic_id_inbound,
+                        trigger_msg_id=event.message.id,
+                        agent_name=settings.agent_name,
+                    )
                 # Call agent with new contract: raw user text as message,
                 # group metadata as transient extra_system_context only.
                 reply = await _ask_agent(

--- a/kronos/swarm_store.py
+++ b/kronos/swarm_store.py
@@ -48,9 +48,17 @@ CLAIM_STATE_SENT = "sent"
 CLAIM_STATE_CANCELLED = "cancelled"
 CLAIM_STATE_EXPIRED = "expired"
 
-# Claims older than this many seconds without transitioning to ``sent`` are
-# considered expired (agent crashed / lost power). Lazy cleanup.
+# A ``claimed`` row older than this many seconds (arbitration won but the
+# agent never started executing) is considered stale — the agent crashed
+# between claiming and winning. Lazy cleanup.
 CLAIM_EXPIRY_SECONDS = 120
+
+# Once an agent wins arbitration it flips its claim to ``executing`` and holds
+# that lease while the (possibly slow) LLM/tool run and Telegram delivery
+# happen. The lease is deliberately generous so a long invoke is NOT mistaken
+# for a dead agent and answered a second time by a peer. If the process really
+# dies mid-run, the lease still expires and another agent may pick up.
+EXECUTING_LEASE_SECONDS = 600
 
 # Retention for swarm_messages (used by a cron job, not enforced here).
 MESSAGE_RETENTION_DAYS = 90
@@ -71,6 +79,47 @@ def _schema(conn) -> None:
     }
     if columns and "fingerprint" not in columns:
         conn.execute("ALTER TABLE session_messages ADD COLUMN fingerprint TEXT")
+
+    # reply_claims gained an 'executing' state (a lease held between winning
+    # arbitration and confirmed delivery). SQLite can't ALTER a CHECK
+    # constraint, so recreate the table when the legacy constraint is present.
+    # reply_claims is an ephemeral ledger (claims live minutes), so copying
+    # rows forward is safe. Runs before the main script below, whose
+    # CREATE TABLE / CREATE INDEX IF NOT EXISTS then no-op / rebuild indexes.
+    claims_ddl = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='reply_claims'"
+    ).fetchone()
+    if claims_ddl and claims_ddl[0] and "'executing'" not in claims_ddl[0]:
+        conn.executescript(
+            """
+            ALTER TABLE reply_claims RENAME TO reply_claims_legacy;
+            CREATE TABLE reply_claims (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                chat_id INTEGER NOT NULL,
+                topic_id INTEGER NOT NULL DEFAULT 0,
+                root_msg_id INTEGER NOT NULL,
+                trigger_msg_id INTEGER NOT NULL,
+                agent_name TEXT NOT NULL,
+                tier INTEGER NOT NULL,
+                eta_ts REAL NOT NULL,
+                state TEXT NOT NULL CHECK (
+                    state IN ('claimed','executing','sent','cancelled','expired')
+                ),
+                reason TEXT,
+                reply_msg_id INTEGER,
+                created_at REAL NOT NULL,
+                UNIQUE (chat_id, topic_id, trigger_msg_id, agent_name)
+            );
+            INSERT INTO reply_claims
+                (id, chat_id, topic_id, root_msg_id, trigger_msg_id, agent_name,
+                 tier, eta_ts, state, reason, reply_msg_id, created_at)
+                SELECT id, chat_id, topic_id, root_msg_id, trigger_msg_id,
+                       agent_name, tier, eta_ts, state, reason, reply_msg_id,
+                       created_at
+                FROM reply_claims_legacy;
+            DROP TABLE reply_claims_legacy;
+            """
+        )
 
     conn.executescript(
         """
@@ -102,7 +151,7 @@ def _schema(conn) -> None:
             agent_name TEXT NOT NULL,
             tier INTEGER NOT NULL,
             eta_ts REAL NOT NULL,
-            state TEXT NOT NULL CHECK (state IN ('claimed','sent','cancelled','expired')),
+            state TEXT NOT NULL CHECK (state IN ('claimed','executing','sent','cancelled','expired')),
             reason TEXT,
             reply_msg_id INTEGER,
             created_at REAL NOT NULL,
@@ -438,40 +487,47 @@ class SwarmStore:
         now = time.time()
 
         def _tx(conn):
-            # Lazy-expire stale claims
+            # Lazy-expire stale rows: a ``claimed`` row past CLAIM_EXPIRY (won
+            # nothing yet) and an ``executing`` lease past EXECUTING_LEASE (the
+            # agent likely died mid-run) both become ``expired``.
             conn.execute(
                 """
                 UPDATE reply_claims
                 SET state = 'expired'
-                WHERE state = 'claimed'
-                  AND (? - created_at) > ?
+                WHERE (state = 'claimed' AND (? - created_at) > ?)
+                   OR (state = 'executing' AND (? - created_at) > ?)
                 """,
-                (now, CLAIM_EXPIRY_SECONDS),
+                (now, CLAIM_EXPIRY_SECONDS, now, EXECUTING_LEASE_SECONDS),
             )
 
             # Tier 1 bypasses arbitration & cap.
             if tier == 1:
                 return ClaimOutcome(True, "tier-1 explicit")
 
-            # Anti-flood cap across all agents.
+            # Anti-flood cap across all agents. An ``executing`` winner already
+            # occupies a reply slot, so it counts alongside ``sent``.
             (sent_count,) = conn.execute(
                 """
                 SELECT COUNT(*) FROM reply_claims
                 WHERE chat_id = ? AND topic_id = ? AND root_msg_id = ?
-                  AND state = 'sent' AND tier > 1
+                  AND state IN ('executing', 'sent') AND tier > 1
                 """,
                 (chat_id, topic_id or 0, root_msg_id),
             ).fetchone()
             if sent_count >= max_implicit_replies:
                 return ClaimOutcome(False, f"cap reached ({sent_count}>={max_implicit_replies})")
 
-            # Winner lookup.
+            # Winner lookup across still-active rows (claimed OR executing). An
+            # agent already ``executing`` outranks any fresh ``claimed`` peer
+            # regardless of eta — it already holds the slot and is running — so
+            # a late arrival with an earlier eta cannot steal a live invoke.
             winner = conn.execute(
                 """
                 SELECT agent_name FROM reply_claims
                 WHERE chat_id = ? AND topic_id = ? AND root_msg_id = ?
-                  AND state = 'claimed'
-                ORDER BY tier ASC, eta_ts ASC, agent_name ASC
+                  AND state IN ('claimed', 'executing')
+                ORDER BY (state = 'executing') DESC,
+                         tier ASC, eta_ts ASC, agent_name ASC
                 LIMIT 1
                 """,
                 (chat_id, topic_id or 0, root_msg_id),
@@ -484,6 +540,45 @@ class SwarmStore:
 
         return self._db.write_tx(_tx)
 
+    def begin_executing(
+        self,
+        *,
+        chat_id: int,
+        topic_id: int | None,
+        trigger_msg_id: int,
+        agent_name: str,
+    ) -> bool:
+        """Acquire the executing lease immediately before a (slow) invoke.
+
+        Flips this agent's winning claim from ``claimed`` to ``executing`` and
+        renews created_at, so the EXECUTING_LEASE window starts now. This is
+        what stops a peer from seeing the 120s ``claimed`` expiry mid-invoke,
+        assuming the agent is dead, and answering the same message twice.
+
+        Kept separate from ``can_send_claim`` so the lease covers only the
+        invoke+delivery — not the media pre-processing between them, whose
+        failure paths should fall back to the shorter ``claimed`` expiry.
+
+        Returns True if the lease was acquired; False means the claim was no
+        longer ``claimed`` (already sent/cancelled/expired).
+        """
+        now = time.time()
+
+        def _tx(conn):
+            cur = conn.execute(
+                """
+                UPDATE reply_claims
+                SET state = 'executing', created_at = ?
+                WHERE chat_id = ? AND topic_id = ?
+                  AND trigger_msg_id = ? AND agent_name = ?
+                  AND state = 'claimed'
+                """,
+                (now, chat_id, topic_id or 0, trigger_msg_id, agent_name),
+            )
+            return cur.rowcount > 0
+
+        return self._db.write_tx(_tx)
+
     def mark_sent(
         self,
         *,
@@ -493,12 +588,16 @@ class SwarmStore:
         agent_name: str,
         reply_msg_id: int | None,
     ) -> None:
+        # Compare-and-set: only an in-flight claim (owner/tier-1 stay 'claimed';
+        # a tier-2/3 winner is 'executing') may transition to 'sent'. This never
+        # resurrects a row that was already cancelled or expired.
         self._db.write(
             """
             UPDATE reply_claims
             SET state = 'sent', reply_msg_id = ?
             WHERE chat_id = ? AND topic_id = ?
               AND trigger_msg_id = ? AND agent_name = ?
+              AND state IN ('claimed', 'executing')
             """,
             (reply_msg_id, chat_id, topic_id or 0, trigger_msg_id, agent_name),
         )
@@ -518,7 +617,7 @@ class SwarmStore:
             SET state = 'cancelled', reason = COALESCE(NULLIF(?, ''), reason)
             WHERE chat_id = ? AND topic_id = ?
               AND trigger_msg_id = ? AND agent_name = ?
-              AND state = 'claimed'
+              AND state IN ('claimed', 'executing')
             """,
             (reason, chat_id, topic_id or 0, trigger_msg_id, agent_name),
         )

--- a/tests/test_swarm_store.py
+++ b/tests/test_swarm_store.py
@@ -162,6 +162,124 @@ class TestArbitration:
         assert self._can_send(swarm, "reviewer", tier=1).won is True
 
 
+class TestExecutingLease:
+    """The executing-state lease that protects a long invoke from being
+    re-answered by a peer (the swarm-lease fix)."""
+
+    def _claim(self, swarm, agent: str, tier: int, eta_offset: float, *, msg_id: int):
+        swarm.claim_reply(
+            chat_id=100, topic_id=None, root_msg_id=1, trigger_msg_id=msg_id,
+            agent_name=agent, tier=tier, eta_ts=time.time() + eta_offset,
+        )
+
+    def _can_send(self, swarm, agent: str, tier: int, **kw):
+        return swarm.can_send_claim(
+            chat_id=100, topic_id=None, root_msg_id=1,
+            agent_name=agent, tier=tier, **kw,
+        )
+
+    def _state(self, swarm, msg_id: int):
+        row = swarm._db.read_one(
+            "SELECT state FROM reply_claims WHERE root_msg_id = 1 AND trigger_msg_id = ?",
+            (msg_id,),
+        )
+        return row["state"] if row else None
+
+    def _age(self, swarm, msg_id: int, seconds_ago: float):
+        swarm._db.write(
+            "UPDATE reply_claims SET created_at = ? WHERE trigger_msg_id = ?",
+            (time.time() - seconds_ago, msg_id),
+        )
+
+    def _acquire(self, swarm, agent: str, tier: int, *, msg_id: int):
+        """Simulate the bridge: win arbitration, then take the lease."""
+        assert self._can_send(swarm, agent, tier).won is True
+        swarm.begin_executing(
+            chat_id=100, topic_id=None, trigger_msg_id=msg_id, agent_name=agent,
+        )
+
+    def test_begin_executing_takes_the_lease(self, swarm):
+        self._claim(swarm, "kronos", tier=2, eta_offset=0.1, msg_id=1)
+        self._acquire(swarm, "kronos", tier=2, msg_id=1)
+        assert self._state(swarm, 1) == "executing"
+
+    def test_long_invoke_not_stolen_after_claim_expiry(self, swarm):
+        # kronos wins and starts a long invoke; its lease is aged past the
+        # 120s CLAIM_EXPIRY (but within the 600s executing lease). A peer
+        # arriving now must NOT treat the running winner as dead.
+        from kronos.swarm_store import CLAIM_EXPIRY_SECONDS
+
+        self._claim(swarm, "kronos", tier=2, eta_offset=0.1, msg_id=1)
+        self._acquire(swarm, "kronos", tier=2, msg_id=1)
+        self._age(swarm, 1, CLAIM_EXPIRY_SECONDS + 60)
+
+        # analyst even has an EARLIER eta — under the old 'claimed'-expiry
+        # behaviour kronos would be expired and analyst would win (the bug).
+        self._claim(swarm, "analyst", tier=2, eta_offset=-5.0, msg_id=2)
+        out = self._can_send(swarm, "analyst", tier=2)
+        assert out.won is False
+        assert self._state(swarm, 1) == "executing"  # winner survived
+
+    def test_dead_agent_lease_expires_and_peer_wins(self, swarm):
+        # If the winner really died mid-run, its executing lease eventually
+        # expires and another agent may pick up.
+        from kronos.swarm_store import EXECUTING_LEASE_SECONDS
+
+        self._claim(swarm, "kronos", tier=2, eta_offset=0.1, msg_id=1)
+        self._acquire(swarm, "kronos", tier=2, msg_id=1)
+        self._age(swarm, 1, EXECUTING_LEASE_SECONDS + 60)
+
+        self._claim(swarm, "analyst", tier=2, eta_offset=0.2, msg_id=2)
+        assert self._can_send(swarm, "analyst", tier=2).won is True
+        assert self._state(swarm, 1) == "expired"
+
+    def test_executing_counts_toward_cap(self, swarm):
+        # A winner still executing (not yet 'sent') already occupies a reply
+        # slot, so with cap=1 a peer is rejected by the cap.
+        self._claim(swarm, "kronos", tier=2, eta_offset=0.1, msg_id=1)
+        self._acquire(swarm, "kronos", tier=2, msg_id=1)
+        self._claim(swarm, "analyst", tier=2, eta_offset=0.2, msg_id=2)
+        out = self._can_send(swarm, "analyst", tier=2, max_implicit_replies=1)
+        assert out.won is False
+        assert "cap" in out.reason.lower()
+
+    def test_mark_sent_from_executing(self, swarm):
+        self._claim(swarm, "kronos", tier=2, eta_offset=0.1, msg_id=1)
+        self._acquire(swarm, "kronos", tier=2, msg_id=1)
+        swarm.mark_sent(
+            chat_id=100, topic_id=None, trigger_msg_id=1,
+            agent_name="kronos", reply_msg_id=777,
+        )
+        assert self._state(swarm, 1) == "sent"
+
+    def test_mark_sent_is_cas_from_active_only(self, swarm):
+        # A cancelled claim must not be resurrected to 'sent'.
+        self._claim(swarm, "kronos", tier=2, eta_offset=0.1, msg_id=1)
+        swarm.cancel_claim(
+            chat_id=100, topic_id=None, trigger_msg_id=1,
+            agent_name="kronos", reason="stood down",
+        )
+        swarm.mark_sent(
+            chat_id=100, topic_id=None, trigger_msg_id=1,
+            agent_name="kronos", reply_msg_id=555,
+        )
+        assert self._state(swarm, 1) == "cancelled"
+
+    def test_cancel_releases_executing_lease(self, swarm):
+        # A winner that acquired the lease but then decides to PASS releases
+        # the slot so a peer can proceed.
+        self._claim(swarm, "kronos", tier=2, eta_offset=0.1, msg_id=1)
+        self._acquire(swarm, "kronos", tier=2, msg_id=1)
+        assert self._state(swarm, 1) == "executing"
+        swarm.cancel_claim(
+            chat_id=100, topic_id=None, trigger_msg_id=1,
+            agent_name="kronos", reason="peer-reaction self-pass",
+        )
+        assert self._state(swarm, 1) == "cancelled"
+        self._claim(swarm, "analyst", tier=2, eta_offset=0.2, msg_id=2)
+        assert self._can_send(swarm, "analyst", tier=2).won is True
+
+
 class TestSharedUserFacts:
     def test_add_and_search(self, swarm):
         swarm.add_shared_fact(
@@ -281,6 +399,69 @@ class TestSchemaMigration:
             from_agent="kronos", to_agent="nexus", context="works now",
         )
         assert handoff_id > 0
+
+        _db._instances.clear()
+        ss._singleton = None
+
+    def test_reply_claims_check_migrated_to_include_executing(self, tmp_path, monkeypatch):
+        """A swarm.db whose reply_claims predates the 'executing' lease state is
+        migrated so the new state is insertable and existing rows survive."""
+        import sqlite3
+
+        swarm_path = tmp_path / "swarm.db"
+        with sqlite3.connect(swarm_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE reply_claims (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    chat_id INTEGER NOT NULL,
+                    topic_id INTEGER NOT NULL DEFAULT 0,
+                    root_msg_id INTEGER NOT NULL,
+                    trigger_msg_id INTEGER NOT NULL,
+                    agent_name TEXT NOT NULL,
+                    tier INTEGER NOT NULL,
+                    eta_ts REAL NOT NULL,
+                    state TEXT NOT NULL CHECK (state IN ('claimed','sent','cancelled','expired')),
+                    reason TEXT,
+                    reply_msg_id INTEGER,
+                    created_at REAL NOT NULL,
+                    UNIQUE (chat_id, topic_id, trigger_msg_id, agent_name)
+                )
+                """
+            )
+            conn.execute(
+                "INSERT INTO reply_claims (chat_id, topic_id, root_msg_id, "
+                "trigger_msg_id, agent_name, tier, eta_ts, state, created_at) "
+                "VALUES (7, 0, 1, 1, 'kronos', 2, 1.0, 'sent', 1.0)"
+            )
+
+        from kronos.config import settings as _settings
+        monkeypatch.setattr(_settings, "swarm_db_path", str(swarm_path))
+        monkeypatch.setattr(_settings, "db_dir", str(tmp_path / "agent"))
+
+        from kronos import db as _db
+        _db._instances.clear()
+        import kronos.swarm_store as ss
+        ss._singleton = None
+
+        ss.get_swarm()  # runs the CHECK migration on load
+
+        with sqlite3.connect(swarm_path) as conn:
+            ddl = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name='reply_claims'"
+            ).fetchone()[0]
+            assert "'executing'" in ddl
+            preserved = conn.execute(
+                "SELECT agent_name, state FROM reply_claims WHERE trigger_msg_id = 1"
+            ).fetchone()
+            assert preserved == ("kronos", "sent")
+            # 'executing' no longer violates the CHECK constraint.
+            conn.execute(
+                "INSERT INTO reply_claims (chat_id, topic_id, root_msg_id, "
+                "trigger_msg_id, agent_name, tier, eta_ts, state, created_at) "
+                "VALUES (7, 0, 1, 2, 'nexus', 2, 1.0, 'executing', 1.0)"
+            )
+            conn.commit()
 
         _db._instances.clear()
         ss._singleton = None


### PR DESCRIPTION
## Problem

Two gaps in reply arbitration (from the code review):

1. `can_send_claim` runs **before** the (possibly slow) LLM/tool invoke, but a claim expires after `CLAIM_EXPIRY_SECONDS` (120s). A run longer than that lets a peer lazy-expire the winner's claim and answer the same message — a **duplicate reply**.
2. `mark_sent` was a blind `UPDATE`, not a compare-and-set.

## Fix — an `executing` lease

- New `executing` state. `can_send_claim` only **arbitrates**; `begin_executing` takes the lease immediately before the invoke (`claimed → executing`, renewed timestamp). Keeping them separate means the lease covers only invoke+delivery — media pre-processing keeps the shorter 120s expiry.
- `can_send_claim` now: counts `executing` toward the anti-flood cap; ranks `executing` ahead of any `claimed` peer (a late arrival with an earlier eta can't steal a live run); lazy-expires `executing` only after `EXECUTING_LEASE_SECONDS` (600s).
- `mark_sent` is a CAS from `claimed`/`executing` only; `cancel_claim` releases an `executing` lease too (PASS / stand-down).
- **Migration:** SQLite can't `ALTER` a CHECK constraint, so `reply_claims` is recreated to allow `executing`; the ephemeral rows are copied forward. Covered by a migration test.
- `bridge.py`: acquire the lease right before `_ask_agent`.

## Tests

+8 tests (lease survives claim-expiry, dead-agent lease expiry, cap counts executing, mark_sent CAS, CHECK migration). Full non-integration suite green: **694 passed**.

> Note: touches live 6-agent coordination and migrates the shared `swarm.db` schema. Merge deploys nothing (deploy is separate), but the migration runs on next start on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)