### PR TITLE
review tech-debt: SafeDB rollback, cron isolation, /clear privacy, loop detector

### DIFF
--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -970,9 +970,18 @@ async def _post_bot_api_message(
 
 
 async def _clear_context(chat_id: int, topic_id: int | None = None) -> str:
-    """Clear conversation history for a chat/topic."""
+    """Clear the conversation for a chat/topic: session history + the shared
+    swarm message ledger. Learned user facts (Mem0 / shared_user_facts) are
+    cross-conversation and are NOT removed here — see clear_context's message.
+    """
     thread_id = f"{chat_id}:{topic_id}" if topic_id else str(chat_id)
-    return await _agent.clear_context(thread_id)
+    result = await _agent.clear_context(thread_id)
+    try:
+        from kronos.swarm_store import get_swarm
+        get_swarm().clear_thread_messages(chat_id=chat_id, topic_id=topic_id)
+    except Exception as e:
+        log.debug("Swarm message clear failed (non-fatal): %s", e)
+    return result
 
 
 # --- Live progress reporter (roadmap 4.1) ---

--- a/kronos/cron/scheduler.py
+++ b/kronos/cron/scheduler.py
@@ -17,8 +17,12 @@ from kronos.config import settings
 
 log = logging.getLogger("kronos.cron.scheduler")
 
-# Persistence file for last_run timestamps (survives restarts)
-_STATE_FILE = Path(__file__).resolve().parents[2] / "data" / "cron_state.json"
+def _state_file() -> Path:
+    # Per-agent last_run persistence, next to the agent's session DB — NOT a
+    # swarm-shared file. A shared data/cron_state.json let 6 agents clobber each
+    # other's timestamps and lose updates racing on one JSON (an agent could
+    # suppress another's job). Only swarm.db is shared across the swarm.
+    return Path(settings.db_path).parent / "cron_state.json"
 
 
 def _history_file() -> Path:
@@ -72,10 +76,11 @@ class Scheduler:
 
     def _load_state(self) -> None:
         """Restore last_run timestamps from disk."""
-        if not _STATE_FILE.exists():
+        state_file = _state_file()
+        if not state_file.exists():
             return
         try:
-            state = json.loads(_STATE_FILE.read_text())
+            state = json.loads(state_file.read_text())
             for name, ts in state.items():
                 if name in self.jobs:
                     self.jobs[name].last_run = float(ts)
@@ -84,11 +89,14 @@ class Scheduler:
             log.warning("Failed to load cron state: %s", e)
 
     def _save_state(self) -> None:
-        """Persist last_run timestamps to disk."""
+        """Persist last_run timestamps to disk (atomic write)."""
         state = {name: job.last_run for name, job in self.jobs.items() if job.last_run > 0}
+        state_file = _state_file()
         try:
-            _STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
-            _STATE_FILE.write_text(json.dumps(state))
+            state_file.parent.mkdir(parents=True, exist_ok=True)
+            tmp = state_file.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(state))
+            tmp.replace(state_file)
         except Exception as e:
             log.warning("Failed to save cron state: %s", e)
 

--- a/kronos/db.py
+++ b/kronos/db.py
@@ -109,44 +109,29 @@ class SafeDB:
 
     def write(self, sql: str, params: tuple = ()) -> sqlite3.Cursor:
         """Execute a single write in an IMMEDIATE transaction."""
-        with self._lock:
-            try:
-                self._conn.execute("BEGIN IMMEDIATE")
-                cursor = self._conn.execute(sql, params)
-                self._conn.execute("COMMIT")
-                return cursor
-            except sqlite3.OperationalError as e:
-                log.warning("SafeDB write failed on %s: %s", self._db_path.name, e)
-                self._rollback_safe()
-                self._conn.execute("BEGIN IMMEDIATE")
-                cursor = self._conn.execute(sql, params)
-                self._conn.execute("COMMIT")
-                return cursor
+        return self.write_tx(lambda conn: conn.execute(sql, params))
 
     def write_many(self, operations: list[tuple[str, tuple]]) -> None:
         """Execute multiple writes in a single IMMEDIATE transaction."""
-        with self._lock:
-            try:
-                self._conn.execute("BEGIN IMMEDIATE")
-                for sql, params in operations:
-                    self._conn.execute(sql, params)
-                self._conn.execute("COMMIT")
-            except sqlite3.OperationalError as e:
-                log.warning("SafeDB write_many failed on %s: %s", self._db_path.name, e)
-                self._rollback_safe()
-                self._conn.execute("BEGIN IMMEDIATE")
-                for sql, params in operations:
-                    self._conn.execute(sql, params)
-                self._conn.execute("COMMIT")
+
+        def _do(conn: sqlite3.Connection) -> None:
+            for sql, params in operations:
+                conn.execute(sql, params)
+
+        self.write_tx(_do)
 
     def write_tx(self, fn) -> any:
         """Execute a function within a locked IMMEDIATE transaction.
 
-        Uses BEGIN IMMEDIATE to acquire write lock upfront,
-        preventing "database is locked" during FTS5 operations.
+        Uses BEGIN IMMEDIATE to acquire the write lock upfront, preventing
+        "database is locked" during FTS5 operations.
 
-        fn receives the connection and should do reads+writes.
-        Commit happens after fn returns; rollback on error.
+        fn receives the connection and should do reads+writes. Commit happens
+        after fn returns. On ANY error the transaction is rolled back before it
+        propagates — a leaked BEGIN would wedge the connection's write lock for
+        every later write. A transient OperationalError ("database is locked")
+        is retried once; other errors (IntegrityError, a raise inside fn) roll
+        back and propagate without a retry that would just fail again.
 
         Usage:
             def update(conn):
@@ -157,17 +142,26 @@ class SafeDB:
         """
         with self._lock:
             try:
-                self._conn.execute("BEGIN IMMEDIATE")
-                result = fn(self._conn)
-                self._conn.execute("COMMIT")
-                return result
+                return self._run_tx(fn)
             except sqlite3.OperationalError as e:
-                log.warning("SafeDB write_tx failed on %s: %s", self._db_path.name, e)
-                self._rollback_safe()
-                self._conn.execute("BEGIN IMMEDIATE")
-                result = fn(self._conn)
-                self._conn.execute("COMMIT")
-                return result
+                log.warning("SafeDB write_tx retry on %s: %s", self._db_path.name, e)
+                return self._run_tx(fn)
+
+    def _run_tx(self, fn):
+        """Run fn in one IMMEDIATE transaction, rolling back on any error.
+
+        Always leaves the connection with no open transaction — whether fn
+        commits, raises IntegrityError, or the callback itself raises — so the
+        write lock is never leaked. Must be called under ``self._lock``.
+        """
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            result = fn(self._conn)
+            self._conn.execute("COMMIT")
+            return result
+        except Exception:
+            self._rollback_safe()
+            raise
 
     def _rollback_safe(self) -> None:
         """Rollback and verify connection is alive. Reconnect if dead."""

--- a/kronos/engine.py
+++ b/kronos/engine.py
@@ -21,6 +21,7 @@ from langchain_core.messages import AIMessage, BaseMessage, SystemMessage, ToolM
 from langchain_core.tools import BaseTool
 
 from kronos.config import settings
+from kronos.security.loop_detector import LoopDetector, LoopLevel, get_nudge_message
 from kronos.security.sanitize import wrap_untrusted
 from kronos.tools.error_handler import classify_tool_error
 
@@ -444,6 +445,12 @@ async def react_loop(
             log.warning("Tool approval request failed for %s: %s", tool.name, e)
             return None
 
+    # Detect runaway tool loops across turns (same call repeated, ping-pong,
+    # polling with no progress). Nudges the model to change course, and aborts
+    # via circuit breaker if it stays stuck — a cost/safety backstop.
+    loop_detector = LoopDetector()
+    last_nudge_level = LoopLevel.OK
+
     for turn in range(max_turns):
         # Call LLM
         try:
@@ -582,10 +589,35 @@ async def react_loop(
                 })
 
             tool_messages.append(tm)
+            loop_detector.record(
+                tool_name, tc.get("args", {}) or {}, tool_message_raw_content(tm)
+            )
 
         messages.extend(tool_messages)
         call_messages.extend(tool_messages)
         await emit_message_delta(tool_messages)
+
+        # Loop backstop: nudge on WARNING/CRITICAL (once per escalation) so the
+        # next turn changes course; abort on CIRCUIT_BREAKER with a partial
+        # result instead of burning turns/budget on a stuck loop.
+        level, desc = loop_detector.check()
+        if level == LoopLevel.CIRCUIT_BREAKER:
+            final = AIMessage(content=get_nudge_message(level, desc))
+            messages.append(final)
+            await emit_message_delta([final])
+            log.warning("React loop circuit breaker: %s", desc)
+            return AgentResult(
+                messages=messages,
+                content=final.content,
+                tool_calls_count=total_tool_calls,
+            )
+        if level in (LoopLevel.WARNING, LoopLevel.CRITICAL) and level != last_nudge_level:
+            nudge = SystemMessage(content=get_nudge_message(level, desc))
+            messages.append(nudge)
+            call_messages.append(nudge)
+            await emit_message_delta([nudge])
+            last_nudge_level = level
+            log.info("React loop nudge (%s): %s", level, desc)
 
     # Max turns exhausted
     log.warning("React loop exhausted after %d turns", max_turns)

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -580,9 +580,18 @@ class KronosAgent:
         return response_text
 
     async def clear_context(self, thread_id: str) -> str:
-        """Clear conversation history for a thread."""
+        """Clear conversation history for a thread.
+
+        Clears THIS conversation only. Facts the agent has learned about the
+        user (Mem0 + shared_user_facts) are cross-conversation and are kept on
+        purpose — the message says so rather than implying everything is gone.
+        """
         if self._session_store:
             deleted = await self._session_store.clear(thread_id)
             log.info("Cleared context for thread %s: %d rows", thread_id, deleted)
-            return f"🧹 Контекст очищен (thread: {thread_id}, удалено: {deleted})"
+            return (
+                "🧹 История этого диалога очищена. "
+                "Факты, которые ты мне рассказывал, я помню и дальше — "
+                "они не привязаны к конкретному диалогу."
+            )
         return "Session store не настроен."

--- a/kronos/swarm_store.py
+++ b/kronos/swarm_store.py
@@ -1226,6 +1226,21 @@ class SwarmStore:
         log.info("Pruned %d swarm_messages older than %d days", deleted, older_than_days)
         return deleted
 
+    def clear_thread_messages(self, *, chat_id: int, topic_id: int | None) -> int:
+        """Delete the shared message ledger for one chat/topic (a /clear).
+
+        So a cleared conversation is also gone from the cross-agent record.
+        Does NOT touch shared_user_facts — learned facts are cross-conversation
+        and are cleared by a separate 'forget' action, not by /clear.
+        """
+        cursor = self._db.write(
+            "DELETE FROM swarm_messages WHERE chat_id = ? AND topic_id = ?",
+            (chat_id, topic_id or 0),
+        )
+        deleted = cursor.rowcount if cursor is not None else 0
+        log.info("Cleared %d swarm_messages for chat=%s topic=%s", deleted, chat_id, topic_id or 0)
+        return deleted
+
 
 _singleton: SwarmStore | None = None
 

--- a/tests/test_cron_scheduler.py
+++ b/tests/test_cron_scheduler.py
@@ -59,3 +59,27 @@ async def test_success_resets_failure_counter(scheduler):
         state["fail"] = False
         await scheduler._run_job(job)
         assert job.consecutive_failures == 0
+
+
+def test_cron_state_is_per_agent_and_roundtrips(tmp_path, monkeypatch):
+    # Cron state lives next to the agent's own session DB (per-agent), not in a
+    # swarm-shared data/cron_state.json, and survives a reload.
+    from kronos.config import settings
+    from kronos.cron import scheduler as sched_mod
+
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "agent" / "session.db"))
+    assert sched_mod._state_file() == tmp_path / "agent" / "cron_state.json"
+
+    async def _noop():
+        return None
+
+    s1 = Scheduler()
+    s1.add(CronJob(name="job-a", func=_noop, interval_seconds=60))
+    s1.jobs["job-a"].last_run = 123.0
+    s1._save_state()
+
+    # A fresh scheduler for the same agent restores the timestamp.
+    s2 = Scheduler()
+    s2.add(CronJob(name="job-a", func=_noop, interval_seconds=60))
+    s2._load_state()
+    assert s2.jobs["job-a"].last_run == 123.0

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,62 @@
+"""SafeDB transaction safety.
+
+A failed write must roll back and never leave the connection wedged in an
+open IMMEDIATE transaction — otherwise every later write on that connection
+deadlocks on the leaked write lock.
+"""
+
+import sqlite3
+
+import pytest
+
+from kronos.db import SafeDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    d = SafeDB(tmp_path / "t.db")
+    d.write("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+    return d
+
+
+def test_write_tx_commits_on_success(db):
+    db.write_tx(lambda c: c.execute("INSERT INTO t (id, v) VALUES (1, 'a')"))
+    assert db.read_one("SELECT v FROM t WHERE id = 1")["v"] == "a"
+
+
+def test_write_tx_rolls_back_on_callback_error(db):
+    def _bad(conn):
+        conn.execute("INSERT INTO t (id, v) VALUES (2, 'b')")
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        db.write_tx(_bad)
+
+    # The insert was rolled back…
+    assert db.read_one("SELECT v FROM t WHERE id = 2") is None
+    # …and the connection is not wedged — a later write still commits.
+    db.write("INSERT INTO t (id, v) VALUES (3, 'c')")
+    assert db.read_one("SELECT v FROM t WHERE id = 3")["v"] == "c"
+
+
+def test_write_rolls_back_on_integrity_error(db):
+    db.write("INSERT INTO t (id, v) VALUES (1, 'a')")
+    # Duplicate primary key → IntegrityError, NOT OperationalError, so the old
+    # code left the BEGIN IMMEDIATE open.
+    with pytest.raises(sqlite3.IntegrityError):
+        db.write("INSERT INTO t (id, v) VALUES (1, 'dup')")
+    # Connection still usable — the failed write rolled back, no open tx.
+    db.write("INSERT INTO t (id, v) VALUES (4, 'd')")
+    assert db.read_one("SELECT v FROM t WHERE id = 4")["v"] == "d"
+
+
+def test_write_many_rolls_back_atomically_on_error(db):
+    with pytest.raises(sqlite3.IntegrityError):
+        db.write_many([
+            ("INSERT INTO t (id, v) VALUES (5, 'e')", ()),
+            ("INSERT INTO t (id, v) VALUES (5, 'dup')", ()),  # dup PK
+        ])
+    # Neither row committed (atomic), and the connection is healthy.
+    assert db.read_one("SELECT v FROM t WHERE id = 5") is None
+    db.write("INSERT INTO t (id, v) VALUES (6, 'f')")
+    assert db.read_one("SELECT v FROM t WHERE id = 6")["v"] == "f"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.tools import StructuredTool
 
 from kronos.config import settings
@@ -518,3 +518,30 @@ class TestCreateAgent:
         await agent(original)
 
         assert len(original) == original_len  # not mutated
+
+
+@pytest.mark.asyncio
+async def test_loop_detector_nudges_then_aborts_runaway_loop():
+    # The model keeps calling the same tool with the same args forever. The
+    # loop detector should nudge it first, then abort via circuit breaker
+    # instead of burning every turn.
+    tool = _make_tool("stuck", result="same")
+    same_call = _ai_with_tool_call("stuck", args={"x": 1})
+    model = _make_model([same_call] * 40)  # past CIRCUIT_BREAKER_THRESHOLD (30)
+
+    result = await react_loop(
+        model,
+        [HumanMessage(content="go")],
+        tools=[tool],
+        max_turns=40,
+    )
+
+    # Aborted early via circuit breaker, not after all 40 turns.
+    assert result.tool_calls_count < 40
+    assert "CIRCUIT BREAKER" in result.content
+    # A loop nudge was injected along the way to try to break out first.
+    nudges = [
+        m for m in result.messages
+        if isinstance(m, SystemMessage) and "LOOP DETECTED" in str(m.content)
+    ]
+    assert nudges

--- a/tests/test_swarm_store.py
+++ b/tests/test_swarm_store.py
@@ -92,6 +92,26 @@ class TestRecordMessages:
         assert rows[0]["sender_type"] == "agent"
         assert rows[0]["agent_name"] == "kronos"
 
+    def test_clear_thread_messages_is_scoped_and_keeps_facts(self, swarm):
+        swarm.record_inbound_message(
+            chat_id=10, topic_id=None, msg_id=1, reply_to_msg_id=None,
+            sender_id=42, sender_type="user", agent_name=None, text="keep",
+        )
+        swarm.record_inbound_message(
+            chat_id=20, topic_id=None, msg_id=1, reply_to_msg_id=None,
+            sender_id=42, sender_type="user", agent_name=None, text="clear me",
+        )
+        swarm.add_shared_fact(user_id="u1", fact="survives clear", source_agent="k")
+
+        deleted = swarm.clear_thread_messages(chat_id=20, topic_id=None)
+
+        assert deleted == 1
+        assert swarm.get_recent_messages(chat_id=20, topic_id=None) == []
+        # Other threads untouched…
+        assert len(swarm.get_recent_messages(chat_id=10, topic_id=None)) == 1
+        # …and learned facts are NOT wiped by clearing a conversation.
+        assert "survives clear" in swarm.all_shared_facts(user_id="u1")
+
 
 class TestArbitration:
     def _claim(self, swarm, agent: str, tier: int, eta_offset: float, *, msg_id: int = 1):


### PR DESCRIPTION
Four correctness/robustness fixes from the code review (the non-multi-user,
non-MCP items). Each is atomic + tested.

- **db**: `SafeDB.write*` only rolled back on `OperationalError`; an
  `IntegrityError` or a raise inside a `write_tx` callback left the
  `BEGIN IMMEDIATE` open and wedged the connection's write lock. All three
  routes now go through a `_run_tx` helper that rolls back on any error.
- **cron**: all 6 agents shared `data/cron_state.json` with no lock (one could
  clobber another's `last_run` / suppress a job). State is now per-agent, next
  to the agent's session DB, written atomically.
- **privacy**: `/clear` told the user "контекст очищен" but only cleared session
  rows — the shared swarm ledger + learned facts lived on. `/clear` now clears
  the thread's `swarm_messages` too and the message is honest that learned
  facts (cross-conversation) are kept. (Full "forget facts" deletion is a
  separate feature — no delete API for Mem0/facts yet.)
- **engine**: the `LoopDetector` existed but was never wired in. The ReAct loop
  now records each tool call and nudges on WARNING/CRITICAL, aborting via
  circuit breaker on a runaway loop instead of burning every turn.

## Tests

+7 tests (db rollback ×3, cron per-agent round-trip, scoped /clear, loop
detector abort). Full non-integration suite green: **705 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)