### PR TITLE
test: fix ainvoke signature guard and let it run in CI

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -15,7 +15,11 @@ from __future__ import annotations
 
 import pytest
 
-pytestmark = pytest.mark.integration
+# No module-level integration mark: TestAinvokeContract is a pure signature
+# guard that MUST run in the default CI suite (`-m "not integration"`) — that
+# is the whole point of a contract regression guard. Only agent construction
+# needs the heavier workspace/settings setup, so the integration mark is
+# applied to that class alone (below), not blanket across the module.
 
 
 @pytest.fixture
@@ -51,6 +55,7 @@ def patched_settings(workspace_dir, monkeypatch, tmp_path):
     return settings
 
 
+@pytest.mark.integration
 class TestKronosAgentConstruction:
     def test_constructs_with_no_tools_and_no_memory(self, patched_settings):
         from kronos.graph import KronosAgent
@@ -97,7 +102,11 @@ class TestAinvokeContract:
             "source_kind",
             "persist_user_turn",
             "extra_system_context",
+            "on_tool_event",
+            "force_tier",
         }
         assert sig.parameters["source_kind"].default == "user"
         assert sig.parameters["persist_user_turn"].default is True
         assert sig.parameters["extra_system_context"].default == ""
+        assert sig.parameters["on_tool_event"].default is None
+        assert sig.parameters["force_tier"].default is None


### PR DESCRIPTION
## Problem
`TestAinvokeContract.test_signature_matches_expected_surface` asserted the pre-phase-6 parameter set of `KronosAgent.ainvoke`, so it failed whenever run in isolation.

## Why it slipped through CI
The whole `test_graph.py` module was marked `pytestmark = pytest.mark.integration`, and CI runs `pytest -m "not integration"` — so the guard was silently **deselected** and never ran. That masked the `on_tool_event` / `force_tier` additions (phase 6): the guard looked green only because it never executed. There is **no** flaky/leaked global state — the "passes in the suite / fails in isolation" split is pure marker deselection.

## Fix
- Add `on_tool_event` / `force_tier` (+ `None` defaults) to the expected surface so it matches the real signature (`kronos/graph.py:414`).
- Drop the blanket module-level integration mark; apply `@pytest.mark.integration` only to `TestKronosAgentConstruction`. The pure signature guard now runs in the default `-m "not integration"` suite and actually guards the contract.

## Verification
- Isolation: passes.
- Full `-m "not integration"`: **706 passed** (was 705 — the guard now actually runs), guard is selected, not deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)