### PR TITLE
cost accounting: real per-call tokens, swarm-wide budget, live session limit

### DIFF
--- a/kronos/llm.py
+++ b/kronos/llm.py
@@ -633,7 +633,7 @@ def _has_key(provider: str) -> bool:
 
 def _create_model(config: ProviderConfig) -> BaseChatModel | None:
     try:
-        callbacks = _observability_callbacks()
+        callbacks = _runtime_callbacks()
         if config.adapter in {"openai", "openai-compatible", "openai_compatible"}:
             from langchain_openai import ChatOpenAI
 
@@ -671,12 +671,21 @@ def _create_model(config: ProviderConfig) -> BaseChatModel | None:
                 command=config.command,
                 timeout_seconds=config.timeout_seconds,
                 cwd=os.getcwd(),
+                callbacks=callbacks or None,
             )
 
         log.error("Unsupported LLM adapter '%s' for provider '%s'", config.adapter, config.provider_id)
     except Exception as e:
         log.error("Failed to create '%s' model: %s", config.provider_id, e)
     return None
+
+
+def _runtime_callbacks() -> list[BaseCallbackHandler]:
+    """Callbacks attached to every model: always-on cost tracking, then the
+    optional Langfuse observability handler when its keys are configured."""
+    from kronos.security.cost_tracking import get_cost_callbacks
+
+    return get_cost_callbacks() + _observability_callbacks()
 
 
 def _observability_callbacks() -> list[BaseCallbackHandler]:

--- a/kronos/security/cost_guardian.py
+++ b/kronos/security/cost_guardian.py
@@ -1,15 +1,33 @@
 """Cost Guardian — enforces spending limits per session and per day.
 
-Tracks approximate costs from audit log and blocks requests
-when limits are exceeded.
+The daily cap reads the shared swarm cost ledger (``swarm_costs``), so the
+limit is swarm-wide rather than per-process; the session cap reads a
+per-process tally fed by the cost-tracking callback. Blocks requests when
+either limit is exceeded.
 """
 
 import logging
 from dataclasses import dataclass, field
 
-from kronos.audit import get_daily_cost
-
 log = logging.getLogger("kronos.security.cost_guardian")
+
+
+def _swarm_daily_cost() -> dict:
+    """Swarm-wide cost totals for today (shared across all six agents).
+
+    The daily budget is a property of the whole swarm, not of one process, so
+    it reads the shared ``swarm_costs`` ledger rather than a per-agent file.
+    Fails open (zeros) on any read error — a metrics glitch must not wedge an
+    agent by pretending the budget is blown.
+    """
+    try:
+        from kronos.swarm_store import get_swarm
+
+        return get_swarm().daily_cost()
+    except Exception as e:  # pragma: no cover - defensive
+        log.debug("Swarm daily-cost read failed, treating as $0: %s", e)
+        return {"cost_usd": 0, "requests": 0, "input_tokens": 0, "output_tokens": 0}
+
 
 # Default limits (can be overridden via config)
 DEFAULT_DAILY_LIMIT_USD = 5.0
@@ -36,7 +54,7 @@ class CostGuardian:
         Returns (allowed, reason).
         """
         # Daily limit check
-        daily = get_daily_cost()
+        daily = _swarm_daily_cost()
         daily_cost = daily.get("cost_usd", 0)
 
         if daily_cost >= self.daily_limit:
@@ -79,12 +97,12 @@ class CostGuardian:
         Soft degradation: keep answering (cheaper) instead of blocking, until
         the hard daily limit in check_budget kicks in.
         """
-        daily_cost = get_daily_cost().get("cost_usd", 0)
+        daily_cost = _swarm_daily_cost().get("cost_usd", 0)
         return daily_cost >= self.daily_limit * DEGRADE_RATIO
 
     def get_status(self) -> dict:
         """Get current cost status."""
-        daily = get_daily_cost()
+        daily = _swarm_daily_cost()
         return {
             "daily_cost": daily.get("cost_usd", 0),
             "daily_limit": self.daily_limit,

--- a/kronos/security/cost_tracking.py
+++ b/kronos/security/cost_tracking.py
@@ -1,0 +1,254 @@
+"""Always-on LLM cost tracking.
+
+A single LangChain callback, attached to every model the factory builds,
+reads each LLM call's token usage in ``on_llm_end`` and records the cost in
+two places:
+
+* the shared swarm ledger (``swarm_costs``) — the daily budget is swarm-wide,
+  so one of the six agents can't quietly burn the whole day's limit on its own
+  while the other five each read a private per-process total;
+* the per-process :class:`CostGuardian` session tally, so the per-conversation
+  limit (previously dead — ``record_cost`` had no caller) actually bites.
+
+Token counts come from the response when the provider reports them
+(``usage_metadata`` / ``llm_output['token_usage']`` — OpenAI, DeepSeek). The
+Codex CLI backend returns only text, so for it we fall back to a length-based
+estimate captured at start (same ~3.5 chars/token heuristic as the audit log).
+
+Pricing is per model and env-overridable
+(``KAOS_MODEL_PRICE_<MODEL>_INPUT`` / ``_OUTPUT``, per 1M tokens). Codex runs
+on a ChatGPT OAuth subscription — flat-rate, no per-token API charge — so its
+marginal price defaults to zero. The budget then tracks real API spend
+(DeepSeek), which is the money that actually accrues.
+
+The callback never raises into the LLM call: any accounting failure is logged
+at debug and swallowed, because a metrics glitch must not break a reply.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+import re
+from typing import Any
+
+from langchain_core.callbacks import BaseCallbackHandler
+
+from kronos.audit import get_tool_audit_context
+from kronos.config import settings
+
+log = logging.getLogger("kronos.security.cost")
+
+# Per-1M-token prices as (input, output). Lower-cased model name is the key.
+# Override any entry from the environment:
+#   KAOS_MODEL_PRICE_DEEPSEEK_CHAT_INPUT=0.27  (dots/dashes → underscore, upper)
+_MODEL_PRICES: dict[str, tuple[float, float]] = {
+    "deepseek-chat": (0.27, 1.10),
+    "deepseek-reasoner": (0.55, 2.19),
+    "gpt-4.1-mini": (0.40, 1.60),
+    "gpt-4.1": (2.00, 8.00),
+    # Codex CLI uses ChatGPT OAuth (subscription, not per-token API billing),
+    # so its marginal cost is zero. Override via env if billed per token.
+    "gpt-5.5": (0.0, 0.0),
+    "gpt-5": (0.0, 0.0),
+}
+
+# Unknown, API-billed model — a conservative non-zero estimate so an
+# unpriced provider still counts against the budget rather than reading free.
+_DEFAULT_PRICE = (0.50, 1.50)
+
+_CHARS_PER_TOKEN = 3.5  # matches kronos.audit._estimate_tokens
+
+
+def _to_float(value: Any, default: float) -> float:
+    if value in (None, ""):
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _price_for(model: str) -> tuple[float, float]:
+    """Resolve (input, output) per-1M price for a model, env-overridable."""
+    key = (model or "").strip().lower()
+    base = _MODEL_PRICES.get(key, _DEFAULT_PRICE)
+    env_key = re.sub(r"[^A-Z0-9]+", "_", key.upper()).strip("_")
+    if not env_key:
+        return base
+    in_price = _to_float(os.environ.get(f"KAOS_MODEL_PRICE_{env_key}_INPUT"), base[0])
+    out_price = _to_float(os.environ.get(f"KAOS_MODEL_PRICE_{env_key}_OUTPUT"), base[1])
+    return in_price, out_price
+
+
+def estimate_cost_usd(model: str, input_tokens: int, output_tokens: int) -> float:
+    """USD cost for a call given its model and token counts."""
+    in_price, out_price = _price_for(model)
+    return (input_tokens * in_price + output_tokens * out_price) / 1_000_000
+
+
+def _content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if content is None:
+        return ""
+    return str(content)
+
+
+def _extract_usage(response: Any) -> tuple[str, int, int]:
+    """Return (model, input_tokens, output_tokens) from an LLMResult.
+
+    Prefers per-message ``usage_metadata`` (provider-agnostic), falling back
+    to ``llm_output['token_usage']`` (OpenAI shape). Zeros mean the provider
+    reported nothing — the caller then estimates from text length.
+    """
+    model = ""
+    input_tokens = 0
+    output_tokens = 0
+
+    llm_output = getattr(response, "llm_output", None)
+    if isinstance(llm_output, dict):
+        model = str(llm_output.get("model_name") or llm_output.get("model") or "")
+        usage = llm_output.get("token_usage") or llm_output.get("usage") or {}
+        if isinstance(usage, dict):
+            input_tokens = int(usage.get("prompt_tokens") or usage.get("input_tokens") or 0)
+            output_tokens = int(usage.get("completion_tokens") or usage.get("output_tokens") or 0)
+
+    for batch in getattr(response, "generations", None) or []:
+        for generation in batch:
+            message = getattr(generation, "message", None)
+            if message is None:
+                continue
+            usage_metadata = getattr(message, "usage_metadata", None)
+            if isinstance(usage_metadata, dict) and (
+                usage_metadata.get("input_tokens") or usage_metadata.get("output_tokens")
+            ):
+                input_tokens = int(usage_metadata.get("input_tokens") or 0)
+                output_tokens = int(usage_metadata.get("output_tokens") or 0)
+            metadata = getattr(message, "response_metadata", None)
+            if not model and isinstance(metadata, dict):
+                model = str(metadata.get("model_name") or metadata.get("model") or "")
+
+    return model, input_tokens, output_tokens
+
+
+def _response_text_len(response: Any) -> int:
+    """Total characters of generated text, for the estimate fallback."""
+    total = 0
+    for batch in getattr(response, "generations", None) or []:
+        for generation in batch:
+            text = getattr(generation, "text", "") or ""
+            if not text:
+                message = getattr(generation, "message", None)
+                text = _content_text(getattr(message, "content", "")) if message else ""
+            total += len(text)
+    return total
+
+
+def record_llm_cost(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cost_usd: float,
+) -> None:
+    """Record one call's cost to the swarm ledger and the session guardian.
+
+    Agent and session come from the per-request audit context (set around the
+    model loop in ``graph.ainvoke``); the swarm write always has the agent
+    (falls back to ``settings.agent_name``), the session tally only fires when
+    a ``session_id`` is present. Both writes are best-effort.
+    """
+    context = get_tool_audit_context()
+    agent = context.get("agent") or settings.agent_name
+    session_id = context.get("session_id", "")
+
+    try:
+        from kronos.swarm_store import get_swarm
+
+        get_swarm().add_cost(
+            agent=agent,
+            cost_usd=cost_usd,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+    except Exception as e:  # pragma: no cover - defensive
+        log.debug("Swarm cost ledger write failed: %s", e)
+
+    if session_id:
+        try:
+            from kronos.security.cost_guardian import get_guardian
+
+            get_guardian().record_cost(session_id, cost_usd)
+        except Exception as e:  # pragma: no cover - defensive
+            log.debug("Guardian session cost record failed: %s", e)
+
+
+class CostTrackingCallbackHandler(BaseCallbackHandler):
+    """Record every LLM call's cost to the swarm ledger + session guardian."""
+
+    raise_error = False  # a metrics failure must never abort an LLM call
+
+    def __init__(self) -> None:
+        super().__init__()
+        # run_id -> input char count, kept only for the Codex estimate fallback.
+        self._pending_input_chars: dict[str, int] = {}
+
+    def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[Any]],
+        *,
+        run_id: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        chars = 0
+        for batch in messages or []:
+            for message in batch:
+                chars += len(_content_text(getattr(message, "content", "")))
+        if run_id is not None:
+            self._pending_input_chars[str(run_id)] = chars
+
+    def on_llm_start(
+        self,
+        serialized: dict[str, Any],
+        prompts: list[str],
+        *,
+        run_id: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        chars = sum(len(prompt) for prompt in prompts or [])
+        if run_id is not None:
+            self._pending_input_chars[str(run_id)] = chars
+
+    def on_llm_end(self, response: Any, *, run_id: Any = None, **kwargs: Any) -> None:
+        try:
+            model, input_tokens, output_tokens = _extract_usage(response)
+            if input_tokens == 0 and output_tokens == 0:
+                # Provider reported no usage (Codex CLI). Estimate from lengths.
+                input_chars = self._pending_input_chars.get(str(run_id), 0)
+                output_chars = _response_text_len(response)
+                input_tokens = math.ceil(input_chars / _CHARS_PER_TOKEN)
+                output_tokens = math.ceil(output_chars / _CHARS_PER_TOKEN)
+            cost = estimate_cost_usd(model, input_tokens, output_tokens)
+            record_llm_cost(model, input_tokens, output_tokens, cost)
+        except Exception as e:  # pragma: no cover - defensive
+            log.debug("Cost tracking failed: %s", e)
+        finally:
+            if run_id is not None:
+                self._pending_input_chars.pop(str(run_id), None)
+
+    def on_llm_error(self, error: BaseException, *, run_id: Any = None, **kwargs: Any) -> None:
+        if run_id is not None:
+            self._pending_input_chars.pop(str(run_id), None)
+
+
+_handler: CostTrackingCallbackHandler | None = None
+
+
+def get_cost_callbacks() -> list[BaseCallbackHandler]:
+    """The always-on cost callback (cached singleton), for model construction."""
+    global _handler
+    if _handler is None:
+        _handler = CostTrackingCallbackHandler()
+    return [_handler]

--- a/kronos/swarm_store.py
+++ b/kronos/swarm_store.py
@@ -314,6 +314,22 @@ def _schema(conn) -> None:
         );
         CREATE INDEX IF NOT EXISTS idx_memory_requests_intake
             ON memory_requests(to_agent, state, created_at);
+
+        -- Per-day, per-agent cost ledger. All six agents write here so the
+        -- daily budget is swarm-wide: one agent can't quietly burn the whole
+        -- limit on its own while the other five each read a private total.
+        -- UPSERT-incremented per LLM call by the cost-tracking callback and
+        -- read by CostGuardian for the daily cap.
+        CREATE TABLE IF NOT EXISTS swarm_costs (
+            day TEXT NOT NULL,
+            agent TEXT NOT NULL,
+            requests INTEGER NOT NULL DEFAULT 0,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            cost_usd REAL NOT NULL DEFAULT 0,
+            updated_at REAL NOT NULL,
+            PRIMARY KEY (day, agent)
+        );
         """
     )
 
@@ -897,6 +913,66 @@ class SwarmStore:
     def get_metrics(self) -> dict[str, int]:
         rows = self._db.read("SELECT metric, value FROM swarm_metrics")
         return {r["metric"]: int(r["value"]) for r in rows}
+
+    # ------------------------------------------------------------------
+    # Cost ledger — swarm-wide daily budget (shared across all agents)
+    # ------------------------------------------------------------------
+
+    def add_cost(
+        self,
+        *,
+        agent: str,
+        cost_usd: float,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        day: str = "",
+    ) -> None:
+        """Add one LLM call's cost to the shared per-day, per-agent ledger."""
+        bucket = day or time.strftime("%Y-%m-%d")
+        self._db.write(
+            """
+            INSERT INTO swarm_costs
+                (day, agent, requests, input_tokens, output_tokens, cost_usd, updated_at)
+            VALUES (?, ?, 1, ?, ?, ?, ?)
+            ON CONFLICT(day, agent) DO UPDATE SET
+                requests = requests + 1,
+                input_tokens = input_tokens + excluded.input_tokens,
+                output_tokens = output_tokens + excluded.output_tokens,
+                cost_usd = cost_usd + excluded.cost_usd,
+                updated_at = excluded.updated_at
+            """,
+            (bucket, agent, int(input_tokens), int(output_tokens), float(cost_usd), time.time()),
+        )
+
+    def daily_cost(self, day: str = "") -> dict:
+        """Swarm-wide cost totals for a day (default: today), summed over agents."""
+        bucket = day or time.strftime("%Y-%m-%d")
+        row = self._db.read_one(
+            """
+            SELECT COALESCE(SUM(cost_usd), 0) AS cost_usd,
+                   COALESCE(SUM(requests), 0) AS requests,
+                   COALESCE(SUM(input_tokens), 0) AS input_tokens,
+                   COALESCE(SUM(output_tokens), 0) AS output_tokens
+            FROM swarm_costs WHERE day = ?
+            """,
+            (bucket,),
+        )
+        return {
+            "date": bucket,
+            "cost_usd": round(float(row["cost_usd"]), 6) if row else 0.0,
+            "requests": int(row["requests"]) if row else 0,
+            "input_tokens": int(row["input_tokens"]) if row else 0,
+            "output_tokens": int(row["output_tokens"]) if row else 0,
+        }
+
+    def per_agent_daily_cost(self, day: str = "") -> dict[str, float]:
+        """Per-agent cost for a day → {agent: cost_usd}. For status/debug."""
+        bucket = day or time.strftime("%Y-%m-%d")
+        rows = self._db.read(
+            "SELECT agent, cost_usd FROM swarm_costs WHERE day = ? ORDER BY cost_usd DESC",
+            (bucket,),
+        )
+        return {r["agent"]: round(float(r["cost_usd"]), 6) for r in rows}
 
     # ------------------------------------------------------------------
     # Shared user facts — cross-agent view of the user

--- a/tests/test_cost_stats.py
+++ b/tests/test_cost_stats.py
@@ -80,9 +80,11 @@ def test_should_degrade_crosses_threshold(monkeypatch):
     from kronos.security import cost_guardian
 
     guardian = cost_guardian.CostGuardian(daily_limit=5.0)
-    monkeypatch.setattr(cost_guardian, "get_daily_cost", lambda: {"cost_usd": 4.5})  # 90%
+    # The daily total now comes from the shared swarm ledger, not the per-agent
+    # audit file — patch that source.
+    monkeypatch.setattr(cost_guardian, "_swarm_daily_cost", lambda: {"cost_usd": 4.5})  # 90%
     assert guardian.should_degrade() is True
-    monkeypatch.setattr(cost_guardian, "get_daily_cost", lambda: {"cost_usd": 1.0})  # 20%
+    monkeypatch.setattr(cost_guardian, "_swarm_daily_cost", lambda: {"cost_usd": 1.0})  # 20%
     assert guardian.should_degrade() is False
 
 

--- a/tests/test_cost_tracking.py
+++ b/tests/test_cost_tracking.py
@@ -1,0 +1,236 @@
+"""Tests for kronos.security.cost_tracking and the guardian/swarm wiring.
+
+Closes the review's "cost guardian is dead" finding:
+  * ``record_cost`` now has a caller (the always-on cost callback), so the
+    per-conversation session limit actually bites;
+  * the daily budget is swarm-wide (summed over all six agents' ledger rows),
+    not a per-process total each agent can blow independently;
+  * Codex calls (no provider-reported usage) fall back to a length estimate.
+
+The ``test_callback_records_through_model_ainvoke`` case is the important one:
+it drives a real ``model.ainvoke`` with the handler attached inside a set audit
+context and asserts the cost landed — proving the per-request ``session_id``
+actually reaches ``on_llm_end`` (the wiring the whole fix depends on).
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, LLMResult
+
+
+@pytest.fixture
+def cost_env(tmp_path, monkeypatch):
+    """Isolated swarm ledger + fresh guardian/handler singletons per test."""
+    swarm_path = tmp_path / "swarm.db"
+    db_dir = tmp_path / "agent"
+    db_dir.mkdir()
+
+    from kronos.config import settings
+    monkeypatch.setattr(settings, "swarm_db_path", str(swarm_path))
+    monkeypatch.setattr(settings, "db_dir", str(db_dir))
+    monkeypatch.setattr(settings, "db_path", str(db_dir / "session.db"))
+    monkeypatch.setattr(settings, "agent_name", "nexus")
+
+    import kronos.security.cost_guardian as cg
+    import kronos.security.cost_tracking as ct
+    import kronos.swarm_store as ss
+    from kronos import db as _db
+
+    _db._instances.clear()
+    ss._singleton = None
+    cg._guardian = None
+    ct._handler = None
+    yield
+    _db._instances.clear()
+    ss._singleton = None
+    cg._guardian = None
+    ct._handler = None
+
+
+# --------------------------------------------------------------------------
+# Pricing
+# --------------------------------------------------------------------------
+
+def test_pricing_known_default_codex_and_env(monkeypatch):
+    from kronos.security.cost_tracking import _price_for, estimate_cost_usd
+
+    assert _price_for("deepseek-chat") == (0.27, 1.10)
+    assert _price_for("gpt-5.5") == (0.0, 0.0)  # Codex OAuth = zero marginal
+    assert _price_for("totally-unknown-model") == (0.50, 1.50)  # default
+
+    # 1M input + 1M output at the DeepSeek rate.
+    assert estimate_cost_usd("deepseek-chat", 1_000_000, 1_000_000) == pytest.approx(1.37)
+    # A zero-priced model never accrues, whatever the token count.
+    assert estimate_cost_usd("gpt-5.5", 5_000_000, 5_000_000) == 0.0
+
+    monkeypatch.setenv("KAOS_MODEL_PRICE_DEEPSEEK_CHAT_INPUT", "1.00")
+    assert _price_for("deepseek-chat")[0] == 1.00
+
+
+# --------------------------------------------------------------------------
+# Usage extraction
+# --------------------------------------------------------------------------
+
+def test_extract_usage_prefers_usage_metadata():
+    from kronos.security.cost_tracking import _extract_usage
+
+    message = AIMessage(
+        content="hi",
+        usage_metadata={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+    )
+    result = LLMResult(
+        generations=[[ChatGeneration(message=message)]],
+        llm_output={"model_name": "deepseek-chat"},
+    )
+    assert _extract_usage(result) == ("deepseek-chat", 10, 5)
+
+
+def test_extract_usage_falls_back_to_llm_output_token_usage():
+    from kronos.security.cost_tracking import _extract_usage
+
+    message = AIMessage(content="hi")
+    result = LLMResult(
+        generations=[[ChatGeneration(message=message)]],
+        llm_output={
+            "model_name": "gpt-4.1-mini",
+            "token_usage": {"prompt_tokens": 20, "completion_tokens": 8},
+        },
+    )
+    assert _extract_usage(result) == ("gpt-4.1-mini", 20, 8)
+
+
+def test_handler_estimates_when_provider_reports_no_usage(cost_env):
+    """Codex CLI returns only text — estimate from stashed input + output len."""
+    from kronos.security.cost_tracking import get_cost_callbacks
+    from kronos.swarm_store import get_swarm
+
+    handler = get_cost_callbacks()[0]
+    run_id = "run-codex-1"
+    handler.on_chat_model_start(
+        {}, [[HumanMessage(content="x" * 350)]], run_id=run_id,
+    )
+    message = AIMessage(content="y" * 70, response_metadata={"model_name": "deepseek-chat"})
+    result = LLMResult(generations=[[ChatGeneration(message=message)]])
+    handler.on_llm_end(result, run_id=run_id)
+
+    daily = get_swarm().daily_cost()
+    # 350 chars / 3.5 = 100 input tokens, 70 / 3.5 = 20 output tokens.
+    assert daily["input_tokens"] == 100
+    assert daily["output_tokens"] == 20
+    assert daily["cost_usd"] > 0
+    # pending map is cleaned up after the call.
+    assert run_id not in handler._pending_input_chars
+
+
+# --------------------------------------------------------------------------
+# Recording wiring (swarm ledger + session guardian)
+# --------------------------------------------------------------------------
+
+def test_record_llm_cost_updates_swarm_and_session(cost_env):
+    from kronos.audit import reset_tool_audit_context, set_tool_audit_context
+    from kronos.security.cost_guardian import get_guardian
+    from kronos.security.cost_tracking import record_llm_cost
+    from kronos.swarm_store import get_swarm
+
+    token = set_tool_audit_context(agent="nexus", session_id="12345", thread_id="12345", user_id="u")
+    try:
+        record_llm_cost("deepseek-chat", 1_000_000, 0, 0.27)
+    finally:
+        reset_tool_audit_context(token)
+
+    assert get_swarm().daily_cost()["cost_usd"] == pytest.approx(0.27)
+    assert get_guardian()._session_costs["12345"] == pytest.approx(0.27)
+
+
+def test_record_llm_cost_without_session_still_logs_daily(cost_env):
+    """No session in context (e.g. cron/digest) → daily ledger still updated."""
+    from kronos.security.cost_guardian import get_guardian
+    from kronos.security.cost_tracking import record_llm_cost
+    from kronos.swarm_store import get_swarm
+
+    record_llm_cost("deepseek-chat", 0, 1_000_000, 1.10)  # no audit context set
+
+    assert get_swarm().daily_cost()["cost_usd"] == pytest.approx(1.10)
+    assert get_guardian()._session_costs == {}
+
+
+# --------------------------------------------------------------------------
+# Guardian limits
+# --------------------------------------------------------------------------
+
+def test_session_limit_enforced_after_record(cost_env):
+    from kronos.security.cost_guardian import get_guardian
+
+    guardian = get_guardian()
+    allowed, _ = guardian.check_budget(session_id="s1")
+    assert allowed
+
+    guardian.record_cost("s1", 1.5)  # over the $1 session limit
+    allowed, reason = guardian.check_budget(session_id="s1")
+    assert not allowed
+    assert "Session cost limit" in reason
+
+
+def test_daily_limit_is_swarm_wide(cost_env):
+    from kronos.security.cost_guardian import get_guardian
+    from kronos.swarm_store import get_swarm
+
+    swarm = get_swarm()
+    # Two different agents each add cost; the daily cap sees the sum.
+    swarm.add_cost(agent="nexus", cost_usd=3.0)
+    swarm.add_cost(agent="lacuna", cost_usd=3.0)
+
+    allowed, reason = get_guardian().check_budget(session_id="s1")
+    assert not allowed  # 6.0 >= 5.0 daily limit
+    assert "Daily cost limit" in reason
+
+
+def test_add_cost_upserts_and_separates_days(cost_env):
+    from kronos.swarm_store import get_swarm
+
+    swarm = get_swarm()
+    swarm.add_cost(agent="nexus", cost_usd=0.1, input_tokens=10, output_tokens=5)
+    swarm.add_cost(agent="nexus", cost_usd=0.2, input_tokens=20, output_tokens=5)
+
+    today = swarm.daily_cost()
+    assert today["cost_usd"] == pytest.approx(0.3)
+    assert today["requests"] == 2
+    assert today["input_tokens"] == 30
+
+    swarm.add_cost(agent="nexus", cost_usd=9.9, day="2000-01-01")
+    assert swarm.daily_cost()["cost_usd"] == pytest.approx(0.3)  # today untouched
+    assert swarm.daily_cost(day="2000-01-01")["cost_usd"] == pytest.approx(9.9)
+    assert swarm.per_agent_daily_cost()["nexus"] == pytest.approx(0.3)
+
+
+# --------------------------------------------------------------------------
+# End-to-end: the ContextVar must reach on_llm_end through model.ainvoke
+# --------------------------------------------------------------------------
+
+async def test_callback_records_through_model_ainvoke(cost_env):
+    from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+
+    from kronos.audit import reset_tool_audit_context, set_tool_audit_context
+    from kronos.security.cost_guardian import get_guardian
+    from kronos.security.cost_tracking import get_cost_callbacks
+    from kronos.swarm_store import get_swarm
+
+    reply = AIMessage(
+        content="pong",
+        usage_metadata={"input_tokens": 100, "output_tokens": 50, "total_tokens": 150},
+        response_metadata={"model_name": "deepseek-chat"},
+    )
+    model = FakeMessagesListChatModel(responses=[reply])
+    handler = get_cost_callbacks()[0]
+
+    token = set_tool_audit_context(agent="nexus", session_id="chat-1", thread_id="chat-1", user_id="u")
+    try:
+        await model.ainvoke([HumanMessage(content="ping")], config={"callbacks": [handler]})
+    finally:
+        reset_tool_audit_context(token)
+
+    # Cost reached BOTH ledgers → session_id propagated into on_llm_end.
+    assert get_swarm().daily_cost()["cost_usd"] > 0
+    assert get_guardian()._session_costs.get("chat-1", 0) > 0

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -168,13 +168,20 @@ def test_get_model_uses_openai_compatible_adapter(monkeypatch):
     model = get_model(ModelTier.STANDARD)
 
     assert isinstance(model, FakeChatOpenAI)
-    assert calls == [{
+    assert len(calls) == 1
+    kwargs = dict(calls[0])
+    # The always-on cost-tracking callback is attached to every model.
+    from kronos.security.cost_tracking import CostTrackingCallbackHandler
+
+    callbacks = kwargs.pop("callbacks", [])
+    assert any(isinstance(cb, CostTrackingCallbackHandler) for cb in callbacks)
+    assert kwargs == {
         "model": "my-model",
         "api_key": "sk-test",
         "max_tokens": 4096,
         "temperature": 0.5,
         "base_url": "https://llm.example.com/v1",
-    }]
+    }
     reset_provider_state()
 
 


### PR DESCRIPTION
## Problem

The cost guardian was effectively dead and the daily budget was wrong (review P1):

- **`record_cost()` had no caller** → the per-conversation session limit never fired (`_session_costs` stayed empty forever).
- **`get_daily_cost()` read a per-agent audit file** → each of the six agents independently allowed up to the daily limit, so the swarm could spend ~6× the cap.
- **Cost came from one top-level estimate** (`len/3.5`) at a single tier — blind to every nested LLM call (sub-agents, memory, router, digest) and mispriced (Codex orchestrator billed at DeepSeek rates).

## Fix

An always-on `on_llm_end` cost callback attached to **every** model the factory builds (including the Codex CLI adapter). Since all internal LLM users go through `get_model`/`get_orchestrator_model`, this captures the whole swarm's spend automatically.

- **Real token usage** from `usage_metadata` / `llm_output['token_usage']` (OpenAI, DeepSeek). Codex reports no usage → estimate from prompt/response length (same 3.5 chars/token heuristic as the audit log).
- **Pricing per model**, env-overridable (`KAOS_MODEL_PRICE_<MODEL>_INPUT/_OUTPUT`). Codex runs on a ChatGPT OAuth subscription (flat-rate) → zero marginal, so the budget tracks real API spend (DeepSeek).
- **New shared `swarm_costs` ledger** (per day, per agent) → the daily cap is swarm-wide, summed across all six processes.
- **`record_cost()` now called** from the callback with the `session_id` from the per-request audit context → the session limit actually bites.

## Safety

- The callback never raises into an LLM call (accounting failure is logged at debug and swallowed).
- The daily read fails open (zeros) — a metrics glitch can't wedge an agent by pretending the budget is blown.
- New table is `CREATE TABLE IF NOT EXISTS`; no migration. Budget accounting starts fresh from deploy (historical estimate file is not migrated — by design).

## Tests

`tests/test_cost_tracking.py` (+ updates to two pre-existing tests reflecting the new source/callback):
- pricing (known / default / Codex-zero / env override), usage extraction (usage_metadata + llm_output), Codex estimate fallback.
- session limit enforced after record; daily limit swarm-wide (summed across agents); UPSERT increment + per-day separation.
- **`test_callback_records_through_model_ainvoke`** drives a real `model.ainvoke` with the handler attached inside a set audit context and asserts the cost landed — proving `session_id` reaches `on_llm_end`.

724 passed (non-integration), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)