### PR TITLE
dashboard security: HttpOnly cookie auth, no token in URL, login rate-limit

### DIFF
--- a/dashboard-ui/src/App.tsx
+++ b/dashboard-ui/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom';
-import { getToken, setToken, api } from './api/client';
+import { login as apiLogin, logout as apiLogout, checkAuth, api } from './api/client';
 import FleetPage from './pages/FleetPage';
 import OverviewPage from './pages/OverviewPage';
 import PersonaPage from './pages/PersonaPage';
@@ -32,17 +32,10 @@ function Login() {
     setLoading(true);
     setError('');
     try {
-      const res = await fetch(`${import.meta.env.VITE_API_URL || ''}/api/auth/login`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password }),
-      });
-      if (!res.ok) { setError('Invalid credentials'); setLoading(false); return; }
-      const data = await res.json();
-      setToken(data.token);
+      await apiLogin(username, password);
       window.location.reload();
-    } catch {
-      setError('Connection failed');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Connection failed');
       setLoading(false);
     }
   };
@@ -285,7 +278,7 @@ function Layout({ children }: { children: React.ReactNode }) {
         <div style={{ padding: '0.75rem 0.5rem', borderTop: '1px solid #1a1a1a', marginTop: '0.5rem' }}>
           <div style={{ fontSize: '0.65rem', color: '#333', marginBottom: '0.5rem' }}>{version ? `v${version} · ` : ''}Kronos Agent OS</div>
           <button
-            onClick={() => { localStorage.removeItem('kronos_token'); window.location.reload(); }}
+            onClick={() => { apiLogout().finally(() => window.location.reload()); }}
             style={{
               background: 'none', border: '1px solid #1a1a1a', borderRadius: '6px',
               color: '#555', cursor: 'pointer', fontSize: '0.75rem', padding: '0.35rem 0.75rem',
@@ -306,7 +299,19 @@ function Layout({ children }: { children: React.ReactNode }) {
 /* ── App ── */
 
 export default function App() {
-  if (!getToken()) return <Login />;
+  // The session cookie is HttpOnly, so JS can't read it — probe /api/auth/me
+  // on load to decide between the app and the login screen.
+  const [authed, setAuthed] = useState<boolean | null>(null);
+  useEffect(() => { checkAuth().then(setAuthed); }, []);
+
+  if (authed === null) {
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh', background: '#09090b', color: '#555' }}>
+        Loading…
+      </div>
+    );
+  }
+  if (!authed) return <Login />;
   return (
     <BrowserRouter>
       <Layout>

--- a/dashboard-ui/src/api/client.ts
+++ b/dashboard-ui/src/api/client.ts
@@ -1,30 +1,54 @@
 const API_BASE = import.meta.env.VITE_API_URL || '';
 
-let token = localStorage.getItem('kronos_token') || '';
-
-export function setToken(t: string) {
-  token = t;
-  localStorage.setItem('kronos_token', t);
-}
-
-export function getToken(): string {
-  return token;
-}
+// Auth is a same-origin HttpOnly session cookie: the browser attaches it
+// automatically, so requests just need `credentials: 'include'`. The token is
+// never held in JS/localStorage (an XSS can't read an HttpOnly cookie).
 
 export async function api<T = any>(path: string, options?: RequestInit): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
     ...options,
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`,
       ...(options?.headers || {}),
     },
   });
   if (res.status === 401) {
-    localStorage.removeItem('kronos_token');
+    // Session expired/invalid — reload lands on the login screen.
     window.location.reload();
     throw new Error('Unauthorized');
   }
   if (!res.ok) throw new Error(`${res.status}: ${await res.text()}`);
   return res.json();
+}
+
+export async function login(username: string, password: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/auth/login`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      res.status === 429 ? 'Too many attempts. Try again later.' : 'Invalid credentials',
+    );
+  }
+}
+
+export async function logout(): Promise<void> {
+  try {
+    await fetch(`${API_BASE}/api/auth/logout`, { method: 'POST', credentials: 'include' });
+  } catch {
+    // Best-effort: the subsequent reload lands on the login screen regardless.
+  }
+}
+
+export async function checkAuth(): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE}/api/auth/me`, { credentials: 'include' });
+    return res.ok;
+  } catch {
+    return false;
+  }
 }

--- a/dashboard-ui/src/pages/LogsPage.tsx
+++ b/dashboard-ui/src/pages/LogsPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import { getToken } from '../api/client';
 import { StatusBadge } from '../components/Charts';
 
 export default function LogsPage() {
@@ -10,7 +9,9 @@ export default function LogsPage() {
   const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const wsUrl = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws/logs?token=${encodeURIComponent(getToken())}`;
+    // Auth rides on the same-origin HttpOnly session cookie, sent automatically
+    // on the WS handshake — no token in the URL (which proxy logs would capture).
+    const wsUrl = `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/ws/logs`;
     const ws = new WebSocket(wsUrl);
 
     ws.onopen = () => setConnected(true);

--- a/dashboard/api/health.py
+++ b/dashboard/api/health.py
@@ -2,13 +2,33 @@
 
 import time
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from pydantic import BaseModel
 
-from dashboard.auth import create_session, verify_credentials
+from dashboard.auth import (
+    clear_login_failures,
+    clear_session_cookie,
+    create_session,
+    invalidate_session,
+    login_retry_after,
+    record_login_failure,
+    set_session_cookie,
+    verify_credentials,
+    verify_token,
+)
 from kronos.config import settings
 
 router = APIRouter(tags=["health"])
+
+
+def _client_ip(request: Request) -> str:
+    return request.client.host if request.client else "unknown"
+
+
+def _cookie_secure(request: Request) -> bool:
+    """Set the Secure flag when the request arrived over TLS (directly or via
+    a TLS-terminating proxy that forwards X-Forwarded-Proto)."""
+    return request.url.scheme == "https" or request.headers.get("x-forwarded-proto", "") == "https"
 
 _start_time = time.time()
 
@@ -31,9 +51,45 @@ async def health():
 
 
 @router.post("/api/auth/login")
-async def login(body: LoginRequest):
-    """Authenticate with username/password, returns session token."""
+async def login(body: LoginRequest, request: Request, response: Response):
+    """Authenticate with username/password; set the session cookie.
+
+    Rate-limited per client IP. The token is delivered only as an HttpOnly
+    cookie — it is deliberately not returned in the body, so it never reaches
+    JavaScript or a browser's storage.
+    """
+    ip = _client_ip(request)
+    retry_after = login_retry_after(ip)
+    if retry_after:
+        raise HTTPException(
+            status_code=429,
+            detail="Too many login attempts. Try again later.",
+            headers={"Retry-After": str(retry_after)},
+        )
+
     if not verify_credentials(body.username, body.password):
+        record_login_failure(ip)
         raise HTTPException(status_code=401, detail="Invalid credentials")
+
+    clear_login_failures(ip)
     token = create_session()
-    return {"token": token}
+    set_session_cookie(response, token, secure=_cookie_secure(request))
+    return {"ok": True}
+
+
+@router.post("/api/auth/logout")
+async def logout(response: Response, token: str = Depends(verify_token)):
+    """Invalidate the current session and clear the cookie."""
+    invalidate_session(token)
+    clear_session_cookie(response)
+    return {"ok": True}
+
+
+@router.get("/api/auth/me")
+async def me(token: str = Depends(verify_token)):
+    """Lightweight auth probe — 200 when the session cookie is valid, else 401.
+
+    The SPA calls this on load to decide whether to show the app or the login
+    screen, since it can no longer read the HttpOnly cookie itself.
+    """
+    return {"authenticated": True}

--- a/dashboard/auth.py
+++ b/dashboard/auth.py
@@ -1,18 +1,34 @@
-"""Session-based auth with login/password."""
+"""Session-based auth with login/password.
+
+The session token lives in an ``HttpOnly``, ``SameSite=Strict`` cookie, not in
+JavaScript-readable storage: an XSS on the dashboard (which renders agent
+output) cannot exfiltrate it, and it never travels in a URL/query string where
+proxy and access logs would capture it. A ``Bearer`` header is still accepted
+so scripts/curl can authenticate. Login is rate-limited per client IP to blunt
+password brute-forcing.
+"""
 
 import secrets
 import time
 
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, Request, Response
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from dashboard.config import DASHBOARD_PASSWORD, DASHBOARD_USERNAME
 
 security = HTTPBearer(auto_error=False)
 
+# Name of the session cookie set on login and read on every authed request.
+COOKIE_NAME = "kronos_session"
+
 # Active sessions: token -> expiry timestamp
 _sessions: dict[str, float] = {}
 SESSION_TTL = 7 * 24 * 3600  # 7 days
+
+# Failed-login throttling (brute-force mitigation), keyed by client IP.
+LOGIN_WINDOW_SECONDS = 900  # 15 minutes
+LOGIN_MAX_FAILURES = 10  # failures within the window before lockout
+_login_failures: dict[str, list[float]] = {}
 
 
 def create_session() -> str:
@@ -49,15 +65,59 @@ def verify_session_token(token: str) -> bool:
     return True
 
 
+def invalidate_session(token: str) -> None:
+    """Drop a session token (logout) so a stolen cookie stops working."""
+    _sessions.pop(token, None)
+
+
+def login_retry_after(ip: str) -> int:
+    """Seconds until ``ip`` may retry login, or 0 if it is not locked out."""
+    now = time.time()
+    recent = [t for t in _login_failures.get(ip, []) if t > now - LOGIN_WINDOW_SECONDS]
+    if len(recent) < LOGIN_MAX_FAILURES:
+        return 0
+    return max(1, int(recent[0] + LOGIN_WINDOW_SECONDS - now))
+
+
+def record_login_failure(ip: str) -> None:
+    """Record one failed login for ``ip``, pruning entries outside the window."""
+    now = time.time()
+    recent = [t for t in _login_failures.get(ip, []) if t > now - LOGIN_WINDOW_SECONDS]
+    recent.append(now)
+    _login_failures[ip] = recent
+
+
+def clear_login_failures(ip: str) -> None:
+    """Reset the failure count for ``ip`` after a successful login."""
+    _login_failures.pop(ip, None)
+
+
+def set_session_cookie(response: Response, token: str, *, secure: bool) -> None:
+    """Attach the session cookie: HttpOnly + SameSite=Strict (+ Secure on TLS)."""
+    response.set_cookie(
+        key=COOKIE_NAME,
+        value=token,
+        max_age=SESSION_TTL,
+        httponly=True,
+        samesite="strict",
+        secure=secure,
+        path="/",
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    """Expire the session cookie (logout)."""
+    response.delete_cookie(key=COOKIE_NAME, path="/", samesite="strict")
+
+
 async def verify_token(
+    request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> str:
-    """Verify Bearer session token."""
-    if not credentials:
+    """Verify the session token from the HttpOnly cookie or a Bearer header."""
+    token = request.cookies.get(COOKIE_NAME) or (credentials.credentials if credentials else "")
+    if not token:
         raise HTTPException(status_code=401, detail="Not authenticated")
-
-    token = credentials.credentials
     if not verify_session_token(token):
         raise HTTPException(status_code=401, detail="Session expired")
-
     return token

--- a/dashboard/ws/handlers.py
+++ b/dashboard/ws/handlers.py
@@ -5,7 +5,7 @@ import logging
 
 from fastapi import WebSocket, WebSocketDisconnect
 
-from dashboard.auth import verify_session_token
+from dashboard.auth import COOKIE_NAME, verify_session_token
 from kronos.logging import add_pii_filter
 
 # Connected WebSocket clients for log streaming
@@ -44,12 +44,14 @@ def install_log_handler() -> None:
 async def ws_logs(websocket: WebSocket) -> None:
     """WebSocket endpoint for live log streaming.
 
-    Requires a valid dashboard session token via the ``token`` query
-    parameter — logs carry message texts and tool arguments, so the stream
-    must not be readable by unauthenticated clients. The check runs before
-    ``accept()``, rejecting the handshake outright.
+    Requires a valid dashboard session via the HttpOnly session cookie (sent
+    automatically by the browser on the same-origin handshake) — logs carry
+    message texts and tool arguments, so the stream must not be readable by
+    unauthenticated clients. The check runs before ``accept()``, rejecting the
+    handshake outright, and keeps the token out of the URL/query string where
+    proxy logs would capture it.
     """
-    if not verify_session_token(websocket.query_params.get("token", "")):
+    if not verify_session_token(websocket.cookies.get(COOKIE_NAME, "")):
         await websocket.close(code=4401)
         return
 

--- a/tests/test_dashboard_auth.py
+++ b/tests/test_dashboard_auth.py
@@ -1,0 +1,83 @@
+"""Dashboard auth hardening: HttpOnly cookie flow, login rate-limit, logout/me.
+
+Covers the review's dashboard-security findings:
+  * the session token is delivered only as an HttpOnly + SameSite=Strict cookie
+    (never in the response body, so it can't reach localStorage/JS);
+  * login is rate-limited per IP to blunt password brute-forcing;
+  * logout invalidates the server-side session, and /me is the SPA's auth probe.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(monkeypatch):
+    import dashboard.auth as auth
+
+    monkeypatch.setattr(auth, "DASHBOARD_USERNAME", "admin")
+    monkeypatch.setattr(auth, "DASHBOARD_PASSWORD", "s3cret")
+    auth._sessions.clear()
+    auth._login_failures.clear()
+
+    from dashboard.server import create_app
+
+    return TestClient(create_app())
+
+
+def test_login_sets_httponly_samesite_cookie_and_no_token_in_body(client):
+    from dashboard.auth import COOKIE_NAME
+
+    res = client.post("/api/auth/login", json={"username": "admin", "password": "s3cret"})
+
+    assert res.status_code == 200
+    assert res.json() == {"ok": True}  # token is NOT in the body
+    assert res.cookies.get(COOKIE_NAME)  # ...it's a cookie instead
+
+    set_cookie = res.headers.get("set-cookie", "").lower()
+    assert "httponly" in set_cookie
+    assert "samesite=strict" in set_cookie
+
+
+def test_me_requires_valid_cookie(client):
+    assert client.get("/api/auth/me").status_code == 401
+
+    client.post("/api/auth/login", json={"username": "admin", "password": "s3cret"})
+    res = client.get("/api/auth/me")  # cookie carried by the client jar
+
+    assert res.status_code == 200
+    assert res.json()["authenticated"] is True
+
+
+def test_logout_invalidates_session(client):
+    client.post("/api/auth/login", json={"username": "admin", "password": "s3cret"})
+    assert client.get("/api/auth/me").status_code == 200
+
+    assert client.post("/api/auth/logout").status_code == 200
+
+    from dashboard.auth import _sessions
+
+    assert _sessions == {}  # server-side session dropped
+    assert client.get("/api/auth/me").status_code == 401  # stale cookie no longer valid
+
+
+def test_bad_password_is_rejected_without_cookie(client):
+    from dashboard.auth import COOKIE_NAME
+
+    res = client.post("/api/auth/login", json={"username": "admin", "password": "wrong"})
+
+    assert res.status_code == 401
+    assert res.cookies.get(COOKIE_NAME) is None
+
+
+def test_login_rate_limited_after_repeated_failures(client):
+    from dashboard.auth import LOGIN_MAX_FAILURES
+
+    for _ in range(LOGIN_MAX_FAILURES):
+        res = client.post("/api/auth/login", json={"username": "admin", "password": "wrong"})
+        assert res.status_code == 401
+
+    # Further attempts are throttled — even with the CORRECT password.
+    res = client.post("/api/auth/login", json={"username": "admin", "password": "s3cret"})
+    assert res.status_code == 429
+    assert "retry-after" in {k.lower() for k in res.headers}

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -20,29 +20,40 @@ def test_spa_static_files_falls_back_to_index_for_client_routes(tmp_path):
     assert asset.text == "asset"
 
 
-def test_ws_logs_rejects_missing_or_invalid_token():
+def test_ws_logs_rejects_missing_or_invalid_cookie():
     import pytest
     from starlette.websockets import WebSocketDisconnect
 
+    from dashboard.auth import COOKIE_NAME
     from dashboard.server import create_app
 
-    client = TestClient(create_app())
+    app = create_app()
 
-    for path in ("/ws/logs", "/ws/logs?token=bogus"):
-        with pytest.raises(WebSocketDisconnect) as exc_info:
-            with client.websocket_connect(path):
-                pass
-        assert exc_info.value.code == 4401
+    # No session cookie.
+    no_cookie = TestClient(app)
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with no_cookie.websocket_connect("/ws/logs"):
+            pass
+    assert exc_info.value.code == 4401
+
+    # Bogus session cookie.
+    bad_cookie = TestClient(app)
+    bad_cookie.cookies.set(COOKIE_NAME, "bogus")
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with bad_cookie.websocket_connect("/ws/logs"):
+            pass
+    assert exc_info.value.code == 4401
 
 
-def test_ws_logs_accepts_valid_session_token():
-    from dashboard.auth import create_session
+def test_ws_logs_accepts_valid_session_cookie():
+    from dashboard.auth import COOKIE_NAME, create_session
     from dashboard.server import create_app
     from dashboard.ws.handlers import log_clients
 
     client = TestClient(create_app())
     token = create_session()
+    client.cookies.set(COOKIE_NAME, token)
 
-    with client.websocket_connect(f"/ws/logs?token={token}"):
+    with client.websocket_connect("/ws/logs"):
         assert len(log_clients) == 1
     assert not log_clients


### PR DESCRIPTION
## Problem

The dashboard renders agent output, so an **XSS there is a real vector** — yet the session token lived in **localStorage** (JS-readable) and rode in the **`/ws/logs` URL** as a `?token=` query param (captured by proxy/access logs). Login had **no brute-force protection**.

## Fix — HttpOnly, SameSite=Strict session cookie

- **Login** sets the cookie and no longer returns the token in the body → it never reaches JavaScript or browser storage; an XSS can't exfiltrate it.
- **WS log stream** authenticates from that cookie (sent automatically on the same-origin handshake) instead of a `?token=` query param → the token stays out of URLs/logs. Rejection still happens **before `accept()`**.
- **`/api/auth/logout`** invalidates the server-side session and clears the cookie; **`/api/auth/me`** is the SPA's auth probe (it can't read the HttpOnly cookie itself).
- **Login rate-limit** per client IP (10 failures / 15 min → `429` + `Retry-After`).
- `SameSite=Strict` blocks CSRF on the cookie; `verify_token` still accepts a **Bearer** header so scripts/curl keep working; `Secure` is set when the request arrives over TLS (directly or via `X-Forwarded-Proto`).

**Frontend** drops localStorage entirely: requests use `credentials:'include'`, the app gates on an async `/me` probe, and the WS URL carries no token.

## Tests

`tests/test_dashboard_auth.py` — cookie flags (HttpOnly + SameSite=Strict), no-token-in-body, rate-limit lockout (correct password still `429` after N failures), logout invalidation, `/me` probe. `tests/test_dashboard_server.py` updated to cookie-based WS auth.

730 passed (non-integration), ruff clean, `dashboard-ui` builds (`tsc -b && vite build`).

## Not included (out of scope per plan)

Multi-user hardening (Discord allowlist / SSRF / peer-registry) — deferred to public-mode work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)