### PR TITLE
deps: add uv.lock for reproducible Python installs + CI freshness gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,18 @@ jobs:
       - run: pip install ruff
       - run: ruff check kronos/ dashboard/ aso/ tests/
 
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install uv
+      # Fails if uv.lock is stale vs pyproject.toml — keeps the pinned
+      # dependency tree in sync so `uv sync` installs are reproducible.
+      - run: uv lock --check
+
   test:
     runs-on: ubuntu-latest
     needs: lint


### PR DESCRIPTION
## Problem

The frontend was already locked (`dashboard-ui/package-lock.json` + `npm ci`), but the Python side installed from `>=` constraints resolved fresh on every run — two installs (dev, CI, prod) could pull different transitive versions. No reproducibility, no drift detection.

## Fix

- **`uv.lock`** — 180 packages pinned across all extras (`dev`, `documents`), universal (cross-platform markers). `uv sync` now gives a reproducible install.
- **`lockfile` CI job** — `uv lock --check` fails when `uv.lock` drifts from `pyproject.toml`, so changing a dependency without regenerating the lock is caught in CI. A lock nobody enforces silently goes stale and misleads.

Install paths are **unchanged**: CI and `deploy.sh` still use `pip install -e`. The lock is the source of truth for exact versions and an opt-in reproducible path (`uv sync`), not a new required install mechanism.

To refresh after a dependency change: `uv lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)