### PR TITLE
approval: enforce tool approval inside sub-agents (nested durable pause)

### DIFF
--- a/kronos/agents/supervisor.py
+++ b/kronos/agents/supervisor.py
@@ -12,6 +12,7 @@ Routes requests to:
 No LangGraph — uses LLM tool-calling for routing decisions.
 """
 
+import inspect
 import json
 import logging
 from collections.abc import Callable
@@ -31,7 +32,14 @@ from kronos.agents.task import create_task_agent
 from kronos.agents.telegram_channels import create_telegram_channels_agent
 from kronos.agents.topic_research.graph import create_topic_research_agent
 from kronos.config import settings
-from kronos.engine import AgentResult, react_loop
+from kronos.engine import (
+    AgentResult,
+    SubAgentApprovalPause,
+    delegation_ctx,
+    enter_delegation,
+    exit_delegation,
+    react_loop,
+)
 from kronos.llm import get_orchestrator_model
 
 log = logging.getLogger("kronos.agents.supervisor")
@@ -103,6 +111,21 @@ SUPERVISOR_PROMPT = """Ты — Supervisor в системе Kronos (персо�
 {persona_context}"""
 
 
+def _accepts_approval_hooks(fn: Callable) -> bool:
+    """Whether ``fn`` takes the approval-callback kwargs (create_agent's run does).
+
+    Custom sub-agent graphs (deep_research, topic_research, knowledge_pipeline)
+    have their own signatures; we don't force the kwargs on them.
+    """
+    try:
+        params = inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return False
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        return True
+    return "request_tool_approval" in params
+
+
 def _make_delegation_tool(agent_name: str, description: str, agent_fn: Callable) -> StructuredTool:
     """Create a delegation tool that routes to a sub-agent."""
 
@@ -112,12 +135,40 @@ def _make_delegation_tool(agent_name: str, description: str, agent_fn: Callable)
         Args:
             request: The full user request to delegate.
         """
+        # If the parent turn has an approval channel, hand it to the sub-agent so
+        # its approval-worthy tools pause too (instead of silently executing),
+        # and record which delegate_to_X call we're inside so the resume can
+        # re-run it with the approved call exempted.
+        ctx = delegation_ctx()
+        hooks: dict[str, Any] = {}
+        active_token = None
+        if ctx and ctx.get("request_tool_approval") and _accepts_approval_hooks(agent_fn):
+            hooks = {
+                "needs_tool_approval": ctx.get("needs_tool_approval"),
+                "request_tool_approval": ctx.get("request_tool_approval"),
+            }
+            active_token = enter_delegation({
+                "tool_name": ctx.get("tool_name", f"delegate_to_{agent_name}"),
+                "tool_call_id": ctx.get("tool_call_id", ""),
+                "request": request,
+            })
         try:
-            result = await agent_fn([HumanMessage(content=request)])
+            result = await agent_fn([HumanMessage(content=request)], **hooks)
+            if getattr(result, "waiting_approval", False):
+                # The sub-agent paused for approval — bubble it up so the whole
+                # turn pauses rather than returning half-done text here.
+                raise SubAgentApprovalPause(
+                    result.approval_id, result.approval_tool_name or ""
+                )
             return result.content
+        except SubAgentApprovalPause:
+            raise
         except Exception as e:
             log.error("Agent '%s' failed: %s", agent_name, e)
             return f"Агент {agent_name} недоступен: {e}"
+        finally:
+            if active_token is not None:
+                exit_delegation(active_token)
 
     tool_name = f"delegate_to_{agent_name}"
     return StructuredTool.from_function(

--- a/kronos/engine.py
+++ b/kronos/engine.py
@@ -13,6 +13,7 @@ import inspect
 import logging
 import time
 from collections.abc import Callable
+from contextvars import ContextVar
 from dataclasses import asdict, dataclass, is_dataclass
 from typing import Any
 
@@ -35,6 +36,67 @@ ToolCacheGetCallback = Callable[[str], Any]
 ToolCacheSaveCallback = Callable[[str, str], Any]
 ToolApprovalPredicate = Callable[[BaseTool, dict], Any]
 ToolApprovalRequestCallback = Callable[[BaseTool, dict], Any]
+
+
+class SubAgentApprovalPause(Exception):  # noqa: N818 - control-flow signal, not an error
+    """Raised by a delegation tool when its sub-agent paused for approval.
+
+    A sub-agent runs inside the parent's ``delegate_to_X`` tool call, so an
+    approval it needs would otherwise be swallowed at that boundary (the tool
+    would just return text and the parent loop would continue). This exception
+    carries the pending approval up so the whole turn pauses: the delegate_to_X
+    call is left unanswered and re-run on resume with the approved call exempted.
+    """
+
+    def __init__(self, approval_id: str, tool_name: str):
+        super().__init__(f"sub-agent approval pending: {tool_name}")
+        self.approval_id = approval_id
+        self.tool_name = tool_name
+
+
+# Published by react_loop immediately before it runs a tool, so a delegation
+# tool can read the parent's approval hooks and its own delegate_to_X call
+# context (name/id/request). A delegation tool reads it synchronously at entry,
+# before its sub-agent runs, so no reset is needed — the next tool overwrites it.
+_delegation_ctx: ContextVar[dict | None] = ContextVar("delegation_ctx", default=None)
+# Set by a delegation tool around its sub-agent run: the frozen delegate_to_X
+# context, read by the approval-request callback to tag a nested approval so the
+# resume can re-run that delegation with the approved sub-call exempted.
+_active_delegation: ContextVar[dict | None] = ContextVar("active_delegation", default=None)
+
+
+def delegation_ctx() -> dict | None:
+    """Parent approval hooks + current tool call, for delegation tools."""
+    return _delegation_ctx.get()
+
+
+def current_delegation() -> dict | None:
+    """The delegate_to_X context we're executing inside, or None."""
+    return _active_delegation.get()
+
+
+def enter_delegation(ctx: dict) -> Any:
+    """Mark that we're running inside a delegate_to_X call; returns a reset token."""
+    return _active_delegation.set(ctx)
+
+
+def exit_delegation(token: Any) -> None:
+    """Clear the active-delegation marker set by :func:`enter_delegation`."""
+    _active_delegation.reset(token)
+
+
+def publish_delegation_ctx(ctx: dict) -> Any:
+    """Publish the delegation context (parent hooks + call info); returns a token.
+
+    react_loop publishes this before each tool; the resume path uses it to
+    re-run a delegation with the approved sub-call exempted."""
+    return _delegation_ctx.set(ctx)
+
+
+def clear_delegation_ctx(token: Any) -> None:
+    """Undo a :func:`publish_delegation_ctx`."""
+    _delegation_ctx.reset(token)
+
 
 RAW_TOOL_CONTENT_KEY = "raw_content"
 MODEL_OUTPUT_MAX_CHARS = 2400
@@ -290,6 +352,10 @@ async def execute_tool(
             # audit journal) stays the unwrapped original.
             content = wrap_untrusted(content, label=f"tool:{tool.name}")
 
+    except SubAgentApprovalPause:
+        # A delegated sub-agent needs approval — propagate so react_loop pauses
+        # the whole turn rather than recording this as a tool error/result.
+        raise
     except TimeoutError:
         content = f"[ERROR] Tool '{tool.name}' timed out after {TOOL_TIMEOUT_SECONDS}s"
         raw_content = content
@@ -569,7 +635,51 @@ async def react_loop(
                         await write_tool_result(tool_call_id, str(tm.content))
                     else:
                         log.info("Executing tool: %s (args: %s)", tool_name, str(tc.get("args", {}))[:200])
-                        tm = await execute_tool(tool, tc, error_handler)
+                        # Publish approval hooks + this call's context so a
+                        # delegation tool can hand the same approval channel to
+                        # its sub-agent (it reads this synchronously at entry).
+                        _delegation_ctx.set({
+                            "request_tool_approval": request_tool_approval,
+                            "needs_tool_approval": needs_tool_approval,
+                            "tool_name": tool_name,
+                            "tool_call_id": tool_call_id,
+                            "request": (tc.get("args") or {}).get("request", ""),
+                        })
+                        try:
+                            tm = await execute_tool(tool, tc, error_handler)
+                        except SubAgentApprovalPause as pause:
+                            # A delegated sub-agent paused for approval: bubble it
+                            # up as a top-level pause. The delegate_to_X call (tc)
+                            # is left unanswered and re-run on resume; the other
+                            # calls in this batch get deferred placeholders.
+                            if tool_messages:
+                                messages.extend(tool_messages)
+                                call_messages.extend(tool_messages)
+                                await emit_message_delta(tool_messages)
+                            deferred = _deferred_tool_messages(response.tool_calls, tc)
+                            if deferred:
+                                messages.extend(deferred)
+                                call_messages.extend(deferred)
+                                await emit_message_delta(deferred)
+                            emit_tool_event("tool_approval_required", {
+                                "name": pause.tool_name,
+                                "call_id": tool_call_id,
+                                "approval_id": pause.approval_id,
+                                "turn": turn + 1,
+                            })
+                            return AgentResult(
+                                messages=messages,
+                                content=(
+                                    "⚠️ Нужно подтверждение перед выполнением tool-call.\n"
+                                    f"Tool: `{pause.tool_name}`\n"
+                                    f"Approval ID: `{pause.approval_id}`\n\n"
+                                    "Нажми Approve/Reject в Telegram или обработай approval вручную."
+                                ),
+                                tool_calls_count=total_tool_calls,
+                                waiting_approval=True,
+                                approval_id=pause.approval_id,
+                                approval_tool_name=pause.tool_name,
+                            )
                         await write_tool_result(tool_call_id, str(tm.content))
                         log.info("Tool result: %s → %s", tool_name, str(tm.content)[:200])
                 raw_content = tool_message_raw_content(tm)
@@ -652,6 +762,9 @@ def create_agent(
     async def run(
         messages: list[BaseMessage],
         extra_tools: list[BaseTool] | None = None,
+        *,
+        needs_tool_approval: ToolApprovalPredicate | None = None,
+        request_tool_approval: ToolApprovalRequestCallback | None = None,
     ) -> AgentResult:
         all_tools = list(tools)
         if extra_tools:
@@ -665,6 +778,8 @@ def create_agent(
             max_turns=max_turns,
             error_handler=error_handler,
             on_tool_event=on_tool_event,
+            needs_tool_approval=needs_tool_approval,
+            request_tool_approval=request_tool_approval,
         )
 
     run.__name__ = name

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -29,8 +29,12 @@ from kronos.audit import log_tool_event, reset_tool_audit_context, set_tool_audi
 from kronos.config import settings
 from kronos.engine import (
     AgentResult,
+    SubAgentApprovalPause,
     ToolEventCallback,
+    clear_delegation_ctx,
+    current_delegation,
     execute_tool,
+    publish_delegation_ctx,
     react_loop,
     tool_requires_approval,
 )
@@ -239,12 +243,16 @@ class KronosAgent:
             )
 
         async def request_tool_approval(tool: BaseTool, tool_call: dict) -> str:
+            # current_delegation() is set when the approval originates inside a
+            # sub-agent — it records the parent delegate_to_X call so the resume
+            # re-runs that delegation with this call exempted.
             return await self._session_store.create_pending_approval(
                 turn_id=turn_id,
                 thread_id=thread_id,
                 tool_call_id=str(tool_call.get("id", "")),
                 tool_name=tool.name,
                 args=tool_call.get("args", {}) or {},
+                delegation=current_delegation(),
             )
 
         kwargs = {
@@ -254,27 +262,32 @@ class KronosAgent:
             "request_tool_approval": request_tool_approval,
         }
         if approved_tool_name:
-            # The exemption must match the EXACT call the user approved, not
-            # just the tool name. Binding to the name alone let an approved
-            # restart_service("x") wave through restart_service("y") during the
-            # resume. Compare canonical (sorted) args so only the approved call
-            # skips a fresh approval; any other args re-prompt.
-            approved_args_key = json.dumps(
-                approved_tool_args or {}, sort_keys=True, default=str
+            kwargs["needs_tool_approval"] = self._approval_scope(
+                approved_tool_name, approved_tool_args
             )
 
-            async def approval_scope(tool: BaseTool, args: dict) -> bool:
-                same_call = tool.name == approved_tool_name and (
-                    json.dumps(args or {}, sort_keys=True, default=str)
-                    == approved_args_key
-                )
-                if same_call:
-                    return False
-                return tool_requires_approval(tool, args)
-
-            kwargs["needs_tool_approval"] = approval_scope
-
         return kwargs
+
+    def _approval_scope(self, approved_tool_name: str, approved_tool_args: dict | None):
+        """Predicate exempting exactly the approved (name, args) call.
+
+        The exemption must match the EXACT call the user approved, not just the
+        tool name. Binding to the name alone let an approved restart_service("x")
+        wave through restart_service("y") during the resume. Compare canonical
+        (sorted) args so only the approved call skips a fresh approval; any other
+        args (or any other tool) re-prompt.
+        """
+        approved_args_key = json.dumps(approved_tool_args or {}, sort_keys=True, default=str)
+
+        async def approval_scope(tool: BaseTool, args: dict) -> bool:
+            same_call = tool.name == approved_tool_name and (
+                json.dumps(args or {}, sort_keys=True, default=str) == approved_args_key
+            )
+            if same_call:
+                return False
+            return tool_requires_approval(tool, args)
+
+        return approval_scope
 
     async def _run_model_loop(
         self,
@@ -336,7 +349,32 @@ class KronosAgent:
         tool_name = str(pending["tool_name"])
         messages = await self._session_store.load_turn_messages(thread_id, turn_id)
 
-        if approved:
+        args = pending.get("args", {}) or {}
+        delegation = pending.get("delegation")
+
+        # Build loop kwargs up front so a nested (sub-agent) re-run can reuse
+        # its approval hooks: the exemption for the approved call plus the
+        # pending channel for any further approval it triggers.
+        react_loop_kwargs = self._build_durable_react_loop_kwargs(
+            turn_id=turn_id,
+            thread_id=thread_id,
+            approved_tool_name=tool_name if approved else None,
+            approved_tool_args=args if approved else None,
+        )
+
+        if delegation:
+            resumed = await self._resume_delegated_approval(
+                approved=approved,
+                turn_id=turn_id,
+                delegation=delegation,
+                request_tool_approval=react_loop_kwargs["request_tool_approval"],
+                needs_tool_approval=react_loop_kwargs.get("needs_tool_approval"),
+            )
+            if resumed.get("waiting_approval"):
+                self._last_pending_approval_id = resumed["approval_id"]
+                return resumed["content"]
+            tool_message = resumed["tool_message"]
+        elif approved:
             tool = self._approval_tool_map().get(tool_name)
             cached = await self._session_store.get_tool_result(turn_id, tool_call_id)
             if cached is not None:
@@ -349,11 +387,7 @@ class KronosAgent:
             else:
                 tool_message = await execute_tool(
                     tool,
-                    {
-                        "name": tool_name,
-                        "id": tool_call_id,
-                        "args": pending.get("args", {}) or {},
-                    },
+                    {"name": tool_name, "id": tool_call_id, "args": args},
                 )
                 await self._session_store.save_tool_result(
                     turn_id=turn_id,
@@ -372,13 +406,6 @@ class KronosAgent:
             messages=[tool_message],
         )
         messages.append(tool_message)
-
-        react_loop_kwargs = self._build_durable_react_loop_kwargs(
-            turn_id=turn_id,
-            thread_id=thread_id,
-            approved_tool_name=tool_name if approved else None,
-            approved_tool_args=(pending.get("args", {}) or {}) if approved else None,
-        )
         audit_token = set_tool_audit_context(
             agent=settings.agent_name,
             thread_id=thread_id,
@@ -410,6 +437,76 @@ class KronosAgent:
             turn_id=turn_id,
         )
         return result.content
+
+    async def _resume_delegated_approval(
+        self,
+        *,
+        approved: bool,
+        turn_id: str,
+        delegation: dict,
+        request_tool_approval,
+        needs_tool_approval,
+    ) -> dict:
+        """Resume an approval that fired inside a sub-agent.
+
+        The approval-worthy tool lives in a sub-agent, not at the top level, so
+        it can't be executed directly here (it isn't in the approval tool map,
+        and running it in isolation would drop the sub-agent's remaining work).
+        Instead re-run the parent ``delegate_to_X`` call with the approved
+        sub-call exempted; the sub-agent's completed result fills the delegation
+        call's ToolMessage. A rejection short-circuits the delegation. If the
+        sub-agent hits a *different* approval-worthy tool on the re-run, it
+        pauses again (returned as ``waiting_approval``).
+
+        Returns ``{"tool_message": ToolMessage}`` or
+        ``{"waiting_approval": True, "approval_id": ..., "content": ...}``.
+        """
+        call_id = str(delegation.get("tool_call_id", ""))
+        deleg_name = str(delegation.get("tool_name", ""))
+        request = str(delegation.get("request", ""))
+
+        if not approved:
+            return {"tool_message": ToolMessage(content="[REJECTED by user]", tool_call_id=call_id)}
+
+        deleg_tool = self._approval_tool_map().get(deleg_name)
+        if deleg_tool is None:
+            return {"tool_message": ToolMessage(
+                content=f"[ERROR] Delegation tool '{deleg_name}' is no longer available after restart.",
+                tool_call_id=call_id,
+            )}
+
+        # Publish the exemption + approval channel so the re-run sub-agent
+        # executes the approved call (and can pause anew for a different one).
+        ctx_token = publish_delegation_ctx({
+            "request_tool_approval": request_tool_approval,
+            "needs_tool_approval": needs_tool_approval,
+            "tool_name": deleg_name,
+            "tool_call_id": call_id,
+            "request": request,
+        })
+        try:
+            tool_message = await execute_tool(
+                deleg_tool,
+                {"name": deleg_name, "id": call_id, "args": {"request": request}},
+            )
+        except SubAgentApprovalPause as pause:
+            return {
+                "waiting_approval": True,
+                "approval_id": pause.approval_id,
+                "content": (
+                    "⚠️ Нужно ещё одно подтверждение перед выполнением tool-call.\n"
+                    f"Tool: `{pause.tool_name}`\n"
+                    f"Approval ID: `{pause.approval_id}`\n\n"
+                    "Нажми Approve/Reject в Telegram или обработай approval вручную."
+                ),
+            }
+        finally:
+            clear_delegation_ctx(ctx_token)
+
+        await self._session_store.save_tool_result(
+            turn_id=turn_id, tool_call_id=call_id, content=str(tool_message.content),
+        )
+        return {"tool_message": tool_message}
 
     async def ainvoke(
         self,

--- a/kronos/session.py
+++ b/kronos/session.py
@@ -177,9 +177,17 @@ class SessionStore:
                     requested_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     decided_at TIMESTAMP,
                     decided_by TEXT,
-                    decision TEXT
+                    decision TEXT,
+                    delegation_json TEXT
                 )
             """)
+            # delegation_json arrived with nested sub-agent approvals (it records
+            # which delegate_to_X call to re-run on resume). Backfill it on
+            # databases created before the column existed.
+            cursor = await db.execute("PRAGMA table_info(pending_approvals)")
+            columns = {row[1] for row in await cursor.fetchall()}
+            if "delegation_json" not in columns:
+                await db.execute("ALTER TABLE pending_approvals ADD COLUMN delegation_json TEXT")
             await db.execute("""
                 CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_approvals_turn_call
                     ON pending_approvals(turn_id, tool_call_id)
@@ -289,6 +297,13 @@ class SessionStore:
             args = json.loads(row[5] or "{}")
         except (json.JSONDecodeError, TypeError):
             args = {}
+        delegation = None
+        # row[12] is delegation_json; older callers may SELECT fewer columns.
+        if len(row) > 12 and row[12]:
+            try:
+                delegation = json.loads(row[12])
+            except (json.JSONDecodeError, TypeError):
+                delegation = None
         return {
             "approval_id": row[0],
             "turn_id": row[1],
@@ -302,6 +317,7 @@ class SessionStore:
             "decided_by": row[9],
             "decision": row[10],
             "input_message": row[11],
+            "delegation": delegation,
         }
 
     async def create_pending_approval(
@@ -312,10 +328,19 @@ class SessionStore:
         tool_call_id: str,
         tool_name: str,
         args: dict,
+        delegation: dict | None = None,
     ) -> str:
-        """Create or reuse a pending approval for a durable tool call."""
+        """Create or reuse a pending approval for a durable tool call.
+
+        ``delegation`` is set when the approval originates inside a sub-agent:
+        it records the parent ``delegate_to_X`` call (name, id, request) so the
+        resume can re-run that delegation with the approved call exempted,
+        rather than trying to execute the sub-agent's tool at the top level
+        (where it isn't registered).
+        """
         approval_id = str(uuid.uuid4())
         args_json = json.dumps(args or {}, ensure_ascii=False, default=str)
+        delegation_json = json.dumps(delegation, ensure_ascii=False, default=str) if delegation else None
 
         async with self._open_db() as db:
             await self._ensure_table(db)
@@ -338,10 +363,10 @@ class SessionStore:
             await db.execute(
                 """
                 INSERT OR IGNORE INTO pending_approvals
-                    (approval_id, turn_id, thread_id, tool_call_id, tool_name, args_json)
-                VALUES (?, ?, ?, ?, ?, ?)
+                    (approval_id, turn_id, thread_id, tool_call_id, tool_name, args_json, delegation_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
-                (approval_id, turn_id, thread_id, tool_call_id, tool_name, args_json),
+                (approval_id, turn_id, thread_id, tool_call_id, tool_name, args_json, delegation_json),
             )
             cursor = await db.execute(
                 """
@@ -379,7 +404,8 @@ class SessionStore:
                     p.decided_at,
                     p.decided_by,
                     p.decision,
-                    t.input_message
+                    t.input_message,
+                    p.delegation_json
                 FROM pending_approvals p
                 JOIN active_turns t ON t.turn_id = p.turn_id
                 WHERE p.approval_id = ?
@@ -416,7 +442,8 @@ class SessionStore:
                     p.decided_at,
                     p.decided_by,
                     p.decision,
-                    t.input_message
+                    t.input_message,
+                    p.delegation_json
                 FROM pending_approvals p
                 JOIN active_turns t ON t.turn_id = p.turn_id
                 WHERE p.approval_id = ? AND p.status = 'pending'

--- a/tests/test_subagent_approval.py
+++ b/tests/test_subagent_approval.py
@@ -1,0 +1,231 @@
+"""Sub-agent approval propagation (nested durable approval through delegation).
+
+Before this, an approval-worthy tool (restart_/delete_/send_/add_expense/…)
+called *inside* a delegated sub-agent executed with no approval — the gate was
+top-level only. Now the sub-agent shares the parent's approval channel, the
+pause bubbles up as a top-level pause, and the resume re-runs the delegation
+with the approved call exempted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import StructuredTool
+
+from kronos.agents.supervisor import _make_delegation_tool
+from kronos.engine import create_agent, current_delegation, react_loop
+
+
+def _make_model(responses: list[AIMessage]):
+    model = AsyncMock()
+    model.ainvoke = AsyncMock(side_effect=list(responses))
+    bound = AsyncMock()
+    bound.ainvoke = AsyncMock(side_effect=list(responses))
+    model.bind_tools = MagicMock(return_value=bound)
+    return model
+
+
+def _ai_tool_call(name: str, args: dict, call_id: str) -> AIMessage:
+    return AIMessage(content="", tool_calls=[{"name": name, "args": args, "id": call_id}])
+
+
+def _make_tool(name: str, result: str, calls: list) -> StructuredTool:
+    async def _fn(**kwargs) -> str:
+        calls.append((name, kwargs))
+        return result
+
+    return StructuredTool.from_function(coroutine=_fn, name=name, description=f"tool {name}")
+
+
+def _server_ops_delegation(sub_responses: list[AIMessage], executed: list):
+    """A delegate_to_server_ops tool wrapping a sub-agent whose only tool is the
+    approval-worthy restart_service."""
+    restart = _make_tool("restart_service", result="restarted", calls=executed)
+    sub_model = _make_model(sub_responses)
+    sub_agent = create_agent(sub_model, [restart], "sub prompt", "server_ops_agent")
+    return _make_delegation_tool("server_ops", "delegate to server ops", sub_agent)
+
+
+@pytest.fixture(autouse=True)
+def _approvals_on(monkeypatch):
+    from kronos.config import settings
+    monkeypatch.setattr(settings, "tool_approvals_enabled", True)
+
+
+# --------------------------------------------------------------------------
+# Bubble-up: a sub-agent's approval-worthy tool pauses the whole turn
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_subagent_approval_bubbles_up_and_tags_delegation():
+    executed: list = []
+    delegation_tool = _server_ops_delegation(
+        [_ai_tool_call("restart_service", {"host": "web1"}, "call_restart")],
+        executed,
+    )
+
+    recorded: dict = {}
+
+    def request_approval(tool, tool_call):
+        recorded["tool"] = tool.name
+        recorded["delegation"] = current_delegation()
+        return "apr_nested_1"
+
+    top_model = _make_model([_ai_tool_call("delegate_to_server_ops", {"request": "restart web1"}, "call_deleg")])
+
+    result = await react_loop(
+        model=top_model,
+        messages=[HumanMessage(content="restart web1")],
+        tools=[delegation_tool],
+        request_tool_approval=request_approval,
+    )
+
+    # The turn paused at the TOP level, naming the sub-agent's tool.
+    assert result.waiting_approval is True
+    assert result.approval_id == "apr_nested_1"
+    assert result.approval_tool_name == "restart_service"
+    # The approval-worthy tool did NOT execute silently.
+    assert executed == []
+    # The pending approval was tagged with the parent delegate_to_X call.
+    assert recorded["tool"] == "restart_service"
+    assert recorded["delegation"]["tool_name"] == "delegate_to_server_ops"
+    assert recorded["delegation"]["tool_call_id"] == "call_deleg"
+    assert recorded["delegation"]["request"] == "restart web1"
+
+
+@pytest.mark.asyncio
+async def test_subagent_safe_tool_runs_without_pause():
+    """A non-approval-worthy sub-agent tool executes normally (no false pause)."""
+    executed: list = []
+    search = _make_tool("search_logs", result="42 lines", calls=executed)
+    sub_model = _make_model([
+        _ai_tool_call("search_logs", {"q": "err"}, "call_s"),
+        AIMessage(content="found 42 error lines"),
+    ])
+    sub_agent = create_agent(sub_model, [search], "sub", "server_ops_agent")
+    delegation_tool = _make_delegation_tool("server_ops", "delegate", sub_agent)
+
+    top_model = _make_model([
+        _ai_tool_call("delegate_to_server_ops", {"request": "search errors"}, "call_deleg"),
+        AIMessage(content="done"),
+    ])
+
+    result = await react_loop(
+        model=top_model,
+        messages=[HumanMessage(content="search errors")],
+        tools=[delegation_tool],
+        request_tool_approval=lambda tool, tc: "should_not_be_used",
+    )
+
+    assert result.waiting_approval is False
+    assert executed and executed[0][0] == "search_logs"  # ran without approval
+
+
+# --------------------------------------------------------------------------
+# Resume: re-delegate with the approved sub-call exempted
+# --------------------------------------------------------------------------
+
+def _fake_agent(delegation_tool: StructuredTool):
+    """Minimal object exposing the two attrs _resume_delegated_approval needs."""
+    from kronos.graph import KronosAgent
+
+    agent = object.__new__(KronosAgent)
+    agent._approval_tool_map = lambda: {delegation_tool.name: delegation_tool}
+    agent._session_store = MagicMock()
+    agent._session_store.save_tool_result = AsyncMock()
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_resume_reruns_delegation_with_exemption():
+    executed: list = []
+    delegation_tool = _server_ops_delegation(
+        [
+            _ai_tool_call("restart_service", {"host": "web1"}, "call_restart"),
+            AIMessage(content="restarted web1 ✓"),
+        ],
+        executed,
+    )
+    agent = _fake_agent(delegation_tool)
+
+    async def exemption(tool, args):
+        # Exempt exactly the approved restart_service(host=web1); anything else
+        # would still require approval.
+        return not (tool.name == "restart_service" and args == {"host": "web1"})
+
+    resumed = await agent.__class__._resume_delegated_approval(
+        agent,
+        approved=True,
+        turn_id="turn_1",
+        delegation={
+            "tool_name": "delegate_to_server_ops",
+            "tool_call_id": "call_deleg",
+            "request": "restart web1",
+        },
+        request_tool_approval=lambda tool, tc: "unused",
+        needs_tool_approval=exemption,
+    )
+
+    # Re-delegation ran, the approved tool executed, its result fills the
+    # delegate_to_X call's ToolMessage.
+    assert executed and executed[0][0] == "restart_service"
+    tool_message = resumed["tool_message"]
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.tool_call_id == "call_deleg"
+    assert "restarted web1" in tool_message.content
+    agent._session_store.save_tool_result.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resume_rejection_short_circuits_delegation():
+    executed: list = []
+    delegation_tool = _server_ops_delegation(
+        [_ai_tool_call("restart_service", {"host": "web1"}, "call_restart")],
+        executed,
+    )
+    agent = _fake_agent(delegation_tool)
+
+    resumed = await agent.__class__._resume_delegated_approval(
+        agent,
+        approved=False,
+        turn_id="turn_1",
+        delegation={"tool_name": "delegate_to_server_ops", "tool_call_id": "call_deleg", "request": "restart web1"},
+        request_tool_approval=lambda tool, tc: "unused",
+        needs_tool_approval=None,
+    )
+
+    assert executed == []  # nothing ran
+    assert resumed["tool_message"].content == "[REJECTED by user]"
+    assert resumed["tool_message"].tool_call_id == "call_deleg"
+
+
+# --------------------------------------------------------------------------
+# Session store round-trips the delegation context
+# --------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pending_approval_round_trips_delegation(tmp_path: Path):
+    from kronos.session import SessionStore
+
+    store = SessionStore(str(tmp_path / "session.db"))
+    turn_id = await store.begin_turn("thread-1", "restart web1")
+    delegation = {"tool_name": "delegate_to_server_ops", "tool_call_id": "call_deleg", "request": "restart web1"}
+
+    approval_id = await store.create_pending_approval(
+        turn_id=turn_id,
+        thread_id="thread-1",
+        tool_call_id="call_restart",
+        tool_name="restart_service",
+        args={"host": "web1"},
+        delegation=delegation,
+    )
+
+    fetched = await store.get_pending_approval(approval_id)
+    assert fetched["delegation"] == delegation
+
+    claimed = await store.claim_pending_approval(approval_id=approval_id, decision="approved")
+    assert claimed["delegation"] == delegation


### PR DESCRIPTION
## Problem

Tool approval was **top-level only**. A sub-agent invoked via `delegate_to_X` runs its own `react_loop`, which received no approval callbacks — so an approval-worthy tool (`restart_`/`delete_`/`send_`/`add_expense`/`mcp_*`/…) called **inside** a sub-agent executed with **no approval** when approvals are enabled. Delegating to a sub-agent was a way to bypass the gate.

(Not live on prod, where `TOOL_APPROVALS_ENABLED=false`, but a real hole for the default / approvals-on configuration.)

## Fix — propagate the approval channel into sub-agents + bubble the pause up

- **Propagate**: `create_agent`'s `run()` forwards `needs_tool_approval`/`request_tool_approval`, and a delegation tool hands the parent's channel to its sub-agent — only when the parent turn has one **and** the sub-agent accepts the kwargs (custom graph sub-agents like deep_research are left untouched).
- **Bubble up**: when a sub-agent pauses, the delegation tool raises `SubAgentApprovalPause`; `react_loop` turns that into a normal top-level pause (the `delegate_to_X` call is left unanswered; other calls in the batch get deferred placeholders). Same pause contract as a direct top-level approval.
- **Tag**: the pending approval records the parent `delegate_to_X` call (name, id, request) via a ContextVar → new nullable `pending_approvals.delegation_json` column (+ backfill migration).
- **Resume**: for a nested approval, `resolve_tool_approval` **re-runs the delegation** with the approved sub-call exempted — it can't execute the sub-tool directly (it isn't in the approval tool map, and running it in isolation would drop the sub-agent's remaining work). The sub-agent's result fills the delegation call's `ToolMessage`; a reject short-circuits it; a *different* approval-worthy tool on the re-run pauses again. **Top-level approval is unchanged.**

The ContextVar plumbing is read synchronously at each boundary (no leak): the delegation tool captures its call context at entry; the approval-request callback reads the frozen delegation on pause.

## Tests

`tests/test_subagent_approval.py`:
- sub-agent's approval-worthy tool bubbles up as a top-level pause, tags the delegation, and does **not** execute silently;
- a safe (read-only) sub-agent tool runs without a false pause;
- resume re-delegation — approve executes the tool, reject short-circuits;
- session store round-trips the delegation context.

738 passed (non-integration), ruff clean. Existing top-level approval / durable-turn tests unchanged.

## Scope

This is the "propagate + bubble-up" depth chosen for the sub-agent approval gap. Multi-user hardening (Discord/SSRF/peer-registry) remains out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)