### PR TITLE
approval: make delegation_json migration race-safe

### DIFF
--- a/kronos/session.py
+++ b/kronos/session.py
@@ -7,6 +7,7 @@ Stores messages as JSON in SQLite, keyed by thread_id.
 import hashlib
 import json
 import logging
+import sqlite3
 import uuid
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -187,7 +188,15 @@ class SessionStore:
             cursor = await db.execute("PRAGMA table_info(pending_approvals)")
             columns = {row[1] for row in await cursor.fetchall()}
             if "delegation_json" not in columns:
-                await db.execute("ALTER TABLE pending_approvals ADD COLUMN delegation_json TEXT")
+                try:
+                    await db.execute("ALTER TABLE pending_approvals ADD COLUMN delegation_json TEXT")
+                except sqlite3.OperationalError as e:
+                    # The PRAGMA check and ALTER aren't atomic across connections,
+                    # so a concurrent SessionStore instance may add the column
+                    # first at startup. A duplicate-column error means it now
+                    # exists — which is exactly the desired end state.
+                    if "duplicate column name" not in str(e).lower():
+                        raise
             await db.execute("""
                 CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_approvals_turn_call
                     ON pending_approvals(turn_id, tool_call_id)

--- a/tests/test_subagent_approval.py
+++ b/tests/test_subagent_approval.py
@@ -229,3 +229,36 @@ async def test_pending_approval_round_trips_delegation(tmp_path: Path):
 
     claimed = await store.claim_pending_approval(approval_id=approval_id, decision="approved")
     assert claimed["delegation"] == delegation
+
+
+@pytest.mark.asyncio
+async def test_pending_approvals_migration_from_old_schema(tmp_path: Path):
+    """A DB created before delegation_json existed migrates cleanly, and a
+    second init over the migrated DB is a no-op (race-safe: the ALTER swallows
+    a concurrent duplicate-column add)."""
+    import aiosqlite
+
+    from kronos.session import SessionStore
+
+    db_path = str(tmp_path / "session.db")
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "CREATE TABLE pending_approvals ("
+            "approval_id TEXT PRIMARY KEY, turn_id TEXT NOT NULL, thread_id TEXT NOT NULL, "
+            "tool_call_id TEXT NOT NULL, tool_name TEXT NOT NULL, args_json TEXT NOT NULL DEFAULT '{}', "
+            "status TEXT NOT NULL DEFAULT 'pending', requested_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+            "decided_at TIMESTAMP, decided_by TEXT, decision TEXT)"
+        )
+        await db.commit()
+
+    store = SessionStore(db_path)
+    turn_id = await store.begin_turn("t", "hi")  # first use migrates (adds the column)
+    approval_id = await store.create_pending_approval(
+        turn_id=turn_id, thread_id="t", tool_call_id="c",
+        tool_name="restart_service", args={}, delegation={"tool_name": "delegate_to_x"},
+    )
+    assert (await store.get_pending_approval(approval_id))["delegation"] == {"tool_name": "delegate_to_x"}
+
+    # A second store re-running _ensure_table over the migrated DB must not raise.
+    store2 = SessionStore(db_path)
+    await store2.begin_turn("t2", "hi")


### PR DESCRIPTION
## Problem

Deploying #25 surfaced a startup error on one of the six agents:

```
sqlite3.OperationalError: duplicate column name: delegation_json
```

Several `SessionStore` instances initialise the same per-agent `session.db` concurrently at startup. The `PRAGMA table_info` → `ALTER TABLE ADD COLUMN` migration added in #25 isn't atomic across connections, so two instances can both observe the column missing and both run the `ALTER` — the second raises.

It **self-heals** (the next `_ensure_table` sees the column and skips the ALTER), so no data is lost and the schema ends up correct — but a spurious startup traceback is a real bug and could fail an in-flight session op during the race window.

## Fix

Swallow the `duplicate column name` `OperationalError` — the column existing is exactly the desired end state — and re-raise anything else. Idempotent and race-safe.

## Test

`test_pending_approvals_migration_from_old_schema`: an old-schema DB (no `delegation_json`) migrates cleanly, round-trips the delegation context, and a second `SessionStore` re-running `_ensure_table` over the migrated DB is a no-op.

20 approval/durable-turn tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)