### PR TITLE
perf(dashboard): route-based code splitting (983 KB → ~265 KB initial)

### DIFF
--- a/dashboard-ui/src/App.tsx
+++ b/dashboard-ui/src/App.tsx
@@ -1,23 +1,28 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, lazy, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom';
 import { login as apiLogin, logout as apiLogout, checkAuth, api } from './api/client';
-import FleetPage from './pages/FleetPage';
-import OverviewPage from './pages/OverviewPage';
-import PersonaPage from './pages/PersonaPage';
-import LogsPage from './pages/LogsPage';
-import McpPage from './pages/McpPage';
-import SkillsPage from './pages/SkillsPage';
-import AgentsPage from './pages/AgentsPage';
-import GraphPage from './pages/GraphPage';
-import SwarmPage from './pages/SwarmPage';
-import ConfigPage from './pages/ConfigPage';
-import MemoryPage from './pages/MemoryPage';
-import MonitoringPage from './pages/MonitoringPage';
-import PerformancePage from './pages/PerformancePage';
-import AnalyticsPage from './pages/AnalyticsPage';
-import AuditTrailPage from './pages/AuditTrailPage';
-import AnomaliesPage from './pages/AnomaliesPage';
-import SandboxPage from './pages/SandboxPage';
+
+// Route-based code splitting: every page ships as its own chunk, fetched on
+// demand instead of in the initial bundle. The shell keeps only React + the
+// router; heavy dependencies that live in a single page — notably the
+// CodeMirror editors on Persona/Skills — never touch first paint.
+const FleetPage = lazy(() => import('./pages/FleetPage'));
+const OverviewPage = lazy(() => import('./pages/OverviewPage'));
+const PersonaPage = lazy(() => import('./pages/PersonaPage'));
+const LogsPage = lazy(() => import('./pages/LogsPage'));
+const McpPage = lazy(() => import('./pages/McpPage'));
+const SkillsPage = lazy(() => import('./pages/SkillsPage'));
+const AgentsPage = lazy(() => import('./pages/AgentsPage'));
+const GraphPage = lazy(() => import('./pages/GraphPage'));
+const SwarmPage = lazy(() => import('./pages/SwarmPage'));
+const ConfigPage = lazy(() => import('./pages/ConfigPage'));
+const MemoryPage = lazy(() => import('./pages/MemoryPage'));
+const MonitoringPage = lazy(() => import('./pages/MonitoringPage'));
+const PerformancePage = lazy(() => import('./pages/PerformancePage'));
+const AnalyticsPage = lazy(() => import('./pages/AnalyticsPage'));
+const AuditTrailPage = lazy(() => import('./pages/AuditTrailPage'));
+const AnomaliesPage = lazy(() => import('./pages/AnomaliesPage'));
+const SandboxPage = lazy(() => import('./pages/SandboxPage'));
 
 /* ── Login ── */
 
@@ -296,6 +301,16 @@ function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 
+/* ── Lazy-route fallback ── */
+
+function PageFallback() {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '60vh', color: '#555' }}>
+      Loading…
+    </div>
+  );
+}
+
 /* ── App ── */
 
 export default function App() {
@@ -315,6 +330,7 @@ export default function App() {
   return (
     <BrowserRouter>
       <Layout>
+        <Suspense fallback={<PageFallback />}>
         <Routes>
           <Route path="/" element={<OverviewPage />} />
           <Route path="/fleet" element={<FleetPage />} />
@@ -334,6 +350,7 @@ export default function App() {
           <Route path="/persona" element={<PersonaPage />} />
           <Route path="/config" element={<ConfigPage />} />
         </Routes>
+        </Suspense>
       </Layout>
     </BrowserRouter>
   );

--- a/dashboard-ui/vite.config.ts
+++ b/dashboard-ui/vite.config.ts
@@ -4,4 +4,28 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      output: {
+        // Split vendor code into stable, long-cached chunks. Matching by
+        // node_modules path (not package name) is what catches subpath imports
+        // like `react-dom/client` — the object form misses those and leaks the
+        // ~180 KB react-dom bulk into the app entry, forcing a re-download on
+        // every deploy. React lands in `react-vendor` (eager, cached across
+        // deploys); CodeMirror lands in `codemirror`, which stays async because
+        // only the lazy Persona/Skills routes import it. Everything else splits
+        // per route via the lazy() imports in App.tsx.
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined
+          if (/[\\/]node_modules[\\/](react|react-dom|react-router|react-router-dom|scheduler)[\\/]/.test(id)) {
+            return 'react-vendor'
+          }
+          if (/[\\/]node_modules[\\/](@codemirror|@lezer|@uiw|codemirror)[\\/]/.test(id)) {
+            return 'codemirror'
+          }
+          return undefined
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## What

Splits the dashboard UI bundle by route. It shipped as a single **983 KB** chunk — React, react-router, all 17 pages, and CodeMirror (the Persona/Skills editor, ~615 KB) all downloaded before first paint.

## Changes

- **`App.tsx`** — every page import converted to `React.lazy()` behind a single `<Suspense>` boundary. Each route now ships as its own chunk, fetched on demand. All 17 pages already used `export default`, so they're lazy-compatible as-is.
- **`vite.config.ts`** — `manualChunks` matches by `node_modules` **path** (not package name). This is what catches subpath imports like `react-dom/client`; the object form misses those and leaks the ~180 KB react-dom bulk into the app entry, invalidating it on every deploy. React now lands in a stable `react-vendor` chunk (caches across deploys); CodeMirror lands in its own async `codemirror` chunk that only the lazy Persona/Skills routes pull in.

## Result (production build)

| | before | after |
|---|---|---|
| entry | 195 KB | **13.6 KB** |
| react-vendor | — (react-dom leaked into entry) | **231 KB**, cached across deploys |
| codemirror | in the monolith, eager | **615 KB**, lazy — Persona/Skills only |
| **landing load** | **983 KB** | **~265 KB** (entry + vendor + route) |

CodeMirror's 615 KB no longer touches first paint.

## Verification

Pure refactor — no behavior change. Verified end-to-end against the standalone dashboard backend:
- ✅ `tsc -b` + `vite build` clean; ESLint clean
- ✅ Login → authed route mounts
- ✅ Lazy route loads on demand (direct nav **and** client-side SPA nav via Suspense)
- ✅ `codemirror` chunk loads **only** when visiting Persona/Skills — absent on Overview/login
- ✅ `react-vendor` + entry served `304` (cached) across navigation
- ✅ Zero console errors; pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)