### PR TITLE
Agent portability: .kaos bundles, import from ChatGPT/Claude/Obsidian/Telegram/Letta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to Kronos Agent OS are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **Agent portability (`.kaos` bundles)** — `kaos export` / `kaos import`
+  move an agent's persona, skills, facts, knowledge graph, shared facts and
+  pending schedule between installations. Bundles carry a `manifest.json`
+  with a SHA-256 per artifact; import verifies it before writing anything and
+  aborts on a single altered byte. Exports are deterministic (sorted JSONL,
+  fixed archive timestamps), so re-exporting unchanged state yields a
+  byte-identical file.
+- **Import from other tools** — `kaos import-from <tool|auto> <path>` converts
+  a foreign export into a bundle, then runs the same verified import path:
+  ChatGPT (`conversations.json`, directory, or export zip — keeps the retained
+  branch of each message tree), Claude projects (directory or `projects.json`),
+  Obsidian vaults (`[[wikilinks]]` become graph relations), Telegram
+  (`result.json`, opt-in per chat), and Letta `.af` agent files.
+- `kaos doctor` reports the bundle schema version and available importers.
+- New docs: [Portability](docs/PORTABILITY.md).
+
+### Changed
+
+- `kronos.audit.redact_secrets` is now public (was `_redact_string`'s inline
+  loop) so exports and audit logs share one copy of the credential patterns.
+
+### Fixed
+
+- `kronos.portability.export` and `import_` resolve `kronos.workspace.ws` at
+  call time instead of binding it at import time; a module-level binding
+  ignored a swapped workspace, which also made an earlier test pass against
+  the wrong directory.
+
 ## [0.2.0] - 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ kaos chat --no-memory # local chat without long-term memory
 kaos chat --tools    # local CLI chat with configured static MCP tools
 kaos dashboard       # start the local dashboard API/UI
 kaos demo-seed --reset # seed public-safe dashboard demo data
+kaos export --out a.kaos # export this agent as a portable bundle
+kaos import a.kaos --dry-run # preview importing a bundle
+kaos import-from auto <path> # bring history from ChatGPT/Claude/Obsidian/Telegram/Letta
 kaos connect telegram # guided Telegram setup check
 kaos templates list  # list bundled agent templates
 kaos skills packs    # list bundled skill packs
@@ -226,6 +229,22 @@ templates/
 docs/                  # docs index, runtime, memory, skills, MCP, automations, coordination
 ```
 
+## Bring Your History
+
+An agent is a persona, a set of skills, and a memory of you — so KAOS makes that
+portable instead of locking it in.
+
+```bash
+kaos export --out my-agent.kaos            # move or back up an agent
+kaos import my-agent.kaos --dry-run        # see exactly what would change
+kaos import-from auto ~/chatgpt-export     # start from history you already have
+```
+
+Bundles are content-hashed and deterministic, secrets and Telegram sessions are
+never included, and imported skills arrive as drafts for review. Importers exist
+for ChatGPT, Claude projects, Obsidian vaults, Telegram exports, and Letta agent
+files. See [Portability](docs/PORTABILITY.md).
+
 ## Sub-Agents And Swarm Mode
 
 KAOS Swarm Mode is the optional multi-agent coordination layer inside the broader Agent OS.
@@ -271,6 +290,7 @@ See [docs/SECURITY.md](docs/SECURITY.md) and [SECURITY.md](SECURITY.md).
 - [Security](docs/SECURITY.md)
 - [Dashboard](docs/DASHBOARD.md)
 - [Memory](docs/MEMORY.md)
+- [Portability](docs/PORTABILITY.md)
 - [Skills](docs/SKILLS.md)
 - [Cron Jobs](docs/CRON-JOBS.md)
 - [Deployment](docs/DEPLOYMENT.md)

--- a/docs/PORTABILITY.md
+++ b/docs/PORTABILITY.md
@@ -1,0 +1,133 @@
+# Kronos Agent OS (KAOS) — Portability
+
+An agent is more than its code: it is a persona, a set of skills, and a memory
+of you. A `.kaos` bundle makes that portable — you can move an agent between
+machines, keep an offline backup, or bring a history that started somewhere else.
+
+```bash
+kaos export --out my-agent.kaos          # take your agent with you
+kaos import my-agent.kaos --dry-run      # see what would change
+kaos import-from auto ~/chatgpt-export   # bring history from another tool
+```
+
+## Bundle Format
+
+A bundle is a zip archive. `manifest.json` lists every artifact with its
+SHA-256, so an importer can prove the payload is exactly what the exporter
+wrote before touching a database.
+
+```text
+manifest.json                    schema_version, kaos_version, agent_name,
+                                 created_at, includes, counts, artifacts{path: sha256}
+persona/{IDENTITY,SOUL,AGENTS,methodology}.md
+skills/<name>/SKILL.md
+skills/<name>/references/*
+memory/facts.jsonl               {user_id, content, source, created_at, relevance?}
+memory/graph.entities.jsonl      {name, type, properties}
+memory/graph.relations.jsonl     {source{name,type}, target{name,type}, relation_type, properties}
+memory/shared_facts.jsonl        this agent's contributions to the swarm ledger
+schedule/tasks.jsonl             pending reminders and follow-ups
+notes/**                         opt-in: --include-notes
+sessions/sessions.jsonl          opt-in: --include-sessions (one row per thread)
+```
+
+Exports are **deterministic**: JSONL rows are sorted, the archive uses a fixed
+entry timestamp, and `created_at` in the manifest is the only field carrying
+wall-clock time. Exporting unchanged state twice produces a byte-identical
+archive — which makes "did my agent's state actually change?" a checkable
+question.
+
+## What Is Never Exported
+
+Enforced in code and covered by a negative test across every flag combination:
+
+- `.env*` and any credential file
+- Telegram `*.session` files
+- the SQLite databases themselves (content is dumped as JSONL instead)
+- the Qdrant vector store — vectors are re-embedded on import from the facts
+- audit logs (`logs/*.jsonl`)
+- other agents' shared facts, and skills from a shared workspace
+
+Credential-looking strings inside exported content (bearer tokens, `sk-…` keys,
+`api_key=` parameters) are redacted. Two levels apply:
+
+| Content | Treatment | Why |
+|---------|-----------|-----|
+| Persona, notes, facts, graph, schedule | credentials stripped, PII kept | This is your own material — masking your own email out of your own facts would destroy what the bundle carries. |
+| Sessions and tool output | credentials stripped **and** PII masked | Third-party data you did not author. |
+
+Transport identifiers (`chat_id`, `topic_id`, `thread_id`) identify someone's
+private chats, so they are dropped by default and the task is marked
+`needs_rebind`. `--include-transport-ids` keeps them; the CLI warns when you do.
+
+## Importing
+
+```bash
+kaos import my-agent.kaos [--merge skip|overwrite|append] [--dry-run] [--rebind-chat <id>]
+```
+
+Verification runs first: a single altered byte aborts the import with nothing
+written. Then each section is merged by a content key, never by id — ids from
+another installation mean nothing locally, which is also what makes a second
+import a no-op.
+
+| Section | Dedupe key | Merge behaviour |
+|---------|-----------|-----------------|
+| Facts | normalized text + user | duplicates skipped (whitespace/case-insensitive) |
+| Graph entities | `(name, type)` | properties merged |
+| Graph relations | `(source, target, type)` | insert-or-ignore |
+| Skills | name | installed as **draft**; existing names kept unless `--merge overwrite` |
+| Persona | filename | kept local on `skip`; `append` adds a marked section; `overwrite` replaces |
+| Notes | relative path | same three modes |
+| Schedule | — | skipped unless `--rebind-chat` says which chat they belong to |
+| Sessions | — | archived into `notes/inbox/imported-sessions-<agent>.md` |
+
+Two deliberate refusals:
+
+- **Imported skills are drafts.** A skill is executable procedure; it gets
+  reviewed before the agent relies on it.
+- **Session history is never written into the live session store.** Thread ids
+  come from another installation, and overwriting a real conversation to
+  "restore" a foreign one is data loss wearing a feature's clothes. The history
+  lands in the inbox as markdown, where the agent can still read it.
+
+`--dry-run` runs the same code path and reports the full result without writing.
+
+## Importing From Other Tools
+
+```bash
+kaos import-from <tool> <path> [--dry-run] [--limit N] [--convert-only --out b.kaos]
+kaos import-from auto ~/Downloads/chatgpt-export     # detect the format
+```
+
+Importers convert a foreign export **into a bundle**, then that bundle goes
+through the normal verified path. One code path, one set of merge rules.
+
+| Tool | Input | Extracted |
+|------|-------|-----------|
+| `chatgpt` | `conversations.json`, its directory, or the export zip | conversation threads (kept branch only) + explicit memory statements ("remember that…", "запомни…") |
+| `claude-projects` | project directory or `projects.json` | instructions → persona draft, `skills/<name>/` → skills, other docs → notes |
+| `obsidian` | vault directory | notes, `[[wikilinks]]` → graph relations, `type: fact` notes and `facts:` frontmatter → facts |
+| `telegram` | `result.json` | owner identity from `personal_information`; conversations **only** for chats named with `--chat` |
+| `letta` | `.af` agent file | persona block → IDENTITY.md, system prompt → methodology.md, human block → facts, messages → session |
+
+Notes on limits:
+
+- ChatGPT and Telegram exports are read whole; above 256 MB the import is
+  refused with advice rather than getting OOM-killed halfway.
+- `--limit` caps conversations (ChatGPT), notes (Obsidian), documents (Claude),
+  messages per chat (Telegram), or trailing messages (Letta). Whatever gets
+  dropped is reported, never silently trimmed.
+- Telegram imports nothing conversational without `--chat`: ingesting every
+  private chat someone ever had is not a sane default.
+
+## Round Trip Check
+
+```bash
+kaos export --out before.kaos
+kaos import before.kaos --dry-run     # expect zero new records
+```
+
+A dry-run import of your own fresh export should report nothing new. If it
+reports additions, the dedupe key and the export disagree — that is a bug worth
+filing.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Start here if you want to understand or contribute to Kronos Agent OS.
 | [Optional Feedback](SOFT_LAUNCH.md) | Lightweight feedback capture and triage rules after publishing |
 | [Runtime](RUNTIME.md) | CLI, connectors, sessions, and execution lifecycle |
 | [Memory](MEMORY.md) | Session memory, hybrid recall, knowledge graph, sleep compute |
+| [Portability](PORTABILITY.md) | `.kaos` bundles: export, import, and bringing history from other tools |
 | [Skills](SKILLS.md) | Workspace-local reusable procedures |
 | [MCP & Tools](MCP.md) | Static MCP, tool gateway, dynamic tool gates |
 | [Automations](AUTOMATIONS.md) | Scheduler, jobs, notifications, audit trail |

--- a/kronos/audit.py
+++ b/kronos/audit.py
@@ -29,7 +29,10 @@ COST_TABLE = {
 
 _audit_dir: Path | None = None
 _tool_audit_context: ContextVar[dict[str, str]] = ContextVar("tool_audit_context", default={})
-_SECRET_FIELD_NAMES = {"token", "secret", "password", "api_key", "apikey", "key", "hash", "authorization"}
+# Field names whose values are secrets regardless of content. Public because
+# every path that persists agent data (audit log, exported bundles) must redact
+# the same set — a second copy of this list would drift.
+SECRET_FIELD_NAMES = frozenset({"token", "secret", "password", "api_key", "apikey", "key", "hash", "authorization"})
 _SECRET_PATTERNS = (
     (re.compile(r"Bearer\s+[A-Za-z0-9._~+/=-]{12,}"), "Bearer ***REDACTED***"),
     (re.compile(r"sk-[A-Za-z0-9_-]{12,}"), "sk-***REDACTED***"),
@@ -71,11 +74,21 @@ def get_tool_audit_context() -> dict[str, str]:
     return dict(_tool_audit_context.get())
 
 
-def _redact_string(value: str, *, max_len: int = 500) -> str:
-    redacted = value
+def redact_secrets(text: str) -> str:
+    """Replace secret-like substrings (bearer tokens, sk- keys, key= params).
+
+    Unlike ``_redact_string`` this neither masks PII nor truncates, so callers
+    that must preserve full content (exported bundles) can still strip
+    credentials.
+    """
+    redacted = text
     for pattern, replacement in _SECRET_PATTERNS:
         redacted = pattern.sub(replacement, redacted)
-    redacted = mask_pii(redacted)
+    return redacted
+
+
+def _redact_string(value: str, *, max_len: int = 500) -> str:
+    redacted = mask_pii(redact_secrets(value))
     if len(redacted) > max_len:
         return f"{redacted[: max_len - 3]}..."
     return redacted
@@ -84,7 +97,7 @@ def _redact_string(value: str, *, max_len: int = 500) -> str:
 def redact_tool_payload(value: Any, key: str = "") -> Any:
     """Redact secret-like fields before tool args/results reach storage or UI."""
     key_name = key.lower().replace("-", "_")
-    if key_name in _SECRET_FIELD_NAMES or key_name.endswith(("_token", "_secret", "_password", "_api_key", "_key")):
+    if key_name in SECRET_FIELD_NAMES or key_name.endswith(("_token", "_secret", "_password", "_api_key", "_key")):
         return "***REDACTED***"
     if isinstance(value, dict):
         return {str(k): redact_tool_payload(v, str(k)) for k, v in value.items()}

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -449,6 +449,14 @@ def run_doctor() -> int:
     else:
         ok("Telegram topic policy", "not configured; legacy group routing")
 
+    from kronos.portability import BUNDLE_SCHEMA_VERSION
+    from kronos.portability.importers import available as _importers
+
+    ok(
+        "Portability",
+        f"bundle schema v{BUNDLE_SCHEMA_VERSION}; importers: {', '.join(_importers())}",
+    )
+
     print("KAOS doctor\n")
     failed = 0
     for status, name, detail in checks:
@@ -824,6 +832,114 @@ def run_demo_seed(data_dir: str, workspace: str, swarm_db: str, reset: bool) -> 
     return 0
 
 
+def run_export(output: str, *, notes: bool, sessions: bool, transport_ids: bool) -> int:
+    """Export this agent into a `.kaos` bundle."""
+    from kronos.portability import BundleError, export_bundle
+
+    try:
+        report = export_bundle(
+            output,
+            include_notes=notes,
+            include_sessions=sessions,
+            include_transport_ids=transport_ids,
+        )
+    except BundleError as e:
+        print(f"Export failed: {e}")
+        return 1
+
+    print(f"Exported agent '{settings.agent_name}' → {report.path}")
+    print(f"  sections: {', '.join(report.manifest.includes)}")
+    for key, value in sorted(report.counts.items()):
+        print(f"  {key}: {value}")
+    for warning in report.warnings:
+        print(f"  ! {warning}")
+    if transport_ids:
+        print("  ! bundle contains Telegram chat ids — treat it as private")
+    return 0
+
+
+def run_import(path: str, *, merge: str, dry_run: bool, rebind_chat: int | None) -> int:
+    """Import a `.kaos` bundle into this agent."""
+    from kronos.portability import BundleError, import_bundle
+
+    try:
+        report = import_bundle(path, merge=merge, dry_run=dry_run, rebind_chat=rebind_chat)
+    except BundleError as e:
+        print(f"Import failed: {e}")
+        return 1
+
+    print(report.render())
+    if dry_run:
+        print("\nNothing was written. Re-run without --dry-run to apply.")
+    elif report.created.get("skills"):
+        print("\nImported skills are drafts — review them, then approve with the agent's approve_skill tool.")
+    return 0
+
+
+def run_import_from(
+    tool: str,
+    path: str,
+    *,
+    merge: str,
+    dry_run: bool,
+    limit: int | None,
+    chats: list[str] | None,
+    output: str,
+    convert_only: bool,
+) -> int:
+    """Convert a foreign export into a bundle, then import it."""
+    from tempfile import TemporaryDirectory
+
+    from kronos.portability import BundleError, import_bundle
+    from kronos.portability.importers import detect_importer, get_importer
+
+    name = tool
+    if tool == "auto":
+        name = detect_importer(path) or ""
+        if not name:
+            print(f"Could not recognise the export at {path}. Pass an explicit importer name.")
+            return 1
+        print(f"Detected importer: {name}")
+
+    try:
+        importer = get_importer(name)
+    except BundleError as e:
+        print(f"{e}")
+        return 1
+
+    kwargs: dict = {"limit": limit}
+    if chats:
+        if name != "telegram":
+            print(f"--chat is only supported by the telegram importer, ignoring it for '{name}'")
+        else:
+            kwargs["chats"] = chats
+
+    with TemporaryDirectory(prefix="kaos-convert-") as staging:
+        bundle_path = Path(output) if output else Path(staging) / f"{name}.kaos"
+        try:
+            result = importer.to_bundle(Path(path), bundle_path, **kwargs)
+        except BundleError as e:
+            print(f"Conversion failed: {e}")
+            return 1
+
+        print(result.render())
+        if convert_only:
+            print(f"\nBundle written to {result.bundle}. Import it with: kaos import {result.bundle}")
+            return 0
+
+        try:
+            report = import_bundle(result.bundle, merge=merge, dry_run=dry_run)
+        except BundleError as e:
+            print(f"Import failed: {e}")
+            return 1
+
+    print()
+    print(report.render())
+    if dry_run:
+        print("\nNothing was written. Re-run without --dry-run to apply.")
+    return 0
+
+
 async def _run_signals_dry_run(
     category: str,
     *,
@@ -862,6 +978,11 @@ async def _run_sessions_backfill_search(agent: str = "") -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
+    # Imported here, like the other command modules, so `kaos --help` does not
+    # pay for the portability stack on every unrelated invocation.
+    from kronos.portability.import_ import MERGE_MODES, MERGE_SKIP
+    from kronos.portability.importers import available as importer_names
+
     parser = argparse.ArgumentParser(
         prog="kaos",
         description="Kronos Agent OS (KAOS) local control CLI",
@@ -949,6 +1070,48 @@ def build_parser() -> argparse.ArgumentParser:
     connect_sub = connect.add_subparsers(dest="connector")
     connect_sub.add_parser("telegram", help="check Telegram connector setup")
 
+    export = sub.add_parser("export", help="export this agent as a .kaos bundle")
+    export.add_argument("--out", "-o", default="agent.kaos", help="output bundle path")
+    export.add_argument("--include-notes", action="store_true", help="include workspace notes")
+    export.add_argument("--include-sessions", action="store_true", help="include conversation history")
+    export.add_argument(
+        "--include-transport-ids",
+        action="store_true",
+        help="keep Telegram chat/topic ids in scheduled tasks (private data)",
+    )
+
+    bundle_import = sub.add_parser("import", help="import a .kaos bundle into this agent")
+    bundle_import.add_argument("path", help="bundle file to import")
+    bundle_import.add_argument(
+        "--merge",
+        choices=MERGE_MODES,
+        default=MERGE_SKIP,
+        help="what to do when persona/notes/skills already exist (default: skip)",
+    )
+    bundle_import.add_argument("--dry-run", action="store_true", help="report what would change, write nothing")
+    bundle_import.add_argument(
+        "--rebind-chat",
+        type=int,
+        default=None,
+        help="chat id to attach imported reminders to",
+    )
+
+    import_from = sub.add_parser("import-from", help="import history from another tool")
+    import_from.add_argument("tool", choices=["auto", *importer_names()], help="source tool ('auto' to detect)")
+    import_from.add_argument("path", help="export file or directory")
+    import_from.add_argument("--merge", choices=MERGE_MODES, default=MERGE_SKIP, help="merge mode (default: skip)")
+    import_from.add_argument("--dry-run", action="store_true", help="report what would change, write nothing")
+    import_from.add_argument("--limit", type=int, default=None, help="cap items read from the export")
+    import_from.add_argument(
+        "--chat",
+        action="append",
+        default=None,
+        metavar="NAME_OR_ID",
+        help="telegram only: chat to import (repeatable)",
+    )
+    import_from.add_argument("--out", "-o", default="", help="keep the intermediate bundle at this path")
+    import_from.add_argument("--convert-only", action="store_true", help="write the bundle without importing it")
+
     return parser
 
 
@@ -1034,6 +1197,26 @@ def main(argv: list[str] | None = None) -> int:
             return run_connect_telegram()
         parser.parse_args(["connect", "--help"])
         return 0
+    if args.command == "export":
+        return run_export(
+            args.out,
+            notes=args.include_notes,
+            sessions=args.include_sessions,
+            transport_ids=args.include_transport_ids,
+        )
+    if args.command == "import":
+        return run_import(args.path, merge=args.merge, dry_run=args.dry_run, rebind_chat=args.rebind_chat)
+    if args.command == "import-from":
+        return run_import_from(
+            args.tool,
+            args.path,
+            merge=args.merge,
+            dry_run=args.dry_run,
+            limit=args.limit,
+            chats=args.chat,
+            output=args.out,
+            convert_only=args.convert_only,
+        )
 
     parser.print_help()
     return 0

--- a/kronos/portability/__init__.py
+++ b/kronos/portability/__init__.py
@@ -1,0 +1,34 @@
+"""Agent portability — export and import an agent as a `.kaos` bundle.
+
+A bundle carries what makes an agent *this* agent: persona files, skills,
+extracted facts, knowledge graph, shared facts, and schedule. Runtime secrets
+(`.env`, Telegram sessions), vector stores, and audit logs are never included.
+"""
+
+from kronos.portability.manifest import (
+    ALL_SECTIONS,
+    BUNDLE_SCHEMA_VERSION,
+    MANIFEST_NAME,
+    BundleError,
+    BundleManifest,
+    build_manifest,
+    file_sha256,
+    hash_artifacts,
+    read_manifest,
+    verify_manifest,
+    write_manifest,
+)
+
+__all__ = [
+    "ALL_SECTIONS",
+    "BUNDLE_SCHEMA_VERSION",
+    "MANIFEST_NAME",
+    "BundleError",
+    "BundleManifest",
+    "build_manifest",
+    "file_sha256",
+    "hash_artifacts",
+    "read_manifest",
+    "verify_manifest",
+    "write_manifest",
+]

--- a/kronos/portability/__init__.py
+++ b/kronos/portability/__init__.py
@@ -5,6 +5,15 @@ extracted facts, knowledge graph, shared facts, and schedule. Runtime secrets
 (`.env`, Telegram sessions), vector stores, and audit logs are never included.
 """
 
+from kronos.portability.export import ExportReport, export_bundle
+from kronos.portability.import_ import (
+    MERGE_APPEND,
+    MERGE_MODES,
+    MERGE_OVERWRITE,
+    MERGE_SKIP,
+    ImportReport,
+    import_bundle,
+)
 from kronos.portability.manifest import (
     ALL_SECTIONS,
     BUNDLE_SCHEMA_VERSION,
@@ -23,11 +32,19 @@ __all__ = [
     "ALL_SECTIONS",
     "BUNDLE_SCHEMA_VERSION",
     "MANIFEST_NAME",
+    "MERGE_APPEND",
+    "MERGE_MODES",
+    "MERGE_OVERWRITE",
+    "MERGE_SKIP",
     "BundleError",
     "BundleManifest",
+    "ExportReport",
+    "ImportReport",
     "build_manifest",
+    "export_bundle",
     "file_sha256",
     "hash_artifacts",
+    "import_bundle",
     "read_manifest",
     "verify_manifest",
     "write_manifest",

--- a/kronos/portability/build.py
+++ b/kronos/portability/build.py
@@ -1,0 +1,252 @@
+"""Bundle construction primitives.
+
+``export.py`` builds a bundle from this agent's databases; importers build one
+from a foreign export (ChatGPT, Obsidian, Letta…). Both need the same staging,
+canonical JSONL and deterministic zip, so those live here — the low level that
+knows how to write a bundle, not where the content came from.
+"""
+
+import json
+import logging
+import zipfile
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from tempfile import mkdtemp
+
+from kronos.portability.manifest import (
+    SECTION_FACTS,
+    SECTION_GRAPH,
+    SECTION_NOTES,
+    SECTION_PERSONA,
+    SECTION_SESSIONS,
+    SECTION_SKILLS,
+    BundleManifest,
+    build_manifest,
+    write_manifest,
+)
+from kronos.portability.redact import redact_structure, redact_text
+
+log = logging.getLogger("kronos.portability.build")
+
+# A fixed timestamp keeps the archive byte-identical across runs; the real
+# creation time lives in the manifest, which is the one place time belongs.
+ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+
+_PERSONA_FILENAMES = ("IDENTITY.md", "SOUL.md", "AGENTS.md", "methodology.md")
+
+
+def write_jsonl(path: Path, rows: Iterable[dict]) -> int:
+    """Write rows as canonical JSONL. Returns the number of rows written."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    written = 0
+    with open(path, "w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+            written += 1
+    return written
+
+
+def write_zip(source_dir: Path, out_path: Path) -> None:
+    """Zip a staged bundle deterministically (sorted entries, fixed mtime)."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    files = sorted(p for p in source_dir.rglob("*") if p.is_file())
+    with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in files:
+            info = zipfile.ZipInfo(path.relative_to(source_dir).as_posix(), date_time=ZIP_TIMESTAMP)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            archive.writestr(info, path.read_bytes())
+
+
+@dataclass
+class BundleBuilder:
+    """Accumulates bundle content in memory, then writes a `.kaos` archive.
+
+    Importers convert a foreign export into a bundle rather than writing into
+    KAOS databases directly. That way every import — from a KAOS peer or from
+    ChatGPT — goes through the same verification, dedupe and dry-run path.
+    """
+
+    agent_name: str
+    created_at: str = ""
+    facts: list[dict] = field(default_factory=list)
+    entities: list[dict] = field(default_factory=list)
+    relations: list[dict] = field(default_factory=list)
+    notes: dict[str, str] = field(default_factory=dict)
+    sessions: list[dict] = field(default_factory=list)
+    persona: dict[str, str] = field(default_factory=dict)
+    skills: dict[str, dict] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+    def add_fact(self, content: str, *, user_id: str, created_at: str = "", source: str = "import") -> bool:
+        """Record a fact. Returns False when it is empty or a duplicate."""
+        text = redact_text(" ".join(content.split()))
+        if len(text) < 3:
+            return False
+        if any(existing["content"] == text and existing["user_id"] == user_id for existing in self.facts):
+            return False
+        self.facts.append({"user_id": user_id, "content": text, "created_at": created_at, "source": source})
+        return True
+
+    def add_entity(self, name: str, entity_type: str, properties: dict | None = None) -> None:
+        name, entity_type = name.strip(), entity_type.strip()
+        if not name or not entity_type:
+            return
+        if any(e["name"] == name and e["type"] == entity_type for e in self.entities):
+            return
+        self.entities.append({"name": name, "type": entity_type, "properties": properties or {}})
+
+    def add_relation(
+        self,
+        source_name: str,
+        source_type: str,
+        target_name: str,
+        target_type: str,
+        relation_type: str,
+    ) -> None:
+        if not (source_name.strip() and target_name.strip() and relation_type.strip()):
+            return
+        self.add_entity(source_name, source_type)
+        self.add_entity(target_name, target_type)
+        row = {
+            "source": {"name": source_name.strip(), "type": source_type},
+            "target": {"name": target_name.strip(), "type": target_type},
+            "relation_type": relation_type.strip(),
+            "properties": {},
+        }
+        if row not in self.relations:
+            self.relations.append(row)
+
+    def add_note(self, relpath: str, content: str) -> None:
+        """Add a markdown note under notes/<relpath>."""
+        safe = relpath.strip("/").replace("..", "_")
+        if not safe.endswith(".md"):
+            safe = f"{safe}.md"
+        self.notes[safe] = redact_text(content)
+
+    def add_session(self, thread_id: str, messages: list[dict], *, updated_at: str = "") -> None:
+        """Add one conversation thread (masked: this is third-party content)."""
+        if not messages:
+            return
+        self.sessions.append(
+            {
+                "thread_id": str(thread_id),
+                "updated_at": updated_at,
+                "messages": redact_structure(messages, mask_personal=True),
+            }
+        )
+
+    def add_persona(self, filename: str, content: str) -> None:
+        """Add a persona file. Only the four canonical names are accepted."""
+        if filename not in _PERSONA_FILENAMES:
+            self.warnings.append(f"ignored unknown persona file: {filename}")
+            return
+        self.persona[filename] = redact_text(content)
+
+    def add_skill(self, name: str, skill_md: str, references: dict[str, str] | None = None) -> None:
+        self.skills[name] = {
+            "SKILL.md": redact_text(skill_md),
+            "references": {ref: redact_text(body) for ref, body in (references or {}).items()},
+        }
+
+    def _includes(self) -> list[str]:
+        includes: list[str] = []
+        if self.persona:
+            includes.append(SECTION_PERSONA)
+        if self.skills:
+            includes.append(SECTION_SKILLS)
+        if self.facts:
+            includes.append(SECTION_FACTS)
+        if self.entities or self.relations:
+            includes.append(SECTION_GRAPH)
+        if self.notes:
+            includes.append(SECTION_NOTES)
+        if self.sessions:
+            includes.append(SECTION_SESSIONS)
+        return includes
+
+    def counts(self) -> dict[str, int]:
+        return {
+            "facts": len(self.facts),
+            "graph_entities": len(self.entities),
+            "graph_relations": len(self.relations),
+            "notes": len(self.notes),
+            "persona_files": len(self.persona),
+            "sessions": len(self.sessions),
+            "skills": len(self.skills),
+        }
+
+    def is_empty(self) -> bool:
+        return not any(self.counts().values())
+
+    def write(self, out_path: str | Path) -> tuple[Path, BundleManifest]:
+        """Stage the accumulated content and write the archive."""
+        target = Path(out_path)
+        staging = Path(mkdtemp(prefix="kaos-build-"))
+        try:
+            for filename, content in sorted(self.persona.items()):
+                path = staging / "persona" / filename
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
+
+            for name, payload in sorted(self.skills.items()):
+                skill_path = staging / "skills" / name / "SKILL.md"
+                skill_path.parent.mkdir(parents=True, exist_ok=True)
+                skill_path.write_text(payload["SKILL.md"], encoding="utf-8")
+                for ref, body in sorted(payload["references"].items()):
+                    ref_path = staging / "skills" / name / "references" / ref
+                    ref_path.parent.mkdir(parents=True, exist_ok=True)
+                    ref_path.write_text(body, encoding="utf-8")
+
+            if self.facts:
+                write_jsonl(staging / "memory" / "facts.jsonl", sorted(self.facts, key=_fact_sort_key))
+            if self.entities or self.relations:
+                write_jsonl(
+                    staging / "memory" / "graph.entities.jsonl",
+                    sorted(self.entities, key=lambda row: (row["type"], row["name"])),
+                )
+                write_jsonl(
+                    staging / "memory" / "graph.relations.jsonl",
+                    sorted(self.relations, key=_relation_sort_key),
+                )
+            for relpath, content in sorted(self.notes.items()):
+                note_path = staging / "notes" / relpath
+                note_path.parent.mkdir(parents=True, exist_ok=True)
+                note_path.write_text(content, encoding="utf-8")
+            if self.sessions:
+                write_jsonl(
+                    staging / "sessions" / "sessions.jsonl",
+                    sorted(self.sessions, key=lambda row: row["thread_id"]),
+                )
+
+            manifest = build_manifest(
+                staging,
+                agent_name=self.agent_name,
+                includes=self._includes(),
+                counts=self.counts(),
+                created_at=self.created_at,
+            )
+            write_manifest(staging, manifest)
+            write_zip(staging, target)
+        finally:
+            for path in sorted(staging.rglob("*"), reverse=True):
+                path.unlink() if path.is_file() else path.rmdir()
+            staging.rmdir()
+
+        log.info("Built bundle %s from '%s': %s", target, self.agent_name, self.counts())
+        return target, manifest
+
+
+def _fact_sort_key(row: dict) -> tuple:
+    return (str(row.get("created_at", "")), row.get("user_id", ""), row.get("content", ""))
+
+
+def _relation_sort_key(row: dict) -> tuple:
+    return (
+        row["source"]["type"],
+        row["source"]["name"],
+        row["relation_type"],
+        row["target"]["type"],
+        row["target"]["name"],
+    )

--- a/kronos/portability/dbread.py
+++ b/kronos/portability/dbread.py
@@ -1,0 +1,29 @@
+"""Read-only SQLite access for bundle export/import.
+
+Both directions need to look at a database that may not exist yet, without
+creating it and without blocking a live writer. ``get_db`` would create the
+file, so portability reads go through a read-only URI instead.
+"""
+
+import logging
+import sqlite3
+from pathlib import Path
+
+log = logging.getLogger("kronos.portability.dbread")
+
+
+def read_rows(db_path: Path, sql: str, params: tuple = ()) -> list[sqlite3.Row]:
+    """Return rows from an existing database, or [] if it or the table is absent."""
+    if not db_path.exists():
+        return []
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(sql, params).fetchall()
+    except sqlite3.OperationalError as e:
+        # The database exists but the table does not — an agent that never wrote
+        # facts is a valid state, not an error.
+        log.debug("Skipping %s: %s", db_path.name, e)
+        return []
+    finally:
+        conn.close()

--- a/kronos/portability/export.py
+++ b/kronos/portability/export.py
@@ -14,7 +14,6 @@ database that did not already exist and never blocks a live writer.
 
 import json
 import logging
-import sqlite3
 import zipfile
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -22,6 +21,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from kronos.config import settings
+from kronos.portability.dbread import read_rows
 from kronos.portability.manifest import (
     SECTION_FACTS,
     SECTION_GRAPH,
@@ -36,7 +36,7 @@ from kronos.portability.manifest import (
     write_manifest,
 )
 from kronos.portability.redact import redact_structure, redact_text
-from kronos.workspace import Workspace, ws
+from kronos.workspace import Workspace
 
 log = logging.getLogger("kronos.portability.export")
 
@@ -80,23 +80,6 @@ def _is_exportable(path: Path) -> bool:
     if name.endswith(_BLOCKED_SUFFIXES):
         return False
     return path.suffix.lower() in _ALLOWED_SUFFIXES
-
-
-def _read_rows(db_path: Path, sql: str, params: tuple = ()) -> list[sqlite3.Row]:
-    """Read rows from an existing database without creating or locking it."""
-    if not db_path.exists():
-        return []
-    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5)
-    conn.row_factory = sqlite3.Row
-    try:
-        return conn.execute(sql, params).fetchall()
-    except sqlite3.OperationalError as e:
-        # Database exists but the table does not — an agent that never wrote
-        # facts is a valid state, not an error.
-        log.debug("Skipping %s: %s", db_path.name, e)
-        return []
-    finally:
-        conn.close()
 
 
 def _write_jsonl(path: Path, rows: Iterable[dict]) -> int:
@@ -168,7 +151,7 @@ def _export_skills(workspace: Workspace, root: Path, *, warnings: list[str]) -> 
 def _export_facts(root: Path, *, warnings: list[str]) -> int:
     """Dump FTS-indexed facts, ordered for reproducible hashes."""
     db_path = Path(settings.db_dir) / "memory_fts.db"
-    rows = _read_rows(db_path, "SELECT * FROM memory_facts ORDER BY created_at, content")
+    rows = read_rows(db_path, "SELECT * FROM memory_facts ORDER BY created_at, content")
     if not rows:
         warnings.append("no extracted facts found")
 
@@ -194,12 +177,12 @@ def _export_graph(root: Path) -> tuple[int, int]:
     """Dump entities and relations, with relations keyed by (name, type)."""
     db_path = Path(settings.db_dir) / "knowledge_graph.db"
 
-    entities = _read_rows(db_path, "SELECT name, type, properties FROM entities ORDER BY type, name")
+    entities = read_rows(db_path, "SELECT name, type, properties FROM entities ORDER BY type, name")
     entity_rows = [
         {"name": row["name"], "type": row["type"], "properties": _json_or_empty(row["properties"])} for row in entities
     ]
 
-    relations = _read_rows(
+    relations = read_rows(
         db_path,
         """
         SELECT s.name AS source_name, s.type AS source_type,
@@ -236,7 +219,7 @@ def _json_or_empty(raw: str | None) -> dict:
 
 def _export_shared_facts(root: Path) -> int:
     """Dump only facts this agent contributed to the swarm ledger."""
-    rows = _read_rows(
+    rows = read_rows(
         Path(settings.swarm_db_path),
         """
         SELECT user_id, fact, created_at FROM shared_user_facts
@@ -258,7 +241,7 @@ def _export_schedule(root: Path, *, include_transport_ids: bool) -> int:
     dropped and the task is marked ``needs_rebind`` — the importer then knows the
     task cannot fire until it is attached to a local chat.
     """
-    rows = _read_rows(
+    rows = read_rows(
         Path(settings.db_dir) / "scheduled_tasks.db",
         """
         SELECT chat_id, topic_id, thread_id, run_at, recur_seconds, message, kind
@@ -311,7 +294,7 @@ def _export_sessions(root: Path) -> int:
     A single file avoids turning thread ids — which contain ``:`` — into
     filesystem-hostile filenames.
     """
-    rows = _read_rows(
+    rows = read_rows(
         Path(settings.db_path),
         "SELECT thread_id, messages, updated_at FROM sessions ORDER BY thread_id",
     )
@@ -356,6 +339,10 @@ def export_bundle(
 ) -> ExportReport:
     """Export the configured agent into a `.kaos` bundle at ``out_path``."""
     target = Path(out_path)
+    # Resolved here, not at import time: tests and multi-agent hosts swap
+    # kronos.workspace.ws, and a module-level binding would freeze the first one.
+    from kronos.workspace import ws
+
     space = workspace or ws
     warnings: list[str] = []
     counts: dict[str, int] = {}

--- a/kronos/portability/export.py
+++ b/kronos/portability/export.py
@@ -14,13 +14,13 @@ database that did not already exist and never blocks a live writer.
 
 import json
 import logging
-import zipfile
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from kronos.config import settings
+from kronos.portability.build import write_jsonl, write_zip
 from kronos.portability.dbread import read_rows
 from kronos.portability.manifest import (
     SECTION_FACTS,
@@ -52,10 +52,6 @@ _ALLOWED_SUFFIXES = (".md", ".txt", ".json", ".yaml", ".yml", ".csv")
 _MAX_COPY_FILE_BYTES = 5 * 1024 * 1024
 _LARGE_BUNDLE_WARN_BYTES = 50 * 1024 * 1024
 
-# A fixed timestamp keeps the archive byte-identical across runs; the real
-# creation time lives in the manifest, which is the one place time belongs.
-_ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
-
 
 @dataclass
 class ExportReport:
@@ -80,17 +76,6 @@ def _is_exportable(path: Path) -> bool:
     if name.endswith(_BLOCKED_SUFFIXES):
         return False
     return path.suffix.lower() in _ALLOWED_SUFFIXES
-
-
-def _write_jsonl(path: Path, rows: Iterable[dict]) -> int:
-    """Write rows as canonical JSONL. Returns the number of rows written."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    written = 0
-    with open(path, "w", encoding="utf-8") as handle:
-        for row in rows:
-            handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
-            written += 1
-    return written
 
 
 def _copy_text_file(src: Path, dest: Path, *, warnings: list[str]) -> bool:
@@ -170,7 +155,7 @@ def _export_facts(root: Path, *, warnings: list[str]) -> int:
                 fact["relevance"] = row["relevance"]
             yield fact
 
-    return _write_jsonl(root / "memory" / "facts.jsonl", _payload())
+    return write_jsonl(root / "memory" / "facts.jsonl", _payload())
 
 
 def _export_graph(root: Path) -> tuple[int, int]:
@@ -204,8 +189,8 @@ def _export_graph(root: Path) -> tuple[int, int]:
         for row in relations
     ]
 
-    written_entities = _write_jsonl(root / "memory" / "graph.entities.jsonl", entity_rows)
-    written_relations = _write_jsonl(root / "memory" / "graph.relations.jsonl", relation_rows)
+    written_entities = write_jsonl(root / "memory" / "graph.entities.jsonl", entity_rows)
+    written_relations = write_jsonl(root / "memory" / "graph.relations.jsonl", relation_rows)
     return written_entities, written_relations
 
 
@@ -231,7 +216,7 @@ def _export_shared_facts(root: Path) -> int:
     payload = [
         {"user_id": row["user_id"], "fact": redact_text(row["fact"]), "created_at": row["created_at"]} for row in rows
     ]
-    return _write_jsonl(root / "memory" / "shared_facts.jsonl", payload)
+    return write_jsonl(root / "memory" / "shared_facts.jsonl", payload)
 
 
 def _export_schedule(root: Path, *, include_transport_ids: bool) -> int:
@@ -271,7 +256,7 @@ def _export_schedule(root: Path, *, include_transport_ids: bool) -> int:
             task |= {"chat_id": None, "topic_id": None, "thread_id": None, "needs_rebind": True}
         payload.append(task)
 
-    return _write_jsonl(root / "schedule" / "tasks.jsonl", payload)
+    return write_jsonl(root / "schedule" / "tasks.jsonl", payload)
 
 
 def _export_notes(workspace: Workspace, root: Path, *, warnings: list[str]) -> int:
@@ -313,19 +298,7 @@ def _export_sessions(root: Path) -> int:
             }
         )
 
-    return _write_jsonl(root / "sessions" / "sessions.jsonl", payload)
-
-
-def _write_zip(source_dir: Path, out_path: Path) -> None:
-    """Zip a staged bundle deterministically (sorted entries, fixed mtime)."""
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    files = sorted(p for p in source_dir.rglob("*") if p.is_file())
-    with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
-        for path in files:
-            info = zipfile.ZipInfo(path.relative_to(source_dir).as_posix(), date_time=_ZIP_TIMESTAMP)
-            info.compress_type = zipfile.ZIP_DEFLATED
-            info.external_attr = 0o644 << 16
-            archive.writestr(info, path.read_bytes())
+    return write_jsonl(root / "sessions" / "sessions.jsonl", payload)
 
 
 def export_bundle(
@@ -380,7 +353,7 @@ def export_bundle(
             created_at=created_at,
         )
         write_manifest(root, manifest)
-        _write_zip(root, target)
+        write_zip(root, target)
 
     size = target.stat().st_size
     if size > _LARGE_BUNDLE_WARN_BYTES:

--- a/kronos/portability/export.py
+++ b/kronos/portability/export.py
@@ -1,0 +1,403 @@
+"""Export an agent as a `.kaos` bundle.
+
+What goes in: persona files, local skills, extracted facts, knowledge graph,
+this agent's shared facts, pending schedule, and — opt-in — notes and session
+history.
+
+What never goes in, under any flag: `.env*`, Telegram `*.session`, SQLite files
+themselves, the Qdrant vector store (re-embedded on import), and audit logs.
+The blocklist is enforced in ``_is_exportable`` and covered by a negative test.
+
+Databases are read through a read-only SQLite URI so exporting never creates a
+database that did not already exist and never blocks a live writer.
+"""
+
+import json
+import logging
+import sqlite3
+import zipfile
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from kronos.config import settings
+from kronos.portability.manifest import (
+    SECTION_FACTS,
+    SECTION_GRAPH,
+    SECTION_NOTES,
+    SECTION_PERSONA,
+    SECTION_SCHEDULE,
+    SECTION_SESSIONS,
+    SECTION_SHARED_FACTS,
+    SECTION_SKILLS,
+    BundleManifest,
+    build_manifest,
+    write_manifest,
+)
+from kronos.portability.redact import redact_structure, redact_text
+from kronos.workspace import Workspace, ws
+
+log = logging.getLogger("kronos.portability.export")
+
+# Files that must never leave the machine, regardless of location or flags.
+_BLOCKED_NAMES = frozenset({".env", ".envrc"})
+_BLOCKED_SUFFIXES = (".session", ".session-journal", ".db", ".db-wal", ".db-shm", ".sqlite", ".sqlite3", ".pem", ".key")
+_BLOCKED_PREFIXES = (".env",)
+_BLOCKED_DIR_NAMES = frozenset({"qdrant", ".git", "__pycache__", "logs"})
+
+# Text-ish payloads we are willing to copy verbatim.
+_ALLOWED_SUFFIXES = (".md", ".txt", ".json", ".yaml", ".yml", ".csv")
+
+_MAX_COPY_FILE_BYTES = 5 * 1024 * 1024
+_LARGE_BUNDLE_WARN_BYTES = 50 * 1024 * 1024
+
+# A fixed timestamp keeps the archive byte-identical across runs; the real
+# creation time lives in the manifest, which is the one place time belongs.
+_ZIP_TIMESTAMP = (1980, 1, 1, 0, 0, 0)
+
+
+@dataclass
+class ExportReport:
+    """Outcome of one export."""
+
+    path: Path
+    manifest: BundleManifest
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def counts(self) -> dict[str, int]:
+        return self.manifest.counts
+
+
+def _is_exportable(path: Path) -> bool:
+    """Whether a file may be copied into a bundle."""
+    if any(part in _BLOCKED_DIR_NAMES for part in path.parts):
+        return False
+    name = path.name
+    if name in _BLOCKED_NAMES or name.startswith(_BLOCKED_PREFIXES):
+        return False
+    if name.endswith(_BLOCKED_SUFFIXES):
+        return False
+    return path.suffix.lower() in _ALLOWED_SUFFIXES
+
+
+def _read_rows(db_path: Path, sql: str, params: tuple = ()) -> list[sqlite3.Row]:
+    """Read rows from an existing database without creating or locking it."""
+    if not db_path.exists():
+        return []
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5)
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(sql, params).fetchall()
+    except sqlite3.OperationalError as e:
+        # Database exists but the table does not — an agent that never wrote
+        # facts is a valid state, not an error.
+        log.debug("Skipping %s: %s", db_path.name, e)
+        return []
+    finally:
+        conn.close()
+
+
+def _write_jsonl(path: Path, rows: Iterable[dict]) -> int:
+    """Write rows as canonical JSONL. Returns the number of rows written."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    written = 0
+    with open(path, "w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+            written += 1
+    return written
+
+
+def _copy_text_file(src: Path, dest: Path, *, warnings: list[str]) -> bool:
+    """Copy one file with credential redaction. Returns False if skipped."""
+    if not _is_exportable(src):
+        return False
+    if src.stat().st_size > _MAX_COPY_FILE_BYTES:
+        warnings.append(f"skipped oversized file: {src.name} (>{_MAX_COPY_FILE_BYTES // 1024 // 1024} MB)")
+        return False
+    try:
+        content = src.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        warnings.append(f"skipped non-text file: {src.name}")
+        return False
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(redact_text(content), encoding="utf-8")
+    return True
+
+
+def _export_persona(workspace: Workspace, root: Path, *, warnings: list[str]) -> int:
+    """Copy the four persona files that define who the agent is."""
+    count = 0
+    for source in (workspace.identity, workspace.soul, workspace.agents, workspace.methodology):
+        if source.exists() and _copy_text_file(source, root / "persona" / source.name, warnings=warnings):
+            count += 1
+    return count
+
+
+def _export_skills(workspace: Workspace, root: Path, *, warnings: list[str]) -> int:
+    """Copy local skills (SKILL.md plus references). Shared skills stay behind.
+
+    A shared workspace belongs to the deployment, not to this agent, so
+    exporting it would hand over someone else's material.
+    """
+    skills_dir = workspace.skills_dir
+    if not skills_dir.exists():
+        return 0
+
+    count = 0
+    for skill_dir in sorted(p for p in skills_dir.iterdir() if p.is_dir()):
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.exists():
+            continue
+        if not _copy_text_file(skill_md, root / "skills" / skill_dir.name / "SKILL.md", warnings=warnings):
+            continue
+        count += 1
+        refs = skill_dir / "references"
+        if refs.is_dir():
+            for ref in sorted(p for p in refs.rglob("*") if p.is_file()):
+                _copy_text_file(
+                    ref,
+                    root / "skills" / skill_dir.name / "references" / ref.relative_to(refs),
+                    warnings=warnings,
+                )
+    return count
+
+
+def _export_facts(root: Path, *, warnings: list[str]) -> int:
+    """Dump FTS-indexed facts, ordered for reproducible hashes."""
+    db_path = Path(settings.db_dir) / "memory_fts.db"
+    rows = _read_rows(db_path, "SELECT * FROM memory_facts ORDER BY created_at, content")
+    if not rows:
+        warnings.append("no extracted facts found")
+
+    def _payload() -> Iterable[dict]:
+        for row in rows:
+            keys = row.keys()
+            fact = {
+                "user_id": row["user_id"],
+                "content": redact_text(row["content"]),
+                "source": row["source"] if "source" in keys else "",
+                "created_at": row["created_at"],
+            }
+            # relevance arrived with the Ebbinghaus decay migration; mem0_id is a
+            # local vector pointer and is meaningless in another installation.
+            if "relevance" in keys and row["relevance"] is not None:
+                fact["relevance"] = row["relevance"]
+            yield fact
+
+    return _write_jsonl(root / "memory" / "facts.jsonl", _payload())
+
+
+def _export_graph(root: Path) -> tuple[int, int]:
+    """Dump entities and relations, with relations keyed by (name, type)."""
+    db_path = Path(settings.db_dir) / "knowledge_graph.db"
+
+    entities = _read_rows(db_path, "SELECT name, type, properties FROM entities ORDER BY type, name")
+    entity_rows = [
+        {"name": row["name"], "type": row["type"], "properties": _json_or_empty(row["properties"])} for row in entities
+    ]
+
+    relations = _read_rows(
+        db_path,
+        """
+        SELECT s.name AS source_name, s.type AS source_type,
+               t.name AS target_name, t.type AS target_type,
+               r.relation_type, r.properties
+        FROM relations r
+        JOIN entities s ON s.id = r.source_id
+        JOIN entities t ON t.id = r.target_id
+        ORDER BY s.type, s.name, r.relation_type, t.type, t.name
+        """,
+    )
+    relation_rows = [
+        {
+            "source": {"name": row["source_name"], "type": row["source_type"]},
+            "target": {"name": row["target_name"], "type": row["target_type"]},
+            "relation_type": row["relation_type"],
+            "properties": _json_or_empty(row["properties"]),
+        }
+        for row in relations
+    ]
+
+    written_entities = _write_jsonl(root / "memory" / "graph.entities.jsonl", entity_rows)
+    written_relations = _write_jsonl(root / "memory" / "graph.relations.jsonl", relation_rows)
+    return written_entities, written_relations
+
+
+def _json_or_empty(raw: str | None) -> dict:
+    try:
+        parsed = json.loads(raw or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _export_shared_facts(root: Path) -> int:
+    """Dump only facts this agent contributed to the swarm ledger."""
+    rows = _read_rows(
+        Path(settings.swarm_db_path),
+        """
+        SELECT user_id, fact, created_at FROM shared_user_facts
+        WHERE source_agent = ?
+        ORDER BY created_at, fact
+        """,
+        (settings.agent_name,),
+    )
+    payload = [
+        {"user_id": row["user_id"], "fact": redact_text(row["fact"]), "created_at": row["created_at"]} for row in rows
+    ]
+    return _write_jsonl(root / "memory" / "shared_facts.jsonl", payload)
+
+
+def _export_schedule(root: Path, *, include_transport_ids: bool) -> int:
+    """Dump pending reminders/follow-ups.
+
+    Transport ids identify someone's private chats, so by default they are
+    dropped and the task is marked ``needs_rebind`` — the importer then knows the
+    task cannot fire until it is attached to a local chat.
+    """
+    rows = _read_rows(
+        Path(settings.db_dir) / "scheduled_tasks.db",
+        """
+        SELECT chat_id, topic_id, thread_id, run_at, recur_seconds, message, kind
+        FROM scheduled_tasks
+        WHERE agent_name = ? AND status = 'pending'
+        ORDER BY run_at, message
+        """,
+        (settings.agent_name,),
+    )
+
+    payload = []
+    for row in rows:
+        task = {
+            "run_at": row["run_at"],
+            "recur_seconds": row["recur_seconds"],
+            "message": redact_text(row["message"]),
+            "kind": row["kind"],
+        }
+        if include_transport_ids:
+            task |= {
+                "chat_id": row["chat_id"],
+                "topic_id": row["topic_id"],
+                "thread_id": row["thread_id"],
+                "needs_rebind": False,
+            }
+        else:
+            task |= {"chat_id": None, "topic_id": None, "thread_id": None, "needs_rebind": True}
+        payload.append(task)
+
+    return _write_jsonl(root / "schedule" / "tasks.jsonl", payload)
+
+
+def _export_notes(workspace: Workspace, root: Path, *, warnings: list[str]) -> int:
+    """Copy markdown notes (owner-authored knowledge)."""
+    notes_dir = workspace.notes_dir
+    if not notes_dir.exists():
+        return 0
+    count = 0
+    for note in sorted(p for p in notes_dir.rglob("*.md") if p.is_file()):
+        if _copy_text_file(note, root / "notes" / note.relative_to(notes_dir), warnings=warnings):
+            count += 1
+    return count
+
+
+def _export_sessions(root: Path) -> int:
+    """Dump conversation history, one JSONL row per thread.
+
+    Session content is third-party material and tool output, so it is masked
+    with ``redact_structure`` rather than the lighter owner-content redaction.
+    A single file avoids turning thread ids — which contain ``:`` — into
+    filesystem-hostile filenames.
+    """
+    rows = _read_rows(
+        Path(settings.db_path),
+        "SELECT thread_id, messages, updated_at FROM sessions ORDER BY thread_id",
+    )
+
+    payload = []
+    for row in rows:
+        try:
+            messages = json.loads(row["messages"] or "[]")
+        except json.JSONDecodeError:
+            continue
+        payload.append(
+            {
+                "thread_id": row["thread_id"],
+                "updated_at": str(row["updated_at"]),
+                "messages": redact_structure(messages, mask_personal=True),
+            }
+        )
+
+    return _write_jsonl(root / "sessions" / "sessions.jsonl", payload)
+
+
+def _write_zip(source_dir: Path, out_path: Path) -> None:
+    """Zip a staged bundle deterministically (sorted entries, fixed mtime)."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    files = sorted(p for p in source_dir.rglob("*") if p.is_file())
+    with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in files:
+            info = zipfile.ZipInfo(path.relative_to(source_dir).as_posix(), date_time=_ZIP_TIMESTAMP)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o644 << 16
+            archive.writestr(info, path.read_bytes())
+
+
+def export_bundle(
+    out_path: str | Path,
+    *,
+    include_notes: bool = False,
+    include_sessions: bool = False,
+    include_transport_ids: bool = False,
+    created_at: str = "",
+    workspace: Workspace | None = None,
+) -> ExportReport:
+    """Export the configured agent into a `.kaos` bundle at ``out_path``."""
+    target = Path(out_path)
+    space = workspace or ws
+    warnings: list[str] = []
+    counts: dict[str, int] = {}
+    includes = [
+        SECTION_PERSONA,
+        SECTION_SKILLS,
+        SECTION_FACTS,
+        SECTION_GRAPH,
+        SECTION_SHARED_FACTS,
+        SECTION_SCHEDULE,
+    ]
+
+    with TemporaryDirectory(prefix="kaos-export-") as staging:
+        root = Path(staging)
+
+        counts["persona_files"] = _export_persona(space, root, warnings=warnings)
+        counts["skills"] = _export_skills(space, root, warnings=warnings)
+        counts["facts"] = _export_facts(root, warnings=warnings)
+        counts["graph_entities"], counts["graph_relations"] = _export_graph(root)
+        counts["shared_facts"] = _export_shared_facts(root)
+        counts["scheduled_tasks"] = _export_schedule(root, include_transport_ids=include_transport_ids)
+
+        if include_notes:
+            counts["notes"] = _export_notes(space, root, warnings=warnings)
+            includes.append(SECTION_NOTES)
+        if include_sessions:
+            counts["sessions"] = _export_sessions(root)
+            includes.append(SECTION_SESSIONS)
+
+        manifest = build_manifest(
+            root,
+            agent_name=settings.agent_name,
+            includes=includes,
+            counts=counts,
+            created_at=created_at,
+        )
+        write_manifest(root, manifest)
+        _write_zip(root, target)
+
+    size = target.stat().st_size
+    if size > _LARGE_BUNDLE_WARN_BYTES:
+        warnings.append(f"bundle is {size // 1024 // 1024} MB — consider exporting without sessions/notes")
+
+    log.info("Exported bundle: %s (%d bytes, sections: %s)", target, size, ", ".join(manifest.includes))
+    return ExportReport(path=target, manifest=manifest, warnings=warnings)

--- a/kronos/portability/import_.py
+++ b/kronos/portability/import_.py
@@ -1,0 +1,469 @@
+"""Import a `.kaos` bundle into the local agent.
+
+Design rules, in order of importance:
+
+1. **Verify before writing.** The manifest is checked against the payload; a
+   single altered byte aborts the import before any database is touched.
+2. **Idempotent.** Importing the same bundle twice changes nothing the second
+   time — dedupe keys are content-based, not id-based, because ids from another
+   installation are meaningless here.
+3. **Never activate silently.** Imported skills land as ``draft`` and persona
+   files are left alone unless the caller explicitly asks otherwise: a bundle is
+   someone else's material until a human reviews it.
+4. **Dry-run is real.** ``dry_run=True`` produces the full report and writes
+   nothing, so the same code path answers "what would this do?".
+"""
+
+import json
+import logging
+import re
+import zipfile
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from kronos.config import settings
+from kronos.portability.dbread import read_rows
+from kronos.portability.manifest import (
+    SECTION_NOTES,
+    SECTION_SESSIONS,
+    BundleError,
+    BundleManifest,
+    read_manifest,
+    verify_manifest,
+)
+from kronos.skills.store import SkillStore, _parse_frontmatter
+from kronos.workspace import Workspace
+
+log = logging.getLogger("kronos.portability.import")
+
+MERGE_SKIP = "skip"
+MERGE_OVERWRITE = "overwrite"
+MERGE_APPEND = "append"
+MERGE_MODES = (MERGE_SKIP, MERGE_OVERWRITE, MERGE_APPEND)
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+@dataclass
+class ImportReport:
+    """What an import did — or would do, when dry_run is set."""
+
+    source: Path
+    source_agent: str
+    merge: str
+    dry_run: bool
+    manifest: BundleManifest | None = None
+    created: dict[str, int] = field(default_factory=dict)
+    skipped: dict[str, int] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+    def _bump(self, bucket: dict[str, int], key: str, delta: int = 1) -> None:
+        bucket[key] = bucket.get(key, 0) + delta
+
+    def add(self, key: str, delta: int = 1) -> None:
+        self._bump(self.created, key, delta)
+
+    def skip(self, key: str, delta: int = 1) -> None:
+        self._bump(self.skipped, key, delta)
+
+    @property
+    def total_created(self) -> int:
+        return sum(self.created.values())
+
+    def render(self) -> str:
+        """Human-readable summary for CLI output."""
+        head = f"{'Would import' if self.dry_run else 'Imported'} bundle from agent '{self.source_agent}'"
+        lines = [head, f"  merge mode: {self.merge}"]
+        for key in sorted(set(self.created) | set(self.skipped)):
+            lines.append(f"  {key}: +{self.created.get(key, 0)} new, {self.skipped.get(key, 0)} skipped")
+        for warning in self.warnings:
+            lines.append(f"  ! {warning}")
+        return "\n".join(lines)
+
+
+def _normalize(text: str) -> str:
+    """Content key for dedupe: whitespace- and case-insensitive."""
+    return _WHITESPACE_RE.sub(" ", text.strip()).casefold()
+
+
+def _safe_extract(archive_path: Path, dest: Path) -> None:
+    """Extract a zip, refusing entries that escape the destination.
+
+    A bundle arrives from outside; ``..`` or absolute members would let it write
+    anywhere on disk.
+    """
+    with zipfile.ZipFile(archive_path) as archive:
+        for member in archive.infolist():
+            name = member.filename
+            if name.endswith("/"):
+                continue
+            target = (dest / name).resolve()
+            if not str(target).startswith(str(dest.resolve())):
+                raise BundleError(f"bundle contains an unsafe path: {name}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(member) as src, open(target, "wb") as out:
+                out.write(src.read())
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    rows: list[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            rows.append(parsed)
+    return rows
+
+
+def _import_facts(root: Path, report: ImportReport) -> None:
+    """Index facts that are not already present (normalized comparison)."""
+    rows = _read_jsonl(root / "memory" / "facts.jsonl")
+    if not rows:
+        return
+
+    from kronos.memory import fts
+
+    existing: dict[str, set[str]] = {}
+    for row in rows:
+        content = str(row.get("content", "")).strip()
+        user_id = str(row.get("user_id", "")) or settings.agent_name
+        if len(content) < 3:
+            report.skip("facts")
+            continue
+
+        if user_id not in existing:
+            db_path = Path(settings.db_dir) / "memory_fts.db"
+            existing[user_id] = {
+                _normalize(str(row["content"]))
+                for row in read_rows(db_path, "SELECT content FROM memory_facts WHERE user_id = ?", (user_id,))
+            }
+
+        key = _normalize(content)
+        if key in existing[user_id]:
+            report.skip("facts")
+            continue
+
+        existing[user_id].add(key)
+        report.add("facts")
+        if not report.dry_run:
+            fts.index_fact(content, user_id)
+
+
+def _import_graph(root: Path, report: ImportReport) -> None:
+    """Upsert entities and relations; both stores are already UNIQUE-keyed."""
+    entities = _read_jsonl(root / "memory" / "graph.entities.jsonl")
+    relations = _read_jsonl(root / "memory" / "graph.relations.jsonl")
+    if not entities and not relations:
+        return
+
+    from kronos.memory import knowledge_graph
+
+    for row in entities:
+        name, entity_type = str(row.get("name", "")).strip(), str(row.get("type", "")).strip()
+        if not name or not entity_type:
+            report.skip("graph_entities")
+            continue
+        report.add("graph_entities")
+        if not report.dry_run:
+            knowledge_graph.add_entity(name, entity_type, row.get("properties") or {})
+
+    for row in relations:
+        source, target = row.get("source") or {}, row.get("target") or {}
+        relation_type = str(row.get("relation_type", "")).strip()
+        if not (source.get("name") and target.get("name") and relation_type):
+            report.skip("graph_relations")
+            continue
+        report.add("graph_relations")
+        if not report.dry_run:
+            knowledge_graph.add_relation(
+                str(source["name"]),
+                str(source.get("type", "concept")),
+                str(target["name"]),
+                str(target.get("type", "concept")),
+                relation_type,
+                row.get("properties") or {},
+            )
+
+
+def _import_shared_facts(root: Path, report: ImportReport) -> None:
+    """Adopt shared facts under this agent's name.
+
+    The exporting agent does not exist in this installation, so attributing the
+    fact to it would create a phantom source.
+    """
+    rows = _read_jsonl(root / "memory" / "shared_facts.jsonl")
+    if not rows:
+        return
+
+    from kronos.swarm_store import get_swarm
+
+    store = None if report.dry_run else get_swarm()
+    for row in rows:
+        fact = str(row.get("fact", "")).strip()
+        user_id = str(row.get("user_id", "")) or settings.agent_name
+        if not fact:
+            report.skip("shared_facts")
+            continue
+        if report.dry_run:
+            report.add("shared_facts")
+            continue
+        if store.add_shared_fact(user_id=user_id, fact=fact, source_agent=settings.agent_name):
+            report.add("shared_facts")
+        else:
+            report.skip("shared_facts")
+
+
+def _import_skills(root: Path, space: Workspace, report: ImportReport) -> None:
+    """Install skills as drafts, honouring the merge mode for existing names."""
+    skills_root = root / "skills"
+    if not skills_root.is_dir():
+        return
+
+    store = SkillStore(space.root)
+    imported_at = datetime.now(UTC).isoformat(timespec="seconds")
+
+    for skill_dir in sorted(p for p in skills_root.iterdir() if p.is_dir()):
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.exists():
+            continue
+        name = skill_dir.name
+
+        if store.get(name) and report.merge != MERGE_OVERWRITE:
+            report.skip("skills")
+            report.warnings.append(f"skill '{name}' already exists — kept local version")
+            continue
+
+        meta, body = _parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+        meta |= {
+            "name": name,
+            "status": "draft",
+            "imported_from": report.source_agent,
+            "imported_at": imported_at,
+            "review_required": True,
+        }
+        report.add("skills")
+        if report.dry_run:
+            continue
+
+        store.add_skill(name, body, meta)
+        refs_src = skill_dir / "references"
+        if refs_src.is_dir():
+            refs_dest = space.skills_dir / name / "references"
+            refs_dest.mkdir(parents=True, exist_ok=True)
+            for ref in sorted(p for p in refs_src.rglob("*") if p.is_file()):
+                dest = refs_dest / ref.relative_to(refs_src)
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_text(ref.read_text(encoding="utf-8"), encoding="utf-8")
+                report.add("skill_references")
+
+
+def _import_persona(root: Path, space: Workspace, report: ImportReport) -> None:
+    """Persona is identity — never replaced implicitly.
+
+    ``skip`` (default) leaves local persona untouched, ``append`` adds a clearly
+    marked imported section, ``overwrite`` replaces the file.
+    """
+    persona_dir = root / "persona"
+    if not persona_dir.is_dir():
+        return
+
+    targets = {
+        "IDENTITY.md": space.identity,
+        "SOUL.md": space.soul,
+        "AGENTS.md": space.agents,
+        "methodology.md": space.methodology,
+    }
+
+    for source in sorted(p for p in persona_dir.iterdir() if p.is_file()):
+        target = targets.get(source.name)
+        if target is None:
+            report.skip("persona_files")
+            continue
+
+        content = source.read_text(encoding="utf-8")
+        if target.exists() and report.merge == MERGE_SKIP:
+            report.skip("persona_files")
+            report.warnings.append(f"persona {source.name} kept local (merge=skip)")
+            continue
+
+        report.add("persona_files")
+        if report.dry_run:
+            continue
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists() and report.merge == MERGE_APPEND:
+            stamp = f"\n\n## Imported from '{report.source_agent}' ({datetime.now(UTC).date().isoformat()})\n\n"
+            with open(target, "a", encoding="utf-8") as handle:
+                handle.write(stamp + content.strip() + "\n")
+        else:
+            target.write_text(content, encoding="utf-8")
+
+
+def _import_notes(root: Path, space: Workspace, report: ImportReport) -> None:
+    """Copy notes, respecting the merge mode per file."""
+    notes_root = root / "notes"
+    if not notes_root.is_dir():
+        return
+
+    for note in sorted(p for p in notes_root.rglob("*.md") if p.is_file()):
+        target = space.notes_dir / note.relative_to(notes_root)
+        if target.exists() and report.merge == MERGE_SKIP:
+            report.skip("notes")
+            continue
+
+        report.add("notes")
+        if report.dry_run:
+            continue
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        content = note.read_text(encoding="utf-8")
+        if target.exists() and report.merge == MERGE_APPEND:
+            with open(target, "a", encoding="utf-8") as handle:
+                handle.write(f"\n\n<!-- imported from '{report.source_agent}' -->\n\n{content.strip()}\n")
+        else:
+            target.write_text(content, encoding="utf-8")
+
+
+def _import_schedule(root: Path, report: ImportReport, *, rebind_chat: int | None) -> None:
+    """Recreate pending reminders/follow-ups.
+
+    A task without a local chat to fire into is useless and would silently never
+    deliver, so ``needs_rebind`` tasks are skipped unless ``rebind_chat`` says
+    where they belong.
+    """
+    rows = _read_jsonl(root / "schedule" / "tasks.jsonl")
+    if not rows:
+        return
+
+    from kronos import scheduled_tasks
+
+    for row in rows:
+        needs_rebind = bool(row.get("needs_rebind"))
+        chat_id = rebind_chat if needs_rebind else row.get("chat_id")
+        if chat_id is None:
+            report.skip("scheduled_tasks")
+            report.warnings.append("scheduled tasks skipped — pass rebind_chat to attach them to a chat")
+            continue
+
+        message = str(row.get("message", "")).strip()
+        if not message:
+            report.skip("scheduled_tasks")
+            continue
+
+        report.add("scheduled_tasks")
+        if report.dry_run:
+            continue
+
+        topic_id = None if needs_rebind else row.get("topic_id")
+        thread_id = str(chat_id) if needs_rebind else str(row.get("thread_id") or chat_id)
+        scheduled_tasks.add_task(
+            agent_name=settings.agent_name,
+            chat_id=int(chat_id),
+            topic_id=topic_id,
+            thread_id=thread_id,
+            run_at=float(row.get("run_at") or 0.0),
+            message=message,
+            recur_seconds=int(row.get("recur_seconds") or 0),
+            kind=str(row.get("kind") or "reminder"),
+        )
+
+
+def _import_sessions(root: Path, space: Workspace, report: ImportReport) -> None:
+    """Archive session history into notes/inbox as readable markdown.
+
+    Deliberately NOT written into the live session store: thread ids come from
+    another installation, and overwriting a real conversation's history to
+    "restore" a foreign one is a data-loss bug wearing a feature's clothes. As an
+    inbox note the history stays available to the agent through its own files.
+    """
+    sessions_file = root / "sessions" / "sessions.jsonl"
+    rows = _read_jsonl(sessions_file)
+    if not rows:
+        return
+
+    lines = [f"# Imported sessions from '{report.source_agent}'", ""]
+    for row in rows:
+        lines.append(f"## thread {row.get('thread_id', 'unknown')} (updated {row.get('updated_at', '')})")
+        for message in row.get("messages") or []:
+            if not isinstance(message, dict):
+                continue
+            role = str(message.get("type") or message.get("role") or "message")
+            content = message.get("content")
+            text = content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
+            lines.append(f"- **{role}**: {text}")
+        lines.append("")
+
+    report.add("session_threads", len(rows))
+    if report.dry_run:
+        return
+
+    target = space.inbox_dir / f"imported-sessions-{report.source_agent}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("\n".join(lines), encoding="utf-8")
+
+
+def import_bundle(
+    path: str | Path,
+    *,
+    merge: str = MERGE_SKIP,
+    dry_run: bool = False,
+    rebind_chat: int | None = None,
+    workspace: Workspace | None = None,
+) -> ImportReport:
+    """Import a bundle into the configured agent and return what happened."""
+    if merge not in MERGE_MODES:
+        raise BundleError(f"unknown merge mode '{merge}' (expected one of: {', '.join(MERGE_MODES)})")
+
+    archive = Path(path)
+    if not archive.exists():
+        raise BundleError(f"bundle not found: {archive}")
+
+    # Resolved at call time so a swapped kronos.workspace.ws is honoured.
+    from kronos.workspace import ws
+
+    space = workspace or ws
+
+    with TemporaryDirectory(prefix="kaos-import-") as staging:
+        root = Path(staging)
+        _safe_extract(archive, root)
+
+        manifest = read_manifest(root)
+        problems = verify_manifest(root)
+        if problems:
+            raise BundleError("bundle failed verification: " + "; ".join(problems[:5]))
+
+        report = ImportReport(
+            source=archive,
+            source_agent=manifest.agent_name,
+            merge=merge,
+            dry_run=dry_run,
+            manifest=manifest,
+        )
+
+        _import_facts(root, report)
+        _import_graph(root, report)
+        _import_shared_facts(root, report)
+        _import_skills(root, space, report)
+        _import_persona(root, space, report)
+        _import_schedule(root, report, rebind_chat=rebind_chat)
+        if SECTION_NOTES in manifest.includes:
+            _import_notes(root, space, report)
+        if SECTION_SESSIONS in manifest.includes:
+            _import_sessions(root, space, report)
+
+    log.info(
+        "Bundle import %s: %d new records from '%s'",
+        "planned" if dry_run else "done",
+        report.total_created,
+        report.source_agent,
+    )
+    return report

--- a/kronos/portability/importers/__init__.py
+++ b/kronos/portability/importers/__init__.py
@@ -1,0 +1,70 @@
+"""Importers that convert a foreign export into a `.kaos` bundle.
+
+Every importer produces a bundle rather than writing into KAOS databases, so a
+history coming from ChatGPT, Obsidian or Letta goes through exactly the same
+verification, dedupe, merge and dry-run path as a bundle from a KAOS peer.
+
+Contract per importer module:
+
+    NAME: str
+    def detect(path: Path) -> bool
+    def to_bundle(path: Path, out_path: Path, *, limit: int | None = None) -> ImporterResult
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import ModuleType
+
+from kronos.portability.importers import chatgpt, obsidian
+from kronos.portability.manifest import BundleError, BundleManifest
+
+
+@dataclass
+class ImporterResult:
+    """A bundle produced from a foreign export."""
+
+    importer: str
+    bundle: Path
+    manifest: BundleManifest
+    counts: dict[str, int] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+
+    def render(self) -> str:
+        lines = [f"Converted {self.importer} export → {self.bundle.name}"]
+        for key, value in sorted(self.counts.items()):
+            if value:
+                lines.append(f"  {key}: {value}")
+        for warning in self.warnings:
+            lines.append(f"  ! {warning}")
+        return "\n".join(lines)
+
+
+_REGISTRY: dict[str, ModuleType] = {
+    chatgpt.NAME: chatgpt,
+    obsidian.NAME: obsidian,
+}
+
+
+def available() -> list[str]:
+    """Importer names, sorted for stable CLI help output."""
+    return sorted(_REGISTRY)
+
+
+def get_importer(name: str) -> ModuleType:
+    """Look up an importer by name."""
+    try:
+        return _REGISTRY[name]
+    except KeyError:
+        raise BundleError(f"unknown importer '{name}' (available: {', '.join(available())})") from None
+
+
+def detect_importer(path: str | Path) -> str | None:
+    """Guess which importer can read this path, or None if none recognise it."""
+    target = Path(path)
+    for name in available():
+        if _REGISTRY[name].detect(target):
+            return name
+    return None
+
+
+__all__ = ["ImporterResult", "available", "detect_importer", "get_importer"]

--- a/kronos/portability/importers/__init__.py
+++ b/kronos/portability/importers/__init__.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from types import ModuleType
 
-from kronos.portability.importers import chatgpt, obsidian
+from kronos.portability.importers import chatgpt, claude_projects, letta, obsidian, telegram
 from kronos.portability.manifest import BundleError, BundleManifest
 
 
@@ -39,15 +39,21 @@ class ImporterResult:
         return "\n".join(lines)
 
 
+# Detection order matters: claude-projects and letta identify themselves by a
+# specific marker file, while obsidian accepts any markdown directory, so the
+# strict ones must be probed first. `available()` keeps that order stable.
 _REGISTRY: dict[str, ModuleType] = {
     chatgpt.NAME: chatgpt,
+    claude_projects.NAME: claude_projects,
+    letta.NAME: letta,
+    telegram.NAME: telegram,
     obsidian.NAME: obsidian,
 }
 
 
 def available() -> list[str]:
-    """Importer names, sorted for stable CLI help output."""
-    return sorted(_REGISTRY)
+    """Importer names in detection order (strict matchers first)."""
+    return list(_REGISTRY)
 
 
 def get_importer(name: str) -> ModuleType:

--- a/kronos/portability/importers/chatgpt.py
+++ b/kronos/portability/importers/chatgpt.py
@@ -1,0 +1,216 @@
+"""Import a ChatGPT data export (`conversations.json`).
+
+Extracts two things: conversation threads (as session history) and explicit
+memory statements the user made ("remember that…", "я предпочитаю…"). Everything
+else in the export — model metadata, moderation results, node graph plumbing —
+is noise for an agent bundle.
+
+The export's `mapping` is a message tree, not a list: nodes carry `parent`
+pointers and branch when a message was regenerated. We walk the parent chain
+back from the last leaf, which reproduces the conversation the user actually
+kept rather than every abandoned branch.
+"""
+
+import json
+import logging
+import re
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+from kronos.portability.build import BundleBuilder
+from kronos.portability.manifest import BundleError
+
+log = logging.getLogger("kronos.portability.importers.chatgpt")
+
+NAME = "chatgpt"
+_CONVERSATIONS = "conversations.json"
+
+# json.load materialises the whole document; a multi-hundred-MB export would
+# balloon to gigabytes of Python objects, so refuse with actionable advice
+# instead of getting OOM-killed halfway through.
+_MAX_JSON_BYTES = 256 * 1024 * 1024
+
+_FACT_MARKERS = (
+    "remember that",
+    "remember:",
+    "keep in mind",
+    "i prefer",
+    "my name is",
+    "запомни",
+    "я предпочитаю",
+    "меня зовут",
+    "не забывай",
+)
+_MAX_FACT_CHARS = 400
+
+
+def detect(path: Path) -> bool:
+    """True for conversations.json, a directory holding it, or an export zip."""
+    if path.is_dir():
+        return (path / _CONVERSATIONS).exists()
+    if path.name == _CONVERSATIONS:
+        return True
+    if path.suffix.lower() == ".zip" and zipfile.is_zipfile(path):
+        with zipfile.ZipFile(path) as archive:
+            return any(Path(name).name == _CONVERSATIONS for name in archive.namelist())
+    return False
+
+
+def _load_conversations(path: Path) -> list[dict]:
+    """Read the conversations array from a file, directory or export zip."""
+    if path.is_dir():
+        return _load_conversations(path / _CONVERSATIONS)
+
+    if path.suffix.lower() == ".zip" and zipfile.is_zipfile(path):
+        with zipfile.ZipFile(path) as archive:
+            member = next((n for n in archive.namelist() if Path(n).name == _CONVERSATIONS), None)
+            if member is None:
+                raise BundleError(f"{path.name} does not contain {_CONVERSATIONS}")
+            info = archive.getinfo(member)
+            if info.file_size > _MAX_JSON_BYTES:
+                raise BundleError(_too_large_message(info.file_size))
+            with archive.open(member) as handle:
+                raw = json.load(handle)
+    else:
+        if not path.exists():
+            raise BundleError(f"not found: {path}")
+        if path.stat().st_size > _MAX_JSON_BYTES:
+            raise BundleError(_too_large_message(path.stat().st_size))
+        raw = json.loads(path.read_text(encoding="utf-8"))
+
+    if isinstance(raw, dict):
+        raw = raw.get("conversations", [])
+    if not isinstance(raw, list):
+        raise BundleError(f"{_CONVERSATIONS} does not contain a list of conversations")
+    return [item for item in raw if isinstance(item, dict)]
+
+
+def _too_large_message(size: int) -> str:
+    return (
+        f"{_CONVERSATIONS} is {size // 1024 // 1024} MB, above the {_MAX_JSON_BYTES // 1024 // 1024} MB import limit — "
+        "split the export or import a subset"
+    )
+
+
+def _message_text(message: dict) -> str:
+    content = message.get("content") or {}
+    parts = content.get("parts") if isinstance(content, dict) else None
+    if isinstance(parts, list):
+        chunks = [part for part in parts if isinstance(part, str)]
+        return "\n".join(chunk.strip() for chunk in chunks if chunk.strip())
+    if isinstance(content, str):
+        return content.strip()
+    return ""
+
+
+def _linear_history(conversation: dict) -> list[dict]:
+    """Reconstruct the kept branch of a conversation, oldest message first."""
+    mapping = conversation.get("mapping")
+    if not isinstance(mapping, dict):
+        return []
+
+    # The leaf of the kept branch is the newest node that carries a message.
+    def node_time(node: dict) -> float:
+        message = node.get("message") or {}
+        return float(message.get("create_time") or 0.0)
+
+    candidates = [node for node in mapping.values() if isinstance(node, dict) and node.get("message")]
+    if not candidates:
+        return []
+    node = max(candidates, key=node_time)
+
+    chain: list[dict] = []
+    seen: set[str] = set()
+    while node is not None:
+        message = node.get("message") or {}
+        node_id = str(node.get("id") or id(node))
+        if node_id in seen:
+            break  # Malformed export with a parent cycle.
+        seen.add(node_id)
+
+        role = ((message.get("author") or {}).get("role") or "").strip()
+        text = _message_text(message)
+        if role in {"user", "assistant"} and text:
+            chain.append({"type": "human" if role == "user" else "ai", "content": text})
+
+        parent_id = node.get("parent")
+        node = mapping.get(parent_id) if isinstance(parent_id, str) else None
+
+    chain.reverse()
+    return chain
+
+
+def _iso(timestamp: object) -> str:
+    try:
+        return datetime.fromtimestamp(float(timestamp or 0), tz=UTC).isoformat(timespec="seconds")
+    except (TypeError, ValueError, OSError):
+        return ""
+
+
+def _harvest_facts(builder: BundleBuilder, text: str, *, user_id: str, created_at: str) -> int:
+    """Pull explicit memory statements out of one user message."""
+    added = 0
+    for sentence in re.split(r"(?<=[.!?\n])\s+", text):
+        candidate = sentence.strip()
+        if not candidate or len(candidate) > _MAX_FACT_CHARS:
+            continue
+        lowered = candidate.lower()
+        if any(marker in lowered for marker in _FACT_MARKERS):
+            if builder.add_fact(candidate, user_id=user_id, created_at=created_at, source="chatgpt"):
+                added += 1
+    return added
+
+
+def to_bundle(
+    path: str | Path,
+    out_path: str | Path,
+    *,
+    limit: int | None = None,
+    user_id: str = "",
+    created_at: str = "",
+):
+    """Convert a ChatGPT export into a bundle at ``out_path``."""
+    from kronos.config import settings
+    from kronos.portability.importers import ImporterResult
+
+    source = Path(path)
+    conversations = _load_conversations(source)
+    conversations.sort(key=lambda item: float(item.get("update_time") or item.get("create_time") or 0.0), reverse=True)
+
+    dropped = 0
+    if limit is not None and len(conversations) > limit:
+        dropped = len(conversations) - limit
+        conversations = conversations[:limit]
+
+    builder = BundleBuilder(agent_name=NAME, created_at=created_at)
+    owner = user_id or settings.agent_name
+    threads = 0
+
+    for index, conversation in enumerate(conversations):
+        history = _linear_history(conversation)
+        if not history:
+            continue
+        title = str(conversation.get("title") or f"conversation-{index + 1}").strip()
+        updated = _iso(conversation.get("update_time") or conversation.get("create_time"))
+        builder.add_session(f"chatgpt:{index + 1}:{title[:40]}", history, updated_at=updated)
+        threads += 1
+        for message in history:
+            if message["type"] == "human":
+                _harvest_facts(builder, message["content"], user_id=owner, created_at=updated)
+
+    if builder.is_empty():
+        raise BundleError("ChatGPT export produced nothing importable (no conversations with messages)")
+
+    if dropped:
+        builder.warnings.append(f"limited to {limit} most recent conversations, {dropped} older ones skipped")
+
+    bundle, manifest = builder.write(out_path)
+    log.info("ChatGPT import: %d threads, %d facts", threads, len(builder.facts))
+    return ImporterResult(
+        importer=NAME,
+        bundle=bundle,
+        manifest=manifest,
+        counts=builder.counts(),
+        warnings=builder.warnings,
+    )

--- a/kronos/portability/importers/claude_projects.py
+++ b/kronos/portability/importers/claude_projects.py
@@ -1,0 +1,160 @@
+"""Import a Claude project (directory export or `projects.json`).
+
+Mapping choices:
+
+* project instructions (`CLAUDE.md`, `instructions.md`, `project_instructions.md`)
+  become a persona draft — that file is the closest thing a Claude project has to
+  an identity;
+* `skills/<name>/SKILL.md` maps to KAOS skills one-to-one, references included;
+* every other document becomes a note.
+
+Detection is deliberately strict (an instructions file, a skills directory, or a
+`projects.json`) so a plain markdown folder is still recognised as an Obsidian
+vault rather than being claimed here.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+from kronos.portability.build import BundleBuilder
+from kronos.portability.manifest import BundleError
+
+log = logging.getLogger("kronos.portability.importers.claude_projects")
+
+NAME = "claude-projects"
+
+_INSTRUCTION_FILES = ("CLAUDE.md", "project_instructions.md", "instructions.md")
+_PROJECTS_JSON = "projects.json"
+_DOC_SUFFIXES = (".md", ".txt")
+_SKIP_DIRS = frozenset({".git", "node_modules", "__pycache__", ".obsidian"})
+_MAX_DOC_BYTES = 1024 * 1024
+_MAX_JSON_BYTES = 64 * 1024 * 1024
+
+
+def detect(path: Path) -> bool:
+    """True for a project directory with instructions/skills, or a projects.json."""
+    if path.is_file():
+        return path.name == _PROJECTS_JSON
+    if not path.is_dir():
+        return False
+    if (path / _PROJECTS_JSON).exists():
+        return True
+    if (path / "skills").is_dir():
+        return True
+    return any((path / name).exists() for name in _INSTRUCTION_FILES)
+
+
+def _add_skills(builder: BundleBuilder, skills_root: Path) -> None:
+    if not skills_root.is_dir():
+        return
+    for skill_dir in sorted(p for p in skills_root.iterdir() if p.is_dir()):
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.exists():
+            continue
+        references = {}
+        refs_dir = skill_dir / "references"
+        if refs_dir.is_dir():
+            for ref in sorted(p for p in refs_dir.rglob("*") if p.is_file() and p.suffix in _DOC_SUFFIXES):
+                references[ref.relative_to(refs_dir).as_posix()] = ref.read_text(encoding="utf-8")
+        builder.add_skill(skill_dir.name, skill_md.read_text(encoding="utf-8"), references)
+
+
+def _from_directory(builder: BundleBuilder, root: Path) -> None:
+    for name in _INSTRUCTION_FILES:
+        candidate = root / name
+        if candidate.exists():
+            builder.add_persona("IDENTITY.md", candidate.read_text(encoding="utf-8"))
+            break
+
+    _add_skills(builder, root / "skills")
+
+    for doc in sorted(p for p in root.rglob("*") if p.is_file() and p.suffix.lower() in _DOC_SUFFIXES):
+        relative = doc.relative_to(root)
+        if any(part in _SKIP_DIRS or part == "skills" for part in relative.parts[:-1]):
+            continue
+        if relative.name in _INSTRUCTION_FILES and len(relative.parts) == 1:
+            continue
+        if doc.stat().st_size > _MAX_DOC_BYTES:
+            builder.warnings.append(f"skipped oversized document: {relative.as_posix()}")
+            continue
+        try:
+            builder.add_note(f"world/claude-project/{relative.as_posix()}", doc.read_text(encoding="utf-8"))
+        except UnicodeDecodeError:
+            builder.warnings.append(f"skipped non-text document: {relative.as_posix()}")
+
+
+def _from_projects_json(builder: BundleBuilder, path: Path) -> None:
+    if path.stat().st_size > _MAX_JSON_BYTES:
+        raise BundleError(f"{path.name} is above the {_MAX_JSON_BYTES // 1024 // 1024} MB import limit")
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise BundleError(f"{path.name} is not valid JSON: {e}") from e
+
+    projects = raw if isinstance(raw, list) else raw.get("projects", [])
+    if not isinstance(projects, list):
+        raise BundleError(f"{path.name} does not contain a list of projects")
+
+    for project in projects:
+        if not isinstance(project, dict):
+            continue
+        slug = str(project.get("name") or project.get("uuid") or "project").strip() or "project"
+        instructions = str(project.get("prompt_template") or project.get("instructions") or "").strip()
+        if instructions and "IDENTITY.md" not in builder.persona:
+            builder.add_persona("IDENTITY.md", instructions)
+
+        description = str(project.get("description") or "").strip()
+        if description:
+            builder.add_note(f"world/claude-project/{slug}/README.md", f"# {slug}\n\n{description}\n")
+
+        for doc in project.get("docs") or []:
+            if not isinstance(doc, dict):
+                continue
+            filename = str(doc.get("filename") or doc.get("name") or "document.md").strip()
+            content = str(doc.get("content") or "")
+            if content:
+                builder.add_note(f"world/claude-project/{slug}/{filename}", content)
+
+
+def to_bundle(
+    path: str | Path,
+    out_path: str | Path,
+    *,
+    limit: int | None = None,
+    user_id: str = "",
+    created_at: str = "",
+):
+    """Convert a Claude project export into a bundle at ``out_path``."""
+    from kronos.portability.importers import ImporterResult
+
+    source = Path(path)
+    builder = BundleBuilder(agent_name=NAME, created_at=created_at)
+
+    if source.is_file() and source.name == _PROJECTS_JSON:
+        _from_projects_json(builder, source)
+    elif source.is_dir():
+        if (source / _PROJECTS_JSON).exists():
+            _from_projects_json(builder, source / _PROJECTS_JSON)
+        _from_directory(builder, source)
+    else:
+        raise BundleError(f"not a Claude project export: {source}")
+
+    if limit is not None and len(builder.notes) > limit:
+        keep = dict(sorted(builder.notes.items())[:limit])
+        dropped = len(builder.notes) - len(keep)
+        builder.notes = keep
+        builder.warnings.append(f"limited to {limit} documents, {dropped} skipped")
+
+    if builder.is_empty():
+        raise BundleError(f"no importable content found in {source}")
+
+    bundle, manifest = builder.write(out_path)
+    log.info("Claude project import: %s", builder.counts())
+    return ImporterResult(
+        importer=NAME,
+        bundle=bundle,
+        manifest=manifest,
+        counts=builder.counts(),
+        warnings=builder.warnings,
+    )

--- a/kronos/portability/importers/letta.py
+++ b/kronos/portability/importers/letta.py
@@ -1,0 +1,154 @@
+"""Import a Letta/MemGPT agent file (`.af`).
+
+Letta stores what KAOS splits across persona and memory in labelled blocks:
+
+* the ``persona`` block is self-description → IDENTITY.md;
+* the ``system`` prompt is working instruction → methodology.md;
+* the ``human`` block is what the agent knows about its owner → facts, split per
+  line, because that block is conventionally a list of statements;
+* messages become one session thread.
+
+Blocks with other labels are kept as notes rather than dropped — a custom block
+is usually the most agent-specific content in the file.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+from kronos.portability.build import BundleBuilder
+from kronos.portability.manifest import BundleError
+
+log = logging.getLogger("kronos.portability.importers.letta")
+
+NAME = "letta"
+
+_MAX_FILE_BYTES = 64 * 1024 * 1024
+_MAX_FACT_CHARS = 400
+_ROLE_MAP = {"user": "human", "assistant": "ai", "system": "system", "tool": "tool"}
+
+
+def _looks_like_agent_file(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    return bool(
+        payload.get("agent_type")
+        or payload.get("memory_blocks")
+        or payload.get("core_memory")
+        or (payload.get("name") and payload.get("system"))
+    )
+
+
+def detect(path: Path) -> bool:
+    """True for a `.af` file, or a JSON file shaped like an agent file."""
+    if not path.is_file():
+        return False
+    if path.suffix.lower() not in {".af", ".json"}:
+        return False
+    if path.stat().st_size > _MAX_FILE_BYTES:
+        return False
+    try:
+        return _looks_like_agent_file(json.loads(path.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return False
+
+
+def _blocks(payload: dict) -> list[dict]:
+    raw = payload.get("memory_blocks") or payload.get("core_memory") or []
+    if isinstance(raw, dict):
+        # Older dumps used {"persona": "...", "human": "..."}.
+        return [{"label": key, "value": value} for key, value in raw.items()]
+    return [block for block in raw if isinstance(block, dict)]
+
+
+def _message_text(message: dict) -> str:
+    for key in ("text", "content"):
+        value = message.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, list):
+            parts = [part.get("text", "") if isinstance(part, dict) else str(part) for part in value]
+            joined = "\n".join(part for part in parts if part).strip()
+            if joined:
+                return joined
+    return ""
+
+
+def to_bundle(
+    path: str | Path,
+    out_path: str | Path,
+    *,
+    limit: int | None = None,
+    user_id: str = "",
+    created_at: str = "",
+):
+    """Convert a Letta agent file into a bundle at ``out_path``."""
+    from kronos.config import settings
+    from kronos.portability.importers import ImporterResult
+
+    source = Path(path)
+    if not source.is_file():
+        raise BundleError(f"not an agent file: {source}")
+    if source.stat().st_size > _MAX_FILE_BYTES:
+        raise BundleError(f"{source.name} is above the {_MAX_FILE_BYTES // 1024 // 1024} MB import limit")
+
+    try:
+        payload = json.loads(source.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise BundleError(f"{source.name} is not valid JSON: {e}") from e
+    if not _looks_like_agent_file(payload):
+        raise BundleError(f"{source.name} does not look like a Letta agent file")
+
+    builder = BundleBuilder(agent_name=NAME, created_at=created_at)
+    owner = user_id or settings.agent_name
+    agent_name = str(payload.get("name") or "letta-agent").strip()
+
+    system = str(payload.get("system") or "").strip()
+    if system:
+        builder.add_persona("methodology.md", f"# Imported system prompt ({agent_name})\n\n{system}\n")
+
+    for block in _blocks(payload):
+        label = str(block.get("label") or "").strip().lower()
+        value = str(block.get("value") or "").strip()
+        if not value:
+            continue
+        if label == "persona":
+            builder.add_persona("IDENTITY.md", f"# {agent_name}\n\n{value}\n")
+        elif label == "human":
+            for line in value.splitlines():
+                fact = line.strip().lstrip("-*• ").strip()
+                if fact:
+                    builder.add_fact(fact[:_MAX_FACT_CHARS], user_id=owner, source="letta")
+        else:
+            builder.add_note(f"world/letta/{label or 'block'}.md", f"# {label}\n\n{value}\n")
+
+    messages = payload.get("messages")
+    history: list[dict] = []
+    if isinstance(messages, list):
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            role = str(message.get("role") or message.get("message_type") or "").lower()
+            text = _message_text(message)
+            if not text or role not in _ROLE_MAP:
+                continue
+            history.append({"type": _ROLE_MAP[role], "content": text})
+        if limit is not None and len(history) > limit:
+            dropped = len(history) - limit
+            history = history[-limit:]
+            builder.warnings.append(f"limited to the last {limit} messages, {dropped} older ones skipped")
+    if history:
+        builder.add_session(f"letta:{agent_name}", history)
+
+    if builder.is_empty():
+        raise BundleError(f"agent file {source.name} produced nothing importable")
+
+    bundle, manifest = builder.write(out_path)
+    log.info("Letta import: %s", builder.counts())
+    return ImporterResult(
+        importer=NAME,
+        bundle=bundle,
+        manifest=manifest,
+        counts=builder.counts(),
+        warnings=builder.warnings,
+    )

--- a/kronos/portability/importers/obsidian.py
+++ b/kronos/portability/importers/obsidian.py
@@ -1,0 +1,116 @@
+"""Import an Obsidian vault.
+
+A vault is already the shape KAOS calls notes, so the mapping is direct:
+
+* every markdown file becomes a note under the same relative path;
+* `[[wikilinks]]` become graph relations, which is the part a plain file copy
+  would throw away — the link structure is the vault's actual knowledge;
+* notes marked `type: fact` (or listing `facts:` in frontmatter) become
+  extracted facts, so they participate in recall instead of only sitting on disk.
+"""
+
+import logging
+import re
+from pathlib import Path
+
+from kronos.portability.build import BundleBuilder
+from kronos.portability.manifest import BundleError
+from kronos.skills.store import _parse_frontmatter, _parse_list_field
+
+log = logging.getLogger("kronos.portability.importers.obsidian")
+
+NAME = "obsidian"
+
+_SKIP_DIRS = frozenset({".obsidian", ".trash", ".git", "node_modules", "__pycache__"})
+_WIKILINK_RE = re.compile(r"\[\[([^\]|#]+)(?:[#|][^\]]*)?\]\]")
+_MAX_NOTE_BYTES = 1024 * 1024
+_MAX_FACT_CHARS = 400
+
+
+def detect(path: Path) -> bool:
+    """True for a directory that looks like a vault (has .obsidian or markdown)."""
+    if not path.is_dir():
+        return False
+    if (path / ".obsidian").exists():
+        return True
+    return any(True for _ in _markdown_files(path))
+
+
+def _markdown_files(root: Path):
+    for candidate in sorted(root.rglob("*.md")):
+        if not candidate.is_file():
+            continue
+        relative = candidate.relative_to(root)
+        if any(part in _SKIP_DIRS or part.startswith(".") for part in relative.parts[:-1]):
+            continue
+        yield candidate
+
+
+def to_bundle(
+    path: str | Path,
+    out_path: str | Path,
+    *,
+    limit: int | None = None,
+    user_id: str = "",
+    created_at: str = "",
+):
+    """Convert an Obsidian vault into a bundle at ``out_path``."""
+    from kronos.config import settings
+    from kronos.portability.importers import ImporterResult
+
+    root = Path(path)
+    if not root.is_dir():
+        raise BundleError(f"not a vault directory: {root}")
+
+    files = list(_markdown_files(root))
+    dropped = 0
+    if limit is not None and len(files) > limit:
+        dropped = len(files) - limit
+        files = files[:limit]
+
+    builder = BundleBuilder(agent_name=NAME, created_at=created_at)
+    owner = user_id or settings.agent_name
+
+    for note_path in files:
+        if note_path.stat().st_size > _MAX_NOTE_BYTES:
+            builder.warnings.append(f"skipped oversized note: {note_path.name}")
+            continue
+        try:
+            raw = note_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            builder.warnings.append(f"skipped non-text note: {note_path.name}")
+            continue
+
+        relative = note_path.relative_to(root)
+        builder.add_note(f"world/vault/{relative.as_posix()}", raw)
+
+        meta, body = _parse_frontmatter(raw)
+        title = note_path.stem
+
+        for target in {match.strip() for match in _WIKILINK_RE.findall(raw) if match.strip()}:
+            builder.add_relation(title, "note", target, "note", "links_to")
+
+        if str(meta.get("type", "")).strip().lower() == "fact":
+            fact = " ".join(body.split())[:_MAX_FACT_CHARS]
+            builder.add_fact(fact, user_id=owner, created_at=str(meta.get("date", "")), source="obsidian")
+
+        for fact in _parse_list_field(meta.get("facts", "")):
+            builder.add_fact(fact[:_MAX_FACT_CHARS], user_id=owner, created_at="", source="obsidian")
+
+    if builder.is_empty():
+        raise BundleError(f"no importable markdown found in {root}")
+
+    if dropped:
+        builder.warnings.append(f"limited to {limit} notes, {dropped} skipped")
+
+    bundle, manifest = builder.write(out_path)
+    log.info(
+        "Obsidian import: %d notes, %d facts, %d links", len(builder.notes), len(builder.facts), len(builder.relations)
+    )
+    return ImporterResult(
+        importer=NAME,
+        bundle=bundle,
+        manifest=manifest,
+        counts=builder.counts(),
+        warnings=builder.warnings,
+    )

--- a/kronos/portability/importers/telegram.py
+++ b/kronos/portability/importers/telegram.py
@@ -1,0 +1,163 @@
+"""Import a Telegram Desktop export (`result.json`).
+
+Chats are private by nature, so this importer is opt-in twice over: nothing is
+imported unless the caller names the chats (``chats=[…]``), and message text is
+masked as third-party content by the bundle builder.
+
+`personal_information` — present in a full export — becomes facts about the
+owner: name, username, bio. That block is the one place a Telegram export states
+who the account belongs to.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+from kronos.portability.build import BundleBuilder
+from kronos.portability.manifest import BundleError
+
+log = logging.getLogger("kronos.portability.importers.telegram")
+
+NAME = "telegram"
+_RESULT_JSON = "result.json"
+
+_MAX_JSON_BYTES = 256 * 1024 * 1024
+_DETECT_PROBE_BYTES = 8192
+_DEFAULT_MESSAGES_PER_CHAT = 500
+
+
+def detect(path: Path) -> bool:
+    """True for result.json (or a directory holding it) that mentions chats.
+
+    Only the first few KB are probed: a full export can be hundreds of MB and
+    detection must stay cheap.
+    """
+    target = path / _RESULT_JSON if path.is_dir() else path
+    if not target.is_file() or target.name != _RESULT_JSON:
+        return False
+    try:
+        with open(target, encoding="utf-8", errors="ignore") as handle:
+            probe = handle.read(_DETECT_PROBE_BYTES)
+    except OSError:
+        return False
+    return '"chats"' in probe or '"personal_information"' in probe
+
+
+def _text_of(message: dict) -> str:
+    """Flatten Telegram's text field, which is a string or a list of entities."""
+    value = message.get("text")
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, list):
+        parts = []
+        for item in value:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                parts.append(str(item.get("text") or ""))
+        return "".join(parts).strip()
+    return ""
+
+
+def _load(path: Path) -> dict:
+    target = path / _RESULT_JSON if path.is_dir() else path
+    if not target.is_file():
+        raise BundleError(f"not found: {target}")
+    if target.stat().st_size > _MAX_JSON_BYTES:
+        raise BundleError(
+            f"{_RESULT_JSON} is {target.stat().st_size // 1024 // 1024} MB, above the "
+            f"{_MAX_JSON_BYTES // 1024 // 1024} MB import limit — export fewer chats"
+        )
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        raise BundleError(f"{_RESULT_JSON} is not valid JSON: {e}") from e
+    if not isinstance(payload, dict):
+        raise BundleError(f"{_RESULT_JSON} does not contain an export object")
+    return payload
+
+
+def _owner_facts(builder: BundleBuilder, payload: dict, *, user_id: str) -> None:
+    info = payload.get("personal_information")
+    if not isinstance(info, dict):
+        return
+    name = " ".join(str(info.get(key) or "").strip() for key in ("first_name", "last_name")).strip()
+    if name:
+        builder.add_fact(f"Telegram account owner is {name}", user_id=user_id, source="telegram")
+    username = str(info.get("username") or "").strip()
+    if username:
+        builder.add_fact(f"Telegram username is @{username}", user_id=user_id, source="telegram")
+    bio = str(info.get("bio") or "").strip()
+    if bio:
+        builder.add_fact(f"Telegram bio: {bio}", user_id=user_id, source="telegram")
+
+
+def to_bundle(
+    path: str | Path,
+    out_path: str | Path,
+    *,
+    limit: int | None = None,
+    user_id: str = "",
+    created_at: str = "",
+    chats: list[str] | None = None,
+):
+    """Convert selected chats of a Telegram export into a bundle.
+
+    ``chats`` matches chat name or id; without it no conversation is imported —
+    silently ingesting every private chat someone ever had is not a sane default.
+    """
+    from kronos.config import settings
+    from kronos.portability.importers import ImporterResult
+
+    payload = _load(Path(path))
+    builder = BundleBuilder(agent_name=NAME, created_at=created_at)
+    owner = user_id or settings.agent_name
+    _owner_facts(builder, payload, user_id=owner)
+
+    wanted = {str(item).strip().lower() for item in (chats or []) if str(item).strip()}
+    per_chat = limit or _DEFAULT_MESSAGES_PER_CHAT
+    chat_list = ((payload.get("chats") or {}).get("list")) or []
+    matched = 0
+
+    for chat in chat_list:
+        if not isinstance(chat, dict):
+            continue
+        name = str(chat.get("name") or "").strip()
+        chat_id = str(chat.get("id") or "").strip()
+        if not wanted or not ({name.lower(), chat_id.lower()} & wanted):
+            continue
+
+        matched += 1
+        history = []
+        for message in chat.get("messages") or []:
+            if not isinstance(message, dict) or message.get("type") != "message":
+                continue
+            text = _text_of(message)
+            if not text:
+                continue
+            sender = str(message.get("from") or "").strip()
+            history.append({"type": "human", "content": f"{sender}: {text}" if sender else text})
+
+        if len(history) > per_chat:
+            builder.warnings.append(f"chat '{name or chat_id}': kept the last {per_chat} messages")
+            history = history[-per_chat:]
+        if history:
+            builder.add_session(f"telegram:{chat_id or name}", history)
+
+    if wanted and not matched:
+        builder.warnings.append(f"no chats matched: {', '.join(sorted(wanted))}")
+    if not wanted:
+        builder.warnings.append("no chats selected — pass chats=[…] to import conversations")
+
+    if builder.is_empty():
+        raise BundleError("Telegram export produced nothing importable (select chats or check the export)")
+
+    bundle, manifest = builder.write(out_path)
+    log.info("Telegram import: %d chats, %s", matched, builder.counts())
+    return ImporterResult(
+        importer=NAME,
+        bundle=bundle,
+        manifest=manifest,
+        counts=builder.counts(),
+        warnings=builder.warnings,
+    )

--- a/kronos/portability/manifest.py
+++ b/kronos/portability/manifest.py
@@ -1,0 +1,181 @@
+"""Agent bundle manifest — the integrity contract of a `.kaos` bundle.
+
+A bundle is a zip archive whose `manifest.json` lists every artifact with its
+SHA-256. The manifest is what makes a bundle verifiable: an importer can prove
+the payload is exactly what the exporter wrote before touching any database.
+
+Determinism rule: `created_at` is the ONLY field carrying wall-clock time.
+Everything else is derived from content, so exporting unchanged state twice
+produces identical artifact hashes.
+"""
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+from kronos import __version__
+
+BUNDLE_SCHEMA_VERSION = 1
+MANIFEST_NAME = "manifest.json"
+
+# Bundle sections. Persona/skills/memory are always present (possibly empty);
+# notes/sessions are opt-in because they carry the most private content.
+SECTION_PERSONA = "persona"
+SECTION_SKILLS = "skills"
+SECTION_FACTS = "facts"
+SECTION_GRAPH = "graph"
+SECTION_SHARED_FACTS = "shared_facts"
+SECTION_SCHEDULE = "schedule"
+SECTION_NOTES = "notes"
+SECTION_SESSIONS = "sessions"
+
+ALL_SECTIONS = (
+    SECTION_PERSONA,
+    SECTION_SKILLS,
+    SECTION_FACTS,
+    SECTION_GRAPH,
+    SECTION_SHARED_FACTS,
+    SECTION_SCHEDULE,
+    SECTION_NOTES,
+    SECTION_SESSIONS,
+)
+
+_HASH_PREFIX = "sha256:"
+_READ_CHUNK = 65536
+
+
+class BundleError(Exception):
+    """Raised when a bundle is malformed, unreadable, or fails verification."""
+
+
+@dataclass
+class BundleManifest:
+    """Describes a bundle's provenance and content hashes."""
+
+    agent_name: str
+    created_at: str
+    schema_version: int = BUNDLE_SCHEMA_VERSION
+    kaos_version: str = __version__
+    includes: list[str] = field(default_factory=list)
+    counts: dict[str, int] = field(default_factory=dict)
+    artifacts: dict[str, str] = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        """Serialize canonically: sorted keys, stable indentation, UTF-8 text."""
+        return json.dumps(asdict(self), ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+
+    @classmethod
+    def from_json(cls, text: str) -> "BundleManifest":
+        """Parse a manifest, rejecting anything that is not a v1-shaped object."""
+        try:
+            raw = json.loads(text)
+        except json.JSONDecodeError as e:
+            raise BundleError(f"manifest is not valid JSON: {e}") from e
+        if not isinstance(raw, dict):
+            raise BundleError("manifest must be a JSON object")
+
+        missing = [key for key in ("agent_name", "created_at", "schema_version") if key not in raw]
+        if missing:
+            raise BundleError(f"manifest is missing required fields: {', '.join(missing)}")
+
+        known = {f for f in cls.__dataclass_fields__}
+        return cls(**{key: value for key, value in raw.items() if key in known})
+
+    def ensure_supported(self) -> None:
+        """Fail loudly on a bundle from a newer, unknown schema.
+
+        Older schemas stay readable — that is the point of versioning — but a
+        future layout must not be silently half-imported.
+        """
+        if not isinstance(self.schema_version, int):
+            raise BundleError(f"manifest schema_version must be an int, got {self.schema_version!r}")
+        if self.schema_version > BUNDLE_SCHEMA_VERSION:
+            raise BundleError(
+                f"bundle schema v{self.schema_version} is newer than this KAOS supports "
+                f"(v{BUNDLE_SCHEMA_VERSION}) — upgrade kronos-agent-os to import it"
+            )
+
+
+def file_sha256(path: Path) -> str:
+    """Hash one file, streamed so large sessions/notes do not load into memory."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(_READ_CHUNK), b""):
+            digest.update(chunk)
+    return f"{_HASH_PREFIX}{digest.hexdigest()}"
+
+
+def hash_artifacts(bundle_dir: Path) -> dict[str, str]:
+    """Map every payload file to its hash, keyed by POSIX-relative path.
+
+    The manifest itself is excluded (it holds the hashes) and keys are sorted so
+    two exports of the same state yield byte-identical manifests.
+    """
+    artifacts: dict[str, str] = {}
+    for path in sorted(bundle_dir.rglob("*")):
+        if not path.is_file() or path.name == MANIFEST_NAME:
+            continue
+        artifacts[path.relative_to(bundle_dir).as_posix()] = file_sha256(path)
+    return artifacts
+
+
+def build_manifest(
+    bundle_dir: Path,
+    *,
+    agent_name: str,
+    includes: list[str],
+    counts: dict[str, int],
+    created_at: str = "",
+) -> BundleManifest:
+    """Build a manifest for an already-populated bundle directory."""
+    unknown = [section for section in includes if section not in ALL_SECTIONS]
+    if unknown:
+        raise BundleError(f"unknown bundle sections: {', '.join(unknown)}")
+
+    return BundleManifest(
+        agent_name=agent_name,
+        created_at=created_at or datetime.now(UTC).isoformat(timespec="seconds"),
+        includes=sorted(includes),
+        counts=dict(sorted(counts.items())),
+        artifacts=hash_artifacts(bundle_dir),
+    )
+
+
+def write_manifest(bundle_dir: Path, manifest: BundleManifest) -> Path:
+    """Write `manifest.json` into a bundle directory."""
+    path = bundle_dir / MANIFEST_NAME
+    path.write_text(manifest.to_json(), encoding="utf-8")
+    return path
+
+
+def read_manifest(bundle_dir: Path) -> BundleManifest:
+    """Read and validate a bundle's manifest."""
+    path = bundle_dir / MANIFEST_NAME
+    if not path.exists():
+        raise BundleError(f"{MANIFEST_NAME} not found in {bundle_dir}")
+    manifest = BundleManifest.from_json(path.read_text(encoding="utf-8"))
+    manifest.ensure_supported()
+    return manifest
+
+
+def verify_manifest(bundle_dir: Path) -> list[str]:
+    """Return human-readable mismatches between manifest and payload.
+
+    An empty list means the payload is exactly what the manifest claims.
+    """
+    manifest = read_manifest(bundle_dir)
+    actual = hash_artifacts(bundle_dir)
+    problems: list[str] = []
+
+    for relpath, expected in sorted(manifest.artifacts.items()):
+        if relpath not in actual:
+            problems.append(f"missing file: {relpath}")
+        elif actual[relpath] != expected:
+            problems.append(f"hash mismatch: {relpath}")
+
+    for relpath in sorted(set(actual) - set(manifest.artifacts)):
+        problems.append(f"unlisted file: {relpath}")
+
+    return problems

--- a/kronos/portability/redact.py
+++ b/kronos/portability/redact.py
@@ -1,0 +1,57 @@
+"""Redaction for exported bundles — strip credentials, keep the content usable.
+
+Two levels, because the two kinds of payload need different treatment:
+
+* ``redact_text`` — removes credentials only. Used for the owner's own material
+  (persona, notes, extracted facts, graph): masking the owner's own email out of
+  "his address is …" would destroy exactly the value the bundle exists to carry.
+* ``redact_structure`` — credentials **and** PII, recursively. Used for session
+  history and tool output, which contain third-party data the owner never
+  authored.
+
+Neither truncates. ``audit.redact_tool_payload`` clips to 500 chars because logs
+are for humans skimming; a bundle must round-trip.
+"""
+
+from typing import Any
+
+from kronos.audit import SECRET_FIELD_NAMES, redact_secrets
+from kronos.security.pii import mask_pii
+
+_SECRET_KEY_SUFFIXES = ("_token", "_secret", "_password", "_api_key", "_key")
+_REDACTED = "***REDACTED***"
+
+
+def redact_text(text: str) -> str:
+    """Strip credentials from owner-authored text, preserving everything else."""
+    return redact_secrets(text)
+
+
+def redact_private_text(text: str) -> str:
+    """Strip credentials and mask PII — for third-party content."""
+    return mask_pii(redact_secrets(text))
+
+
+def _is_secret_key(key: str) -> bool:
+    name = key.lower().replace("-", "_")
+    return name in SECRET_FIELD_NAMES or name.endswith(_SECRET_KEY_SUFFIXES)
+
+
+def redact_structure(value: Any, *, mask_personal: bool = True, key: str = "") -> Any:
+    """Recursively redact a JSON-like structure without truncating anything.
+
+    Values under secret-looking keys are replaced wholesale; strings elsewhere
+    are cleaned by ``redact_private_text`` (or ``redact_text`` when
+    ``mask_personal`` is False).
+    """
+    if key and _is_secret_key(key):
+        return _REDACTED
+    if isinstance(value, dict):
+        return {str(k): redact_structure(v, mask_personal=mask_personal, key=str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact_structure(item, mask_personal=mask_personal) for item in value]
+    if isinstance(value, tuple):
+        return [redact_structure(item, mask_personal=mask_personal) for item in value]
+    if isinstance(value, str):
+        return redact_private_text(value) if mask_personal else redact_text(value)
+    return value

--- a/tests/test_cli_portability.py
+++ b/tests/test_cli_portability.py
@@ -1,0 +1,143 @@
+"""CLI surface for export/import/import-from (moat phase 7.5)."""
+
+import json
+import zipfile
+
+import pytest
+
+from kronos.cli import build_parser, main
+from kronos.config import settings
+
+
+@pytest.fixture
+def agent(tmp_path, monkeypatch):
+    """An agent with one fact and one persona file, isolated in tmp_path."""
+    db_dir = tmp_path / "data" / "cli"
+    db_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(settings, "agent_name", "cli")
+    monkeypatch.setattr(settings, "db_dir", str(db_dir))
+    monkeypatch.setattr(settings, "db_path", str(db_dir / "session.db"))
+    monkeypatch.setattr(settings, "swarm_db_path", str(tmp_path / "swarm.db"))
+    monkeypatch.setattr(settings, "shared_workspace_path", "")
+
+    import kronos.db as _db
+    import kronos.workspace as _ws
+    from kronos.memory import fts as _fts
+    from kronos.memory import knowledge_graph as _kg
+
+    _db._instances.clear()
+    monkeypatch.setattr(_fts, "_schema_initialized", False)
+    monkeypatch.setattr(_kg, "_schema_initialized", False)
+    space = _ws.Workspace(tmp_path / "workspaces" / "cli")
+    monkeypatch.setattr(_ws, "ws", space)
+    space.ensure_dirs()
+    space.soul.write_text("Отвечаю по делу.\n", encoding="utf-8")
+
+    from kronos.memory import fts
+
+    fts.index_fact("Работает над KAOS", "roman")
+
+    yield tmp_path
+    _db._instances.clear()
+
+
+def test_parser_exposes_portability_commands():
+    parser = build_parser()
+
+    args = parser.parse_args(["export", "--out", "a.kaos", "--include-notes"])
+    assert args.command == "export" and args.include_notes is True
+
+    args = parser.parse_args(["import", "a.kaos", "--merge", "append", "--dry-run", "--rebind-chat", "42"])
+    assert args.merge == "append" and args.dry_run is True and args.rebind_chat == 42
+
+    args = parser.parse_args(["import-from", "auto", "./export", "--limit", "5", "--chat", "Work", "--chat", "123"])
+    assert args.tool == "auto" and args.limit == 5 and args.chat == ["Work", "123"]
+
+
+def test_import_from_rejects_unknown_tool():
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["import-from", "myspace", "./export"])
+
+
+def test_export_then_import_round_trip(agent, capsys):
+    bundle = agent / "cli.kaos"
+
+    assert main(["export", "--out", str(bundle)]) == 0
+    out = capsys.readouterr().out
+    assert "Exported agent 'cli'" in out
+    assert bundle.exists()
+
+    assert main(["import", str(bundle), "--dry-run"]) == 0
+    out = capsys.readouterr().out
+    assert "Would import bundle from agent 'cli'" in out
+    assert "Nothing was written" in out
+
+
+def test_export_warns_when_transport_ids_are_kept(agent, capsys):
+    assert main(["export", "--out", str(agent / "with-ids.kaos"), "--include-transport-ids"]) == 0
+
+    assert "treat it as private" in capsys.readouterr().out
+
+
+def test_import_of_missing_bundle_fails_cleanly(agent, capsys):
+    assert main(["import", str(agent / "absent.kaos")]) == 1
+
+    assert "Import failed:" in capsys.readouterr().out
+
+
+def test_import_from_auto_detects_and_imports(agent, capsys):
+    vault = agent / "vault"
+    (vault / ".obsidian").mkdir(parents=True)
+    (vault / "note.md").write_text("---\ntype: fact\n---\n\nЛюбит краткость.\n", encoding="utf-8")
+
+    assert main(["import-from", "auto", str(vault)]) == 0
+    out = capsys.readouterr().out
+
+    assert "Detected importer: obsidian" in out
+    assert "Converted obsidian export" in out
+    assert "Imported bundle from agent 'obsidian'" in out
+
+
+def test_import_from_convert_only_keeps_the_bundle(agent, capsys):
+    vault = agent / "vault"
+    vault.mkdir()
+    (vault / "note.md").write_text("Заметка.\n", encoding="utf-8")
+    out_bundle = agent / "vault.kaos"
+
+    assert main(["import-from", "obsidian", str(vault), "--convert-only", "--out", str(out_bundle)]) == 0
+    out = capsys.readouterr().out
+
+    assert out_bundle.exists()
+    assert "kaos import" in out
+    with zipfile.ZipFile(out_bundle) as archive:
+        manifest = json.loads(archive.read("manifest.json"))
+    assert manifest["agent_name"] == "obsidian"
+
+
+def test_import_from_unrecognised_export_reports_clearly(agent, capsys):
+    empty = agent / "mystery"
+    empty.mkdir()
+
+    assert main(["import-from", "auto", str(empty)]) == 1
+    assert "Could not recognise the export" in capsys.readouterr().out
+
+
+def test_chat_flag_is_ignored_for_non_telegram_importers(agent, capsys):
+    vault = agent / "vault"
+    vault.mkdir()
+    (vault / "note.md").write_text("Заметка.\n", encoding="utf-8")
+
+    assert main(["import-from", "obsidian", str(vault), "--chat", "Work", "--dry-run"]) == 0
+    assert "--chat is only supported by the telegram importer" in capsys.readouterr().out
+
+
+def test_doctor_reports_portability(agent, capsys):
+    from kronos.cli import run_doctor
+
+    run_doctor()
+
+    out = capsys.readouterr().out
+    assert "Portability" in out
+    assert "bundle schema v1" in out
+    assert "obsidian" in out

--- a/tests/test_portability_export.py
+++ b/tests/test_portability_export.py
@@ -1,0 +1,275 @@
+"""Agent bundle export — content, determinism, secret containment (moat phase 7.2)."""
+
+import json
+import sqlite3
+import zipfile
+
+import pytest
+
+from kronos.config import settings
+
+FIXED_TIME = "2026-01-01T00:00:00+00:00"
+
+
+@pytest.fixture
+def agent_env(tmp_path, monkeypatch):
+    """A populated agent: workspace files, facts, graph, shared facts, schedule, sessions."""
+    db_dir = tmp_path / "data" / "kronos"
+    db_dir.mkdir(parents=True)
+    workspace_root = tmp_path / "workspaces" / "kronos"
+
+    monkeypatch.setattr(settings, "agent_name", "kronos")
+    monkeypatch.setattr(settings, "db_dir", str(db_dir))
+    monkeypatch.setattr(settings, "db_path", str(db_dir / "session.db"))
+    monkeypatch.setattr(settings, "swarm_db_path", str(tmp_path / "data" / "swarm.db"))
+    monkeypatch.setattr(settings, "workspace_path", str(workspace_root))
+    monkeypatch.setattr(settings, "shared_workspace_path", "")
+
+    import kronos.db as _db
+    import kronos.swarm_store as _swarm
+    import kronos.workspace as _ws
+    from kronos.memory import fts as _fts
+    from kronos.memory import knowledge_graph as _kg
+
+    _db._instances.clear()
+    _swarm._singleton = None
+    # fts/knowledge_graph cache "schema is ready" in a module flag, so a fresh
+    # temp database needs the flag cleared or writes hit a schemaless file.
+    monkeypatch.setattr(_fts, "_schema_initialized", False)
+    monkeypatch.setattr(_kg, "_schema_initialized", False)
+    space = _ws.Workspace(workspace_root)
+    monkeypatch.setattr(_ws, "ws", space)
+    space.ensure_dirs()
+
+    # Persona
+    space.identity.write_text("# Кто я\nОператор Романа.\n", encoding="utf-8")
+    space.soul.write_text("Говорю прямо. Токен: sk-secretsecretsecret1234\n", encoding="utf-8")
+
+    # A skill with a reference
+    skill_dir = space.skills_dir / "research-brief"
+    (skill_dir / "references").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: research-brief\ndescription: Краткий бриф\n---\n\n# Бриф\n", encoding="utf-8"
+    )
+    (skill_dir / "references" / "SOURCES.md").write_text("- exa\n- brave\n", encoding="utf-8")
+
+    # Notes
+    (space.user_dir / "USER.md").write_text("Роман. Работает над KAOS.\n", encoding="utf-8")
+
+    # Things that must never be exported
+    (workspace_root / ".env").write_text("DEEPSEEK_API_KEY=sk-live-key\n", encoding="utf-8")
+    (workspace_root / "kronos.session").write_text("telethon-session-blob", encoding="utf-8")
+    (space.notes_dir / "secrets.session").write_text("blob", encoding="utf-8")
+
+    # Facts + graph via the real APIs so schemas cannot drift from production
+    from kronos.memory import fts, knowledge_graph
+
+    fts.index_fact("Предпочитает краткие технические ответы", "roman")
+    fts.index_fact("Ключ доступа Bearer abcdefghijklmnop12345", "roman")
+    knowledge_graph.add_entity("KAOS", "project", {"stack": "python"})
+    knowledge_graph.add_relation("Роман", "person", "KAOS", "project", "owns")
+
+    # Shared facts: one from this agent, one from a peer (must not be exported)
+    from kronos.swarm_store import get_swarm
+
+    store = get_swarm()
+    store.add_shared_fact(user_id="roman", fact="Живёт в Бали", source_agent="kronos")
+    store.add_shared_fact(user_id="roman", fact="Факт от соседа", source_agent="nexus")
+
+    # Schedule
+    from kronos import scheduled_tasks
+
+    scheduled_tasks.add_task(
+        agent_name="kronos",
+        chat_id=123456789,
+        topic_id=42,
+        thread_id="123456789:42",
+        run_at=1800000000.0,
+        message="Напомнить про релиз",
+    )
+
+    # Sessions (SessionStore is async; the schema is stable enough to seed directly)
+    conn = sqlite3.connect(db_dir / "session.db")
+    conn.execute("CREATE TABLE IF NOT EXISTS sessions (thread_id TEXT PRIMARY KEY, messages TEXT, updated_at TEXT)")
+    conn.execute(
+        "INSERT INTO sessions (thread_id, messages, updated_at) VALUES (?, ?, ?)",
+        (
+            "123456789",
+            json.dumps([{"type": "human", "content": "напиши на roman@example.com"}]),
+            "2026-01-01 10:00:00",
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    yield tmp_path
+    _db._instances.clear()
+    _swarm._singleton = None
+
+
+def _export(tmp_path, **kwargs):
+    from kronos.portability.export import export_bundle
+
+    return export_bundle(tmp_path / "out" / "agent.kaos", created_at=FIXED_TIME, **kwargs)
+
+
+def _bundle_files(path) -> dict[str, str]:
+    with zipfile.ZipFile(path) as archive:
+        return {name: archive.read(name).decode("utf-8") for name in archive.namelist()}
+
+
+def test_export_writes_all_default_sections(agent_env):
+    report = _export(agent_env)
+    files = _bundle_files(report.path)
+
+    assert "manifest.json" in files
+    assert "persona/IDENTITY.md" in files
+    assert "skills/research-brief/SKILL.md" in files
+    assert "skills/research-brief/references/SOURCES.md" in files
+    assert "memory/facts.jsonl" in files
+    assert "memory/graph.entities.jsonl" in files
+    assert "memory/graph.relations.jsonl" in files
+    assert "memory/shared_facts.jsonl" in files
+    assert "schedule/tasks.jsonl" in files
+    # Opt-in sections stay out unless asked for.
+    assert not any(name.startswith("notes/") for name in files)
+    assert not any(name.startswith("sessions/") for name in files)
+
+
+def test_manifest_counts_match_payload(agent_env):
+    report = _export(agent_env)
+    files = _bundle_files(report.path)
+
+    assert report.counts["persona_files"] == 2
+    assert report.counts["skills"] == 1
+    assert report.counts["facts"] == len(files["memory/facts.jsonl"].strip().splitlines())
+    assert report.counts["graph_entities"] == 2  # KAOS(project) + Роман(person); KAOS is reused by the relation
+    assert report.counts["graph_relations"] == 1
+    assert report.counts["shared_facts"] == 1
+    assert report.counts["scheduled_tasks"] == 1
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"include_notes": True},
+        {"include_sessions": True},
+        {"include_notes": True, "include_sessions": True, "include_transport_ids": True},
+    ],
+)
+def test_export_never_contains_secrets(agent_env, kwargs):
+    report = _export(agent_env, **kwargs)
+    files = _bundle_files(report.path)
+
+    assert not any(name.endswith((".env", ".session")) for name in files)
+    assert not any(name.endswith((".db", ".db-wal", ".sqlite")) for name in files)
+    blob = "\n".join(files.values())
+    assert "sk-secretsecretsecret1234" not in blob
+    assert "sk-live-key" not in blob
+    assert "telethon-session-blob" not in blob
+    assert "abcdefghijklmnop12345" not in blob
+
+
+def test_export_redacts_secrets_but_keeps_owner_content(agent_env):
+    files = _bundle_files(_export(agent_env).path)
+
+    assert "Говорю прямо." in files["persona/SOUL.md"]
+    assert "sk-***REDACTED***" in files["persona/SOUL.md"]
+    facts = files["memory/facts.jsonl"]
+    assert "Предпочитает краткие технические ответы" in facts
+    assert "Bearer ***REDACTED***" in facts
+
+
+def test_export_is_byte_identical_for_unchanged_state(agent_env):
+    first = _export(agent_env)
+    first_bytes = first.path.read_bytes()
+    first.path.unlink()
+    second = _export(agent_env)
+
+    assert second.path.read_bytes() == first_bytes
+    assert second.manifest.artifacts == first.manifest.artifacts
+
+
+def test_export_bundle_verifies_against_its_manifest(agent_env, tmp_path):
+    from kronos.portability.manifest import verify_manifest
+
+    report = _export(agent_env)
+    extracted = tmp_path / "extracted"
+    with zipfile.ZipFile(report.path) as archive:
+        archive.extractall(extracted)
+
+    assert verify_manifest(extracted) == []
+
+
+def test_shared_facts_exclude_other_agents(agent_env):
+    files = _bundle_files(_export(agent_env).path)
+    shared = files["memory/shared_facts.jsonl"]
+
+    assert "Живёт в Бали" in shared
+    assert "Факт от соседа" not in shared
+
+
+def test_schedule_drops_transport_ids_by_default(agent_env):
+    files = _bundle_files(_export(agent_env).path)
+    task = json.loads(files["schedule/tasks.jsonl"].strip())
+
+    assert task["needs_rebind"] is True
+    assert task["chat_id"] is None and task["thread_id"] is None
+    assert task["message"] == "Напомнить про релиз"
+
+
+def test_schedule_keeps_transport_ids_when_requested(agent_env):
+    files = _bundle_files(_export(agent_env, include_transport_ids=True).path)
+    task = json.loads(files["schedule/tasks.jsonl"].strip())
+
+    assert task["needs_rebind"] is False
+    assert task["chat_id"] == 123456789
+    assert task["topic_id"] == 42
+
+
+def test_notes_are_included_on_demand(agent_env):
+    report = _export(agent_env, include_notes=True)
+    files = _bundle_files(report.path)
+
+    assert "notes/user/USER.md" in files
+    assert "Работает над KAOS" in files["notes/user/USER.md"]
+    assert "notes" in report.manifest.includes
+
+
+def test_sessions_are_included_on_demand_and_pii_masked(agent_env):
+    report = _export(agent_env, include_sessions=True)
+    files = _bundle_files(report.path)
+    row = json.loads(files["sessions/sessions.jsonl"].strip())
+
+    assert row["thread_id"] == "123456789"
+    assert "roman@example.com" not in json.dumps(row, ensure_ascii=False)
+    assert "sessions" in report.manifest.includes
+
+
+def test_export_on_empty_agent_reports_warning(tmp_path, monkeypatch):
+    """A fresh agent with no memory exports a valid, mostly-empty bundle."""
+    db_dir = tmp_path / "data" / "empty"
+    db_dir.mkdir(parents=True)
+    monkeypatch.setattr(settings, "agent_name", "empty")
+    monkeypatch.setattr(settings, "db_dir", str(db_dir))
+    monkeypatch.setattr(settings, "db_path", str(db_dir / "session.db"))
+    monkeypatch.setattr(settings, "swarm_db_path", str(tmp_path / "swarm.db"))
+
+    import kronos.db as _db
+    import kronos.workspace as _ws
+
+    _db._instances.clear()
+    space = _ws.Workspace(tmp_path / "workspaces" / "empty")
+    monkeypatch.setattr(_ws, "ws", space)
+
+    from kronos.portability.export import export_bundle
+
+    report = export_bundle(tmp_path / "empty.kaos", created_at=FIXED_TIME)
+
+    assert report.path.exists()
+    assert report.counts["facts"] == 0
+    assert "no extracted facts found" in report.warnings
+    # Reading a non-existent database must not create one.
+    assert not (db_dir / "memory_fts.db").exists()
+    _db._instances.clear()

--- a/tests/test_portability_import.py
+++ b/tests/test_portability_import.py
@@ -1,0 +1,292 @@
+"""Agent bundle import — dedupe, merge modes, dry-run, safety (moat phase 7.3)."""
+
+import json
+import sqlite3
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from kronos.config import settings
+from kronos.portability import BundleError, import_bundle
+from kronos.portability.export import export_bundle
+from kronos.workspace import Workspace
+
+FIXED_TIME = "2026-01-01T00:00:00+00:00"
+
+
+@dataclass
+class ImportEnv:
+    """A bundle exported from agent 'source', with settings pointing at 'target'."""
+
+    bundle: Path
+    space: Workspace
+    db_dir: Path
+    tmp: Path
+
+
+def _point_settings_at(monkeypatch, tmp_path, agent: str) -> tuple[Path, Workspace]:
+    db_dir = tmp_path / "data" / agent
+    db_dir.mkdir(parents=True, exist_ok=True)
+    workspace_root = tmp_path / "workspaces" / agent
+
+    monkeypatch.setattr(settings, "agent_name", agent)
+    monkeypatch.setattr(settings, "db_dir", str(db_dir))
+    monkeypatch.setattr(settings, "db_path", str(db_dir / "session.db"))
+    monkeypatch.setattr(settings, "swarm_db_path", str(tmp_path / "data" / f"swarm-{agent}.db"))
+    monkeypatch.setattr(settings, "workspace_path", str(workspace_root))
+    monkeypatch.setattr(settings, "shared_workspace_path", "")
+
+    import kronos.db as _db
+    import kronos.swarm_store as _swarm
+    import kronos.workspace as _ws
+    from kronos.memory import fts as _fts
+    from kronos.memory import knowledge_graph as _kg
+
+    _db._instances.clear()
+    _swarm._singleton = None
+    monkeypatch.setattr(_fts, "_schema_initialized", False)
+    monkeypatch.setattr(_kg, "_schema_initialized", False)
+
+    space = _ws.Workspace(workspace_root)
+    monkeypatch.setattr(_ws, "ws", space)
+    space.ensure_dirs()
+    return db_dir, space
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """Build a bundle from agent 'source', then switch to a blank agent 'target'."""
+    _, source_space = _point_settings_at(monkeypatch, tmp_path, "source")
+
+    source_space.identity.write_text("# Кто я\nАгент источника.\n", encoding="utf-8")
+    source_space.soul.write_text("Отвечаю коротко.\n", encoding="utf-8")
+    (source_space.user_dir / "USER.md").write_text("Роман строит KAOS.\n", encoding="utf-8")
+
+    skill_dir = source_space.skills_dir / "research-brief"
+    (skill_dir / "references").mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: research-brief\ndescription: Краткий бриф\nstatus: active\n---\n\n# Бриф\nШаги.\n",
+        encoding="utf-8",
+    )
+    (skill_dir / "references" / "SOURCES.md").write_text("- exa\n", encoding="utf-8")
+
+    from kronos import scheduled_tasks
+    from kronos.memory import fts, knowledge_graph
+    from kronos.swarm_store import get_swarm
+
+    fts.index_fact("Предпочитает краткие ответы", "roman")
+    fts.index_fact("Работает из Бали", "roman")
+    knowledge_graph.add_relation("Роман", "person", "KAOS", "project", "owns")
+    get_swarm().add_shared_fact(user_id="roman", fact="Часовой пояс UTC+8", source_agent="source")
+    scheduled_tasks.add_task(
+        agent_name="source",
+        chat_id=555,
+        topic_id=None,
+        thread_id="555",
+        run_at=1800000000.0,
+        message="Проверить релиз",
+    )
+
+    conn = sqlite3.connect(settings.db_path)
+    conn.execute("CREATE TABLE IF NOT EXISTS sessions (thread_id TEXT PRIMARY KEY, messages TEXT, updated_at TEXT)")
+    conn.execute(
+        "INSERT INTO sessions VALUES (?, ?, ?)",
+        ("555", json.dumps([{"type": "human", "content": "как дела"}]), "2026-01-01 10:00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+    bundle = tmp_path / "source.kaos"
+    export_bundle(bundle, include_notes=True, include_sessions=True, created_at=FIXED_TIME)
+
+    db_dir, target_space = _point_settings_at(monkeypatch, tmp_path, "target")
+    yield ImportEnv(bundle=bundle, space=target_space, db_dir=db_dir, tmp=tmp_path)
+
+    import kronos.db as _db
+
+    _db._instances.clear()
+
+
+def _fact_contents() -> list[str]:
+    db_path = Path(settings.db_dir) / "memory_fts.db"
+    if not db_path.exists():
+        return []
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        return [row[0] for row in conn.execute("SELECT content FROM memory_facts ORDER BY content")]
+    except sqlite3.OperationalError:
+        return []
+    finally:
+        conn.close()
+
+
+def test_import_creates_records(env):
+    report = import_bundle(env.bundle)
+
+    assert report.source_agent == "source"
+    assert report.created["facts"] == 2
+    assert report.created["graph_entities"] == 2
+    assert report.created["graph_relations"] == 1
+    assert report.created["shared_facts"] == 1
+    assert report.created["skills"] == 1
+
+    facts = _fact_contents()
+    assert "Работает из Бали" in facts
+    assert "Предпочитает краткие ответы" in facts
+
+
+def test_imported_skills_are_draft_and_marked(env):
+    import_bundle(env.bundle)
+
+    from kronos.skills.store import SkillStore
+
+    skill = SkillStore(env.space.root).get("research-brief")
+    assert skill is not None
+    assert skill.status == "draft"
+    assert skill.imported_from == "source"
+    assert (env.space.skills_dir / "research-brief" / "references" / "SOURCES.md").exists()
+
+
+def test_import_is_idempotent(env):
+    first = import_bundle(env.bundle)
+    second = import_bundle(env.bundle)
+
+    assert first.created["facts"] == 2
+    assert second.created.get("facts", 0) == 0
+    assert second.skipped["facts"] == 2
+    assert second.created.get("skills", 0) == 0
+    assert second.skipped["skills"] == 1
+    assert len(_fact_contents()) == 2
+
+
+def test_dedupe_ignores_whitespace_and_case(env):
+    from kronos.memory import fts
+
+    fts.index_fact("предпочитает   КРАТКИЕ ответы", "roman")
+    report = import_bundle(env.bundle)
+
+    assert report.skipped["facts"] == 1
+    assert report.created["facts"] == 1
+
+
+def test_dry_run_writes_nothing(env):
+    report = import_bundle(env.bundle, dry_run=True)
+
+    assert report.dry_run is True
+    assert report.created["facts"] == 2
+    assert _fact_contents() == []
+    assert not (env.space.skills_dir / "research-brief").exists()
+    assert not (env.db_dir / "memory_fts.db").exists()
+
+
+def test_persona_is_kept_local_by_default(env):
+    env.space.soul.write_text("Мой собственный голос.\n", encoding="utf-8")
+
+    report = import_bundle(env.bundle)
+
+    assert env.space.soul.read_text(encoding="utf-8") == "Мой собственный голос.\n"
+    assert report.skipped["persona_files"] >= 1
+    assert any("kept local" in w for w in report.warnings)
+
+
+def test_persona_append_marks_the_source(env):
+    env.space.soul.write_text("Мой собственный голос.\n", encoding="utf-8")
+
+    import_bundle(env.bundle, merge="append")
+    content = env.space.soul.read_text(encoding="utf-8")
+
+    assert "Мой собственный голос." in content
+    assert "Imported from 'source'" in content
+    assert "Отвечаю коротко." in content
+
+
+def test_persona_overwrite_replaces_file(env):
+    env.space.soul.write_text("Мой собственный голос.\n", encoding="utf-8")
+
+    import_bundle(env.bundle, merge="overwrite")
+
+    assert env.space.soul.read_text(encoding="utf-8") == "Отвечаю коротко.\n"
+
+
+def test_missing_persona_is_created_even_on_skip(env):
+    import_bundle(env.bundle)
+
+    assert env.space.soul.exists()
+    assert "Отвечаю коротко." in env.space.soul.read_text(encoding="utf-8")
+
+
+def test_notes_are_imported(env):
+    import_bundle(env.bundle)
+
+    assert (env.space.notes_dir / "user" / "USER.md").exists()
+    assert "KAOS" in (env.space.notes_dir / "user" / "USER.md").read_text(encoding="utf-8")
+
+
+def test_sessions_land_in_inbox_not_in_live_history(env):
+    report = import_bundle(env.bundle)
+
+    archive = env.space.inbox_dir / "imported-sessions-source.md"
+    assert archive.exists()
+    assert "thread 555" in archive.read_text(encoding="utf-8")
+    assert report.created["session_threads"] == 1
+    # The live session store must not be rewritten from a foreign installation.
+    assert not (env.db_dir / "session.db").exists()
+
+
+def test_schedule_needs_rebind_is_skipped_with_reason(env):
+    report = import_bundle(env.bundle)
+
+    assert report.skipped["scheduled_tasks"] == 1
+    assert any("rebind_chat" in w for w in report.warnings)
+
+
+def test_schedule_rebinds_to_local_chat(env):
+    import_bundle(env.bundle, rebind_chat=999)
+
+    from kronos import scheduled_tasks
+
+    pending = scheduled_tasks.list_pending("target")
+    assert len(pending) == 1
+    assert pending[0]["chat_id"] == 999
+    assert pending[0]["message"] == "Проверить релиз"
+
+
+def test_unknown_merge_mode_is_rejected(env):
+    with pytest.raises(BundleError, match="unknown merge mode"):
+        import_bundle(env.bundle, merge="rebase")
+
+
+def test_missing_bundle_is_rejected(tmp_path):
+    with pytest.raises(BundleError, match="not found"):
+        import_bundle(tmp_path / "nope.kaos")
+
+
+def test_tampered_bundle_is_refused_before_writing(env, tmp_path):
+    extracted = tmp_path / "unpacked"
+    with zipfile.ZipFile(env.bundle) as archive:
+        archive.extractall(extracted)
+    facts = extracted / "memory" / "facts.jsonl"
+    facts.write_text(
+        facts.read_text(encoding="utf-8") + '{"content": "внедрённый факт", "user_id": "roman"}\n', encoding="utf-8"
+    )
+
+    tampered = tmp_path / "tampered.kaos"
+    with zipfile.ZipFile(tampered, "w") as archive:
+        for path in sorted(p for p in extracted.rglob("*") if p.is_file()):
+            archive.write(path, path.relative_to(extracted).as_posix())
+
+    with pytest.raises(BundleError, match="failed verification"):
+        import_bundle(tampered)
+    assert _fact_contents() == []
+
+
+def test_path_traversal_in_bundle_is_refused(tmp_path):
+    evil = tmp_path / "evil.kaos"
+    with zipfile.ZipFile(evil, "w") as archive:
+        archive.writestr("../escaped.md", "pwned")
+
+    with pytest.raises(BundleError, match="unsafe path"):
+        import_bundle(evil)
+    assert not (tmp_path.parent / "escaped.md").exists()

--- a/tests/test_portability_importers.py
+++ b/tests/test_portability_importers.py
@@ -19,46 +19,50 @@ def _bundle_files(path) -> dict[str, str]:
 def _chatgpt_export(tmp_path, conversations=None):
     """A minimal ChatGPT export: a message tree with one regenerated branch."""
     # `is None` rather than falsy: an explicitly empty export is a valid case.
-    payload = conversations if conversations is not None else [
-        {
-            "title": "Планы на KAOS",
-            "create_time": 1700000000.0,
-            "update_time": 1700000500.0,
-            "mapping": {
-                "root": {"id": "root", "message": None, "parent": None, "children": ["m1"]},
-                "m1": {
-                    "id": "m1",
-                    "parent": "root",
-                    "children": ["m2", "m2-alt"],
-                    "message": {
-                        "author": {"role": "user"},
-                        "create_time": 1700000100.0,
-                        "content": {"parts": ["Запомни: я предпочитаю краткие ответы. Ещё поговорим о KAOS."]},
+    payload = (
+        conversations
+        if conversations is not None
+        else [
+            {
+                "title": "Планы на KAOS",
+                "create_time": 1700000000.0,
+                "update_time": 1700000500.0,
+                "mapping": {
+                    "root": {"id": "root", "message": None, "parent": None, "children": ["m1"]},
+                    "m1": {
+                        "id": "m1",
+                        "parent": "root",
+                        "children": ["m2", "m2-alt"],
+                        "message": {
+                            "author": {"role": "user"},
+                            "create_time": 1700000100.0,
+                            "content": {"parts": ["Запомни: я предпочитаю краткие ответы. Ещё поговорим о KAOS."]},
+                        },
+                    },
+                    "m2-alt": {
+                        "id": "m2-alt",
+                        "parent": "m1",
+                        "children": [],
+                        "message": {
+                            "author": {"role": "assistant"},
+                            "create_time": 1700000200.0,
+                            "content": {"parts": ["Отброшенная ветка."]},
+                        },
+                    },
+                    "m2": {
+                        "id": "m2",
+                        "parent": "m1",
+                        "children": [],
+                        "message": {
+                            "author": {"role": "assistant"},
+                            "create_time": 1700000400.0,
+                            "content": {"parts": ["Понял, буду краток."]},
+                        },
                     },
                 },
-                "m2-alt": {
-                    "id": "m2-alt",
-                    "parent": "m1",
-                    "children": [],
-                    "message": {
-                        "author": {"role": "assistant"},
-                        "create_time": 1700000200.0,
-                        "content": {"parts": ["Отброшенная ветка."]},
-                    },
-                },
-                "m2": {
-                    "id": "m2",
-                    "parent": "m1",
-                    "children": [],
-                    "message": {
-                        "author": {"role": "assistant"},
-                        "create_time": 1700000400.0,
-                        "content": {"parts": ["Понял, буду краток."]},
-                    },
-                },
-            },
-        }
-    ]
+            }
+        ]
+    )
     export_dir = tmp_path / "chatgpt-export"
     export_dir.mkdir()
     (export_dir / "conversations.json").write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
@@ -84,9 +88,194 @@ def _vault(tmp_path):
     return vault
 
 
+def _claude_project(tmp_path):
+    project = tmp_path / "claude-project"
+    (project / "skills" / "brief" / "references").mkdir(parents=True)
+    (project / "docs").mkdir()
+    (project / "CLAUDE.md").write_text("Ты аналитик. Отвечай по-русски.\n", encoding="utf-8")
+    (project / "skills" / "brief" / "SKILL.md").write_text(
+        "---\nname: brief\ndescription: Бриф\n---\n\n# Бриф\n", encoding="utf-8"
+    )
+    (project / "skills" / "brief" / "references" / "SOURCES.md").write_text("- exa\n", encoding="utf-8")
+    (project / "docs" / "spec.md").write_text("# Спека\nДетали.\n", encoding="utf-8")
+    return project
+
+
+def _telegram_export(tmp_path):
+    export = tmp_path / "tg"
+    export.mkdir()
+    payload = {
+        "personal_information": {
+            "first_name": "Роман",
+            "last_name": "Белов",
+            "username": "spyrae",
+            "bio": "строю агентов",
+        },
+        "chats": {
+            "list": [
+                {
+                    "name": "Рабочий чат",
+                    "id": 555,
+                    "type": "personal_chat",
+                    "messages": [
+                        {"id": 1, "type": "message", "from": "Роман", "text": "готов релиз?"},
+                        {
+                            "id": 2,
+                            "type": "message",
+                            "from": "Коллега",
+                            "text": [{"type": "plain", "text": "почти, "}, {"type": "link", "text": "смотри тут"}],
+                        },
+                        {"id": 3, "type": "service", "action": "pin_message"},
+                    ],
+                },
+                {"name": "Личное", "id": 777, "type": "personal_chat", "messages": [{"type": "message", "text": "х"}]},
+            ]
+        },
+    }
+    (export / "result.json").write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    return export
+
+
+def _letta_agent(tmp_path):
+    agent = tmp_path / "agent.af"
+    agent.write_text(
+        json.dumps(
+            {
+                "agent_type": "memgpt_agent",
+                "name": "Sam",
+                "system": "Ты помогаешь с исследованиями.",
+                "memory_blocks": [
+                    {"label": "persona", "value": "Я вдумчивый ассистент."},
+                    {"label": "human", "value": "- Роман\n- Работает над KAOS\n"},
+                    {"label": "project_notes", "value": "Спринт до пятницы."},
+                ],
+                "messages": [
+                    {"role": "user", "text": "привет"},
+                    {"role": "assistant", "content": "здравствуй"},
+                    {"role": "tool", "text": "{}"},
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    return agent
+
+
 def test_registry_lists_importers():
-    assert "chatgpt" in available()
-    assert "obsidian" in available()
+    assert set(available()) == {"chatgpt", "claude-projects", "letta", "telegram", "obsidian"}
+
+
+def test_strict_importers_are_probed_before_obsidian(tmp_path):
+    """A markdown folder with CLAUDE.md is a Claude project, not a vault."""
+    assert detect_importer(_claude_project(tmp_path)) == "claude-projects"
+    assert available().index("claude-projects") < available().index("obsidian")
+
+
+def test_claude_project_maps_instructions_skills_and_docs(tmp_path):
+    result = get_importer("claude-projects").to_bundle(
+        _claude_project(tmp_path), tmp_path / "cp.kaos", created_at=FIXED_TIME
+    )
+    files = _bundle_files(result.bundle)
+
+    assert "Ты аналитик" in files["persona/IDENTITY.md"]
+    assert "skills/brief/SKILL.md" in files
+    assert "skills/brief/references/SOURCES.md" in files
+    assert "notes/world/claude-project/docs/spec.md" in files
+    # The instructions file becomes persona, not a duplicate note.
+    assert not any(name.endswith("claude-project/CLAUDE.md") for name in files)
+
+
+def test_claude_projects_json_variant(tmp_path):
+    payload = [
+        {
+            "uuid": "abc",
+            "name": "KAOS",
+            "description": "Агентная ОС",
+            "prompt_template": "Будь краток.",
+            "docs": [{"filename": "notes.md", "content": "# Заметки\n"}],
+        }
+    ]
+    path = tmp_path / "projects.json"
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+    assert detect_importer(path) == "claude-projects"
+    result = get_importer("claude-projects").to_bundle(path, tmp_path / "cp.kaos", created_at=FIXED_TIME)
+    files = _bundle_files(result.bundle)
+
+    assert "Будь краток." in files["persona/IDENTITY.md"]
+    assert "notes/world/claude-project/KAOS/notes.md" in files
+    assert "notes/world/claude-project/KAOS/README.md" in files
+
+
+def test_telegram_requires_explicit_chat_selection(tmp_path):
+    export = _telegram_export(tmp_path)
+
+    assert detect_importer(export) == "telegram"
+    result = get_importer("telegram").to_bundle(export, tmp_path / "tg.kaos", user_id="roman", created_at=FIXED_TIME)
+
+    assert result.counts["sessions"] == 0
+    assert any("no chats selected" in w for w in result.warnings)
+    # Owner identity still comes through — that is why the bundle is not empty.
+    assert result.counts["facts"] == 3
+
+
+def test_telegram_imports_only_selected_chats(tmp_path):
+    result = get_importer("telegram").to_bundle(
+        _telegram_export(tmp_path),
+        tmp_path / "tg.kaos",
+        user_id="roman",
+        created_at=FIXED_TIME,
+        chats=["Рабочий чат"],
+    )
+    files = _bundle_files(result.bundle)
+    session = json.loads(files["sessions/sessions.jsonl"].strip())
+
+    assert session["thread_id"] == "telegram:555"
+    contents = [message["content"] for message in session["messages"]]
+    assert "Роман: готов релиз?" in contents
+    assert "Коллега: почти, смотри тут" in contents  # entity list flattened
+    assert len(contents) == 2  # the service message is dropped
+    assert not any('"777"' in name for name in files)
+
+
+def test_telegram_message_cap_is_reported(tmp_path):
+    result = get_importer("telegram").to_bundle(
+        _telegram_export(tmp_path),
+        tmp_path / "tg.kaos",
+        created_at=FIXED_TIME,
+        chats=["555"],
+        limit=1,
+    )
+
+    assert any("kept the last 1 messages" in w for w in result.warnings)
+
+
+def test_letta_maps_blocks_to_persona_facts_and_notes(tmp_path):
+    agent = _letta_agent(tmp_path)
+
+    assert detect_importer(agent) == "letta"
+    result = get_importer("letta").to_bundle(agent, tmp_path / "letta.kaos", user_id="roman", created_at=FIXED_TIME)
+    files = _bundle_files(result.bundle)
+
+    assert "Я вдумчивый ассистент." in files["persona/IDENTITY.md"]
+    assert "Ты помогаешь с исследованиями." in files["persona/methodology.md"]
+    facts = files["memory/facts.jsonl"]
+    assert "Работает над KAOS" in facts
+    assert "- Роман" not in facts  # list bullets stripped
+    # An unknown block is kept as a note instead of being dropped.
+    assert "notes/world/letta/project_notes.md" in files
+    session = json.loads(files["sessions/sessions.jsonl"].strip())
+    assert [m["type"] for m in session["messages"]] == ["human", "ai", "tool"]
+
+
+def test_letta_rejects_unrelated_json(tmp_path):
+    path = tmp_path / "random.json"
+    path.write_text(json.dumps({"hello": "world"}), encoding="utf-8")
+
+    assert get_importer("letta").detect(path) is False
+    with pytest.raises(BundleError, match="does not look like a Letta agent file"):
+        get_importer("letta").to_bundle(path, tmp_path / "out.kaos")
 
 
 def test_unknown_importer_is_rejected():

--- a/tests/test_portability_importers.py
+++ b/tests/test_portability_importers.py
@@ -1,0 +1,243 @@
+"""Foreign-export importers → .kaos bundle (moat phase 7.4)."""
+
+import json
+import zipfile
+
+import pytest
+
+from kronos.portability import BundleError
+from kronos.portability.importers import available, detect_importer, get_importer
+
+FIXED_TIME = "2026-01-01T00:00:00+00:00"
+
+
+def _bundle_files(path) -> dict[str, str]:
+    with zipfile.ZipFile(path) as archive:
+        return {name: archive.read(name).decode("utf-8") for name in archive.namelist()}
+
+
+def _chatgpt_export(tmp_path, conversations=None):
+    """A minimal ChatGPT export: a message tree with one regenerated branch."""
+    # `is None` rather than falsy: an explicitly empty export is a valid case.
+    payload = conversations if conversations is not None else [
+        {
+            "title": "Планы на KAOS",
+            "create_time": 1700000000.0,
+            "update_time": 1700000500.0,
+            "mapping": {
+                "root": {"id": "root", "message": None, "parent": None, "children": ["m1"]},
+                "m1": {
+                    "id": "m1",
+                    "parent": "root",
+                    "children": ["m2", "m2-alt"],
+                    "message": {
+                        "author": {"role": "user"},
+                        "create_time": 1700000100.0,
+                        "content": {"parts": ["Запомни: я предпочитаю краткие ответы. Ещё поговорим о KAOS."]},
+                    },
+                },
+                "m2-alt": {
+                    "id": "m2-alt",
+                    "parent": "m1",
+                    "children": [],
+                    "message": {
+                        "author": {"role": "assistant"},
+                        "create_time": 1700000200.0,
+                        "content": {"parts": ["Отброшенная ветка."]},
+                    },
+                },
+                "m2": {
+                    "id": "m2",
+                    "parent": "m1",
+                    "children": [],
+                    "message": {
+                        "author": {"role": "assistant"},
+                        "create_time": 1700000400.0,
+                        "content": {"parts": ["Понял, буду краток."]},
+                    },
+                },
+            },
+        }
+    ]
+    export_dir = tmp_path / "chatgpt-export"
+    export_dir.mkdir()
+    (export_dir / "conversations.json").write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    return export_dir
+
+
+def _vault(tmp_path):
+    vault = tmp_path / "vault"
+    (vault / ".obsidian").mkdir(parents=True)
+    (vault / "projects").mkdir()
+    (vault / "projects" / "KAOS.md").write_text(
+        "---\ntype: note\n---\n\nСвязан с [[Роман]] и [[Bali]].\n", encoding="utf-8"
+    )
+    (vault / "Роман.md").write_text(
+        "---\ntype: fact\ndate: 2026-01-01\n---\n\nРоман работает из Бали.\n", encoding="utf-8"
+    )
+    (vault / "prefs.md").write_text(
+        "---\nfacts: [Любит краткость, Пишет по-русски]\n---\n\nНастройки.\n", encoding="utf-8"
+    )
+    (vault / ".obsidian" / "workspace.json").write_text("{}", encoding="utf-8")
+    (vault / ".trash").mkdir()
+    (vault / ".trash" / "deleted.md").write_text("удалённая заметка\n", encoding="utf-8")
+    return vault
+
+
+def test_registry_lists_importers():
+    assert "chatgpt" in available()
+    assert "obsidian" in available()
+
+
+def test_unknown_importer_is_rejected():
+    with pytest.raises(BundleError, match="unknown importer"):
+        get_importer("myspace")
+
+
+def test_detect_picks_the_right_importer(tmp_path):
+    assert detect_importer(_chatgpt_export(tmp_path)) == "chatgpt"
+    assert detect_importer(_vault(tmp_path)) == "obsidian"
+    assert detect_importer(tmp_path / "nothing-here") is None
+
+
+def test_chatgpt_keeps_only_the_retained_branch(tmp_path):
+    result = get_importer("chatgpt").to_bundle(
+        _chatgpt_export(tmp_path), tmp_path / "out.kaos", user_id="roman", created_at=FIXED_TIME
+    )
+    files = _bundle_files(result.bundle)
+    session = json.loads(files["sessions/sessions.jsonl"].strip())
+
+    contents = [message["content"] for message in session["messages"]]
+    assert "Понял, буду краток." in contents
+    assert "Отброшенная ветка." not in contents
+    assert [message["type"] for message in session["messages"]] == ["human", "ai"]
+
+
+def test_chatgpt_harvests_explicit_memory_statements(tmp_path):
+    result = get_importer("chatgpt").to_bundle(
+        _chatgpt_export(tmp_path), tmp_path / "out.kaos", user_id="roman", created_at=FIXED_TIME
+    )
+    facts = _bundle_files(result.bundle)["memory/facts.jsonl"]
+
+    assert "я предпочитаю краткие ответы" in facts.lower()
+    # A sentence without a memory marker is not a fact.
+    assert "поговорим о KAOS" not in facts
+
+
+def test_chatgpt_reads_an_export_zip(tmp_path):
+    export_dir = _chatgpt_export(tmp_path)
+    archive = tmp_path / "export.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.write(export_dir / "conversations.json", "chatgpt-export/conversations.json")
+
+    assert get_importer("chatgpt").detect(archive) is True
+    result = get_importer("chatgpt").to_bundle(archive, tmp_path / "out.kaos", created_at=FIXED_TIME)
+    assert result.counts["sessions"] == 1
+
+
+def test_chatgpt_limit_reports_what_was_dropped(tmp_path):
+    conversations = []
+    for index in range(3):
+        conversations.append(
+            {
+                "title": f"Разговор {index}",
+                "update_time": 1700000000.0 + index,
+                "mapping": {
+                    f"m{index}": {
+                        "id": f"m{index}",
+                        "parent": None,
+                        "message": {
+                            "author": {"role": "user"},
+                            "create_time": 1700000000.0 + index,
+                            "content": {"parts": [f"сообщение {index}"]},
+                        },
+                    }
+                },
+            }
+        )
+
+    result = get_importer("chatgpt").to_bundle(
+        _chatgpt_export(tmp_path, conversations), tmp_path / "out.kaos", limit=2, created_at=FIXED_TIME
+    )
+
+    assert result.counts["sessions"] == 2
+    assert any("1 older ones skipped" in w for w in result.warnings)
+
+
+def test_chatgpt_empty_export_is_an_explicit_error(tmp_path):
+    result_dir = _chatgpt_export(tmp_path, [])
+    with pytest.raises(BundleError, match="nothing importable"):
+        get_importer("chatgpt").to_bundle(result_dir, tmp_path / "out.kaos")
+
+
+def test_obsidian_maps_notes_links_and_facts(tmp_path):
+    result = get_importer("obsidian").to_bundle(
+        _vault(tmp_path), tmp_path / "vault.kaos", user_id="roman", created_at=FIXED_TIME
+    )
+    files = _bundle_files(result.bundle)
+
+    assert "notes/world/vault/projects/KAOS.md" in files
+    assert "notes/world/vault/Роман.md" in files
+    # Vault plumbing and trash stay out.
+    assert not any("workspace.json" in name for name in files)
+    assert not any("deleted" in name for name in files)
+
+    relations = files["memory/graph.relations.jsonl"]
+    assert '"name": "Роман"' in relations and "links_to" in relations
+    assert '"name": "Bali"' in relations
+
+    facts = files["memory/facts.jsonl"]
+    assert "Роман работает из Бали." in facts
+    assert "Любит краткость" in facts
+    assert "Пишет по-русски" in facts
+
+
+def test_obsidian_requires_a_directory(tmp_path):
+    lonely = tmp_path / "note.md"
+    lonely.write_text("текст\n", encoding="utf-8")
+
+    assert get_importer("obsidian").detect(lonely) is False
+    with pytest.raises(BundleError, match="not a vault directory"):
+        get_importer("obsidian").to_bundle(lonely, tmp_path / "out.kaos")
+
+
+def test_importer_bundles_verify_and_import(tmp_path, monkeypatch):
+    """The whole point: a foreign export becomes a bundle the normal path accepts."""
+    from kronos.config import settings
+    from kronos.portability import import_bundle
+    from kronos.portability.manifest import verify_manifest
+
+    result = get_importer("obsidian").to_bundle(_vault(tmp_path), tmp_path / "vault.kaos", created_at=FIXED_TIME)
+
+    extracted = tmp_path / "unpacked"
+    with zipfile.ZipFile(result.bundle) as archive:
+        archive.extractall(extracted)
+    assert verify_manifest(extracted) == []
+
+    db_dir = tmp_path / "data" / "target"
+    db_dir.mkdir(parents=True)
+    monkeypatch.setattr(settings, "agent_name", "target")
+    monkeypatch.setattr(settings, "db_dir", str(db_dir))
+    monkeypatch.setattr(settings, "db_path", str(db_dir / "session.db"))
+    monkeypatch.setattr(settings, "swarm_db_path", str(tmp_path / "swarm.db"))
+    monkeypatch.setattr(settings, "shared_workspace_path", "")
+
+    import kronos.db as _db
+    import kronos.workspace as _ws
+    from kronos.memory import fts as _fts
+    from kronos.memory import knowledge_graph as _kg
+
+    _db._instances.clear()
+    monkeypatch.setattr(_fts, "_schema_initialized", False)
+    monkeypatch.setattr(_kg, "_schema_initialized", False)
+    space = _ws.Workspace(tmp_path / "workspaces" / "target")
+    monkeypatch.setattr(_ws, "ws", space)
+    space.ensure_dirs()
+
+    report = import_bundle(result.bundle)
+
+    assert report.source_agent == "obsidian"
+    assert report.created["facts"] == 3
+    assert report.created["notes"] == 3
+    assert (space.notes_dir / "world" / "vault" / "Роман.md").exists()
+    _db._instances.clear()

--- a/tests/test_portability_manifest.py
+++ b/tests/test_portability_manifest.py
@@ -1,0 +1,136 @@
+"""Agent bundle manifest — hashing, determinism, verification (moat phase 7.1)."""
+
+import json
+
+import pytest
+
+from kronos.portability import manifest as m
+
+
+@pytest.fixture
+def bundle(tmp_path):
+    """A minimal populated bundle directory (no manifest yet)."""
+    root = tmp_path / "bundle"
+    (root / "persona").mkdir(parents=True)
+    (root / "memory").mkdir(parents=True)
+    (root / "persona" / "SOUL.md").write_text("быть точным\n", encoding="utf-8")
+    (root / "memory" / "facts.jsonl").write_text('{"content": "любит краткость"}\n', encoding="utf-8")
+    return root
+
+
+def test_hash_artifacts_uses_sorted_posix_keys(bundle):
+    artifacts = m.hash_artifacts(bundle)
+
+    assert list(artifacts) == sorted(artifacts)
+    assert "persona/SOUL.md" in artifacts
+    assert artifacts["persona/SOUL.md"].startswith("sha256:")
+
+
+def test_manifest_excludes_itself_from_artifacts(bundle):
+    first = m.build_manifest(bundle, agent_name="kronos", includes=["persona"], counts={"facts": 1})
+    m.write_manifest(bundle, first)
+
+    rehashed = m.hash_artifacts(bundle)
+    assert m.MANIFEST_NAME not in rehashed
+    assert rehashed == first.artifacts
+
+
+def test_manifest_is_deterministic_for_same_content(bundle):
+    counts = {"facts": 1, "skills": 0}
+    first = m.build_manifest(
+        bundle, agent_name="kronos", includes=["persona"], counts=counts, created_at="2026-01-01T00:00:00+00:00"
+    )
+    second = m.build_manifest(
+        bundle, agent_name="kronos", includes=["persona"], counts=counts, created_at="2026-01-01T00:00:00+00:00"
+    )
+
+    assert first.to_json() == second.to_json()
+
+
+def test_created_at_is_the_only_time_dependent_field(bundle):
+    early = m.build_manifest(
+        bundle, agent_name="kronos", includes=["persona"], counts={}, created_at="2026-01-01T00:00:00+00:00"
+    )
+    later = m.build_manifest(
+        bundle, agent_name="kronos", includes=["persona"], counts={}, created_at="2026-07-25T12:00:00+00:00"
+    )
+
+    assert early.created_at != later.created_at
+    assert early.artifacts == later.artifacts
+
+
+def test_includes_are_validated(bundle):
+    with pytest.raises(m.BundleError, match="unknown bundle sections"):
+        m.build_manifest(bundle, agent_name="kronos", includes=["persona", "bitcoin_wallet"], counts={})
+
+
+def test_verify_manifest_accepts_untouched_bundle(bundle):
+    m.write_manifest(bundle, m.build_manifest(bundle, agent_name="kronos", includes=["persona"], counts={}))
+
+    assert m.verify_manifest(bundle) == []
+
+
+def test_verify_manifest_detects_single_changed_byte(bundle):
+    m.write_manifest(bundle, m.build_manifest(bundle, agent_name="kronos", includes=["persona"], counts={}))
+    (bundle / "persona" / "SOUL.md").write_text("быть точнык\n", encoding="utf-8")
+
+    problems = m.verify_manifest(bundle)
+
+    assert problems == ["hash mismatch: persona/SOUL.md"]
+
+
+def test_verify_manifest_detects_missing_and_unlisted_files(bundle):
+    m.write_manifest(bundle, m.build_manifest(bundle, agent_name="kronos", includes=["persona"], counts={}))
+    (bundle / "memory" / "facts.jsonl").unlink()
+    (bundle / "memory" / "smuggled.jsonl").write_text("{}\n", encoding="utf-8")
+
+    problems = m.verify_manifest(bundle)
+
+    assert "missing file: memory/facts.jsonl" in problems
+    assert "unlisted file: memory/smuggled.jsonl" in problems
+
+
+def test_read_manifest_requires_the_file(tmp_path):
+    with pytest.raises(m.BundleError, match="not found"):
+        m.read_manifest(tmp_path)
+
+
+def test_manifest_rejects_malformed_json(bundle):
+    (bundle / m.MANIFEST_NAME).write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(m.BundleError, match="not valid JSON"):
+        m.read_manifest(bundle)
+
+
+def test_manifest_rejects_missing_required_fields(bundle):
+    (bundle / m.MANIFEST_NAME).write_text(json.dumps({"agent_name": "kronos"}), encoding="utf-8")
+
+    with pytest.raises(m.BundleError, match="missing required fields"):
+        m.read_manifest(bundle)
+
+
+def test_manifest_tolerates_unknown_future_fields(bundle):
+    payload = {
+        "agent_name": "kronos",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "schema_version": m.BUNDLE_SCHEMA_VERSION,
+        "artifacts": {},
+        "some_future_field": {"nested": True},
+    }
+    (bundle / m.MANIFEST_NAME).write_text(json.dumps(payload), encoding="utf-8")
+
+    parsed = m.read_manifest(bundle)
+
+    assert parsed.agent_name == "kronos"
+
+
+def test_newer_schema_version_is_refused(bundle):
+    payload = {
+        "agent_name": "kronos",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "schema_version": m.BUNDLE_SCHEMA_VERSION + 1,
+    }
+    (bundle / m.MANIFEST_NAME).write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(m.BundleError, match="newer than this KAOS supports"):
+        m.read_manifest(bundle)


### PR DESCRIPTION
An agent is a persona, a set of skills, and a memory of you. Until now none of
that could leave the machine it grew on — only single skills had an export. This
adds portable, content-hashed agent bundles and five importers so a history that
started in another tool can become the starting point here.

## What's in it

```bash
kaos export --out my-agent.kaos            # persona, skills, facts, graph, schedule
kaos import my-agent.kaos --dry-run        # verify + report, write nothing
kaos import-from auto ~/chatgpt-export     # detect format, convert, import
```

- **`manifest.json` with a SHA-256 per artifact.** Import verifies the payload
  before touching a database and aborts on a single altered byte.
- **Deterministic exports.** Sorted JSONL, fixed archive timestamps, and
  `created_at` as the only wall-clock field — re-exporting unchanged state gives
  a byte-identical file, which makes "did my agent's state change?" checkable.
- **Content-based dedupe** (whitespace/case-insensitive), so a second import is
  a no-op. Ids from another installation mean nothing locally.
- **Importers:** ChatGPT (`conversations.json`, directory, or export zip),
  Claude projects (directory or `projects.json`), Obsidian vaults, Telegram
  (`result.json`), Letta `.af`. Each converts to a bundle first, so every path
  inherits the same verification, merge rules and dry-run.

## Safety decisions worth reviewing

- **Nothing secret leaves.** `.env*`, `*.session`, the SQLite files themselves,
  `qdrant/` and audit logs are blocklisted; a parametrized negative test asserts
  this across every flag combination.
- **Two redaction levels.** Owner-authored material (persona, notes, facts)
  keeps its PII — masking your own email out of your own facts would destroy
  what the bundle carries — while sessions and tool output, which contain
  third-party data, are PII-masked. `audit.redact_secrets` is now public so both
  paths share one copy of the credential patterns.
- **Transport ids are dropped by default.** `chat_id`/`topic_id`/`thread_id`
  identify someone's private chats; tasks are marked `needs_rebind` instead, and
  `--include-transport-ids` warns.
- **Imported skills arrive as drafts** and persona files stay local unless
  `--merge append|overwrite` is asked for.
- **Session history is never written into the live session store.** Thread ids
  come from another installation; overwriting a real conversation to "restore" a
  foreign one is data loss wearing a feature's clothes. It lands in
  `notes/inbox/` as markdown, still readable by the agent.
- **Zip-slip refused** on import; foreign archives are extracted path-checked.

## Also fixed

`export`/`import` bound `kronos.workspace.ws` at import time, so a swapped
workspace was ignored — which also meant an earlier version of the export suite
was passing against the previous test's directory. Both now resolve `ws` at call
time.

## Verification

- 74 new tests; full suite **821 passed**, `pytest -m eval` 6 passed, ruff clean.
- Live smoke: `kaos export` on an agent whose workspace contained a real-looking
  `.env` produced an archive with no secret in it, and `kaos import --dry-run`
  correctly kept the local persona.
- Docs: [docs/PORTABILITY.md](docs/PORTABILITY.md), README section, CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)