### PR TITLE
fix(test): egress test must not depend on a local EXA_API_KEY

### DIFF
--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -190,7 +190,10 @@ def test_search_libraries_respect_the_allowlist(tmp_path, monkeypatch):
 
     _policy(tmp_path, monkeypatch, {"mode": "allowlist", "dry_run": False, "domains": ["api.exa.ai"]})
     monkeypatch.setattr(settings, "brave_api_key", "test-key")
-    monkeypatch.setattr(settings, "exa_api_key", "test-key")
+    # exa reads its key from the environment, not from settings — patching only
+    # the setting made this test pass locally (where the key exists) and fail in
+    # CI (where it does not).
+    monkeypatch.setenv("EXA_API_KEY", "test-key")
     monkeypatch.setattr(brave, "_brave_unavailable_until", 0.0, raising=False)
 
     # Brave's host is not listed → blocked before any request is made, and the


### PR DESCRIPTION
`test_search_libraries_respect_the_allowlist` patched `settings.exa_api_key`, but
`exa.search` reads `EXA_API_KEY` from the environment. So the test passed locally
(where the key exists) and failed in CI (where it does not) — the failure that
went into main with #34.

Patching the env var instead makes the test independent of the machine it runs on.
Verified with the keys explicitly unset:

```bash
env -u EXA_API_KEY -u BRAVE_API_KEY -u DEEPSEEK_API_KEY -u OPENAI_API_KEY \
  pytest -m "not integration" -q
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)