### PR TITLE
Durable execution v2: finish interrupted turns, effects ledger, turn inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Kronos Agent OS are documented here.
 
 ### Added
 
+- **Durable execution v2** — an interrupted turn can now be finished instead of
+  only reported. New `external_effects` ledger makes re-execution safe (a
+  message already sent is not re-sent; `side_effect` + optional
+  `idempotency_key` metadata per tool), `durable.resume_mode: resume` opts in,
+  and `max_resume_attempts` stops a crash loop. Claiming decides superseded /
+  failed / resuming in one transaction. New `kaos turns list/show/fork/resume`,
+  a Durable Turns page in the control room, `running_turns` on `/health`, and a
+  weekly `turn-retention` job. Docs: [Runtime](docs/RUNTIME.md).
 - **Governance as code (`policy.yaml`)** — one validated file for capability
   gates, approval rules, budgets, untrusted-output handling, egress, retention
   and PII masking, with `kaos policy report` printing the effective value and

--- a/dashboard-ui/src/App.tsx
+++ b/dashboard-ui/src/App.tsx
@@ -21,6 +21,7 @@ const MonitoringPage = lazy(() => import('./pages/MonitoringPage'));
 const PerformancePage = lazy(() => import('./pages/PerformancePage'));
 const AnalyticsPage = lazy(() => import('./pages/AnalyticsPage'));
 const AuditTrailPage = lazy(() => import('./pages/AuditTrailPage'));
+const TurnsPage = lazy(() => import('./pages/TurnsPage'));
 const AnomaliesPage = lazy(() => import('./pages/AnomaliesPage'));
 const SandboxPage = lazy(() => import('./pages/SandboxPage'));
 
@@ -112,6 +113,7 @@ const NAV_SECTIONS: NavSection[] = [
       { path: '/performance', label: 'Performance', icon: 'P' },
       { path: '/analytics', label: 'Analytics', icon: 'N' },
       { path: '/audit', label: 'Audit Trail', icon: 'T' },
+      { path: '/turns', label: 'Durable Turns', icon: 'D' },
       { path: '/sandbox', label: 'Sandbox', icon: 'X' },
     ],
   },
@@ -341,6 +343,7 @@ export default function App() {
           <Route path="/performance" element={<PerformancePage />} />
           <Route path="/analytics" element={<AnalyticsPage />} />
           <Route path="/audit" element={<AuditTrailPage />} />
+          <Route path="/turns" element={<TurnsPage />} />
           <Route path="/sandbox" element={<SandboxPage />} />
           <Route path="/anomalies" element={<AnomaliesPage />} />
           <Route path="/mcp" element={<McpPage />} />

--- a/dashboard-ui/src/pages/TurnsPage.tsx
+++ b/dashboard-ui/src/pages/TurnsPage.tsx
@@ -1,0 +1,285 @@
+import { type CSSProperties, useEffect, useState } from 'react';
+import { api } from '../api/client';
+import { KPICard, SectionHeader, StatusBadge } from '../components/Charts';
+
+interface Turn {
+  turn_id: string;
+  thread_id: string;
+  status: string;
+  input_message: string;
+  attempts: number;
+  started_at: string;
+  completed_at: string | null;
+  error: string | null;
+}
+
+interface JournalEntry {
+  seq: number;
+  status: string;
+  created_at: string;
+  message: {
+    type?: string;
+    content?: string;
+    tool_calls?: { name?: string; args?: Record<string, unknown> }[];
+  };
+}
+
+interface TurnDetail extends Turn {
+  journal: JournalEntry[];
+  tool_results: { tool_call_id: string; content: string }[];
+  effects: { idempotency_key: string; tool: string; result: string; created_at: string }[];
+}
+
+interface TurnsResponse {
+  turns: Turn[];
+  counts: Record<string, number>;
+  total: number;
+  running_turns: number;
+  oldest_running_age_seconds: number | null;
+}
+
+const IN_FLIGHT = ['running', 'resuming'];
+const FILTERS = ['all', 'running', 'resuming', 'done', 'failed', 'superseded'] as const;
+
+function badge(status: string): 'running' | 'stopped' | 'error' | 'warning' {
+  if (IN_FLIGHT.includes(status)) return 'warning';
+  if (status === 'failed') return 'error';
+  if (status === 'done') return 'running';
+  return 'stopped';
+}
+
+function age(seconds: number | null): string {
+  if (seconds === null) return '—';
+  if (seconds < 90) return `${Math.round(seconds)}s`;
+  if (seconds < 5400) return `${Math.round(seconds / 60)}m`;
+  return `${Math.round(seconds / 3600)}h`;
+}
+
+export default function TurnsPage() {
+  const [data, setData] = useState<TurnsResponse | null>(null);
+  const [status, setStatus] = useState<string>('all');
+  const [selected, setSelected] = useState<TurnDetail | null>(null);
+  const [busy, setBusy] = useState('');
+  const [notice, setNotice] = useState('');
+
+  const card: CSSProperties = {
+    background: '#111',
+    border: '1px solid #1a1a1a',
+    borderRadius: 8,
+    padding: '1.25rem',
+  };
+  const button: CSSProperties = {
+    background: '#181818',
+    border: '1px solid #262626',
+    borderRadius: 5,
+    color: '#ccc',
+    cursor: 'pointer',
+    fontSize: '0.7rem',
+    marginRight: '0.35rem',
+    padding: '0.25rem 0.6rem',
+  };
+  const cell: CSSProperties = { padding: '0.55rem 0.6rem', verticalAlign: 'top' };
+  const mono: CSSProperties = { fontFamily: 'ui-monospace, SFMono-Regular, monospace', color: '#9ca3af' };
+
+  const load = () => {
+    const query = status === 'all' ? '' : `?status=${status}`;
+    api<TurnsResponse>(`/api/turns${query}`)
+      .then(setData)
+      .catch(() => setNotice('Could not load turns'));
+  };
+
+  useEffect(load, [status]);
+
+  const open = (turnId: string) => {
+    api<TurnDetail>(`/api/turns/${turnId}`)
+      .then(setSelected)
+      .catch(() => setNotice(`Could not load turn ${turnId}`));
+  };
+
+  const act = async (turnId: string, action: 'resume' | 'fork') => {
+    setBusy(turnId);
+    setNotice('');
+    try {
+      const result = await api<{ ok: boolean; answer?: string; thread_id?: string }>(
+        `/api/turns/${turnId}/${action}`,
+        { method: 'POST', body: JSON.stringify({}) }
+      );
+      setNotice(
+        action === 'resume'
+          ? `Turn finished: ${(result.answer ?? '').slice(0, 140)}`
+          : `Forked into thread ${result.thread_id}`
+      );
+      load();
+      if (selected?.turn_id === turnId) open(turnId);
+    } catch {
+      setNotice(`${action} failed — see the agent log`);
+    } finally {
+      setBusy('');
+    }
+  };
+
+  return (
+    <div>
+      <h1 style={{ fontSize: '1.5rem', fontWeight: 600, marginBottom: '0.35rem' }}>Durable Turns</h1>
+      <p style={{ color: '#666', fontSize: '0.8rem', marginBottom: '1.25rem', maxWidth: 640 }}>
+        A turn stuck in flight means a process died while someone was waiting. Resume finishes it —
+        effects already recorded are never repeated.
+      </p>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '0.75rem', marginBottom: '1.25rem' }}>
+        <KPICard icon="D" value={String(data?.running_turns ?? 0)} label="In flight" />
+        <KPICard icon="T" value={age(data?.oldest_running_age_seconds ?? null)} label="Oldest in flight" />
+        <KPICard icon="L" value={String(data?.total ?? 0)} label="Listed" />
+      </div>
+
+      {notice && (
+        <div style={{ ...card, marginBottom: '1rem', borderColor: '#3f2d0a', color: '#fcd34d', fontSize: '0.78rem' }}>
+          {notice}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.4rem', marginBottom: '0.9rem' }}>
+        {FILTERS.map(option => (
+          <button
+            key={option}
+            onClick={() => setStatus(option)}
+            style={{
+              ...button,
+              background: status === option ? '#17120c' : '#181818',
+              borderColor: status === option ? '#92400e' : '#262626',
+              color: status === option ? '#fcd34d' : '#999',
+            }}
+          >
+            {option}
+            {data?.counts?.[option] ? ` (${data.counts[option]})` : ''}
+          </button>
+        ))}
+      </div>
+
+      <div style={{ ...card, marginBottom: '1rem', overflowX: 'auto' }}>
+        <SectionHeader title="Turns" />
+        <table style={{ width: '100%', minWidth: 760, borderCollapse: 'collapse', fontSize: '0.78rem' }}>
+          <thead>
+            <tr style={{ borderBottom: '1px solid #222' }}>
+              {['Status', 'Thread', 'Input', 'Att', 'Started', ''].map(header => (
+                <th
+                  key={header}
+                  style={{
+                    padding: '0.55rem 0.6rem',
+                    textAlign: 'left',
+                    color: '#555',
+                    fontSize: '0.68rem',
+                    fontWeight: 600,
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.04em',
+                  }}
+                >
+                  {header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {(data?.turns ?? []).map(turn => (
+              <tr
+                key={turn.turn_id}
+                style={{
+                  borderBottom: '1px solid #171717',
+                  background: selected?.turn_id === turn.turn_id ? '#17120c' : 'transparent',
+                }}
+              >
+                <td style={cell}>
+                  <StatusBadge status={badge(turn.status)} label={turn.status} />
+                </td>
+                <td style={{ ...cell, ...mono }}>{turn.thread_id}</td>
+                <td style={{ ...cell, color: '#ccc' }}>{turn.input_message?.slice(0, 60) || '—'}</td>
+                <td style={{ ...cell, color: turn.attempts ? '#fcd34d' : '#555' }}>{turn.attempts}</td>
+                <td style={{ ...cell, color: '#666', whiteSpace: 'nowrap' }}>{turn.started_at}</td>
+                <td style={{ ...cell, whiteSpace: 'nowrap' }}>
+                  <button style={button} onClick={() => open(turn.turn_id)}>
+                    Details
+                  </button>
+                  {IN_FLIGHT.includes(turn.status) && (
+                    <button
+                      style={{ ...button, borderColor: '#92400e', color: '#fcd34d' }}
+                      disabled={busy === turn.turn_id}
+                      onClick={() => act(turn.turn_id, 'resume')}
+                    >
+                      {busy === turn.turn_id ? '…' : 'Resume'}
+                    </button>
+                  )}
+                  <button style={button} disabled={busy === turn.turn_id} onClick={() => act(turn.turn_id, 'fork')}>
+                    Fork
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {!data?.turns?.length && (
+          <p style={{ color: '#666', fontSize: '0.78rem', marginTop: '0.75rem' }}>
+            No durable turns recorded for this agent.
+          </p>
+        )}
+      </div>
+
+      {selected && (
+        <div style={card}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.75rem' }}>
+            <h2 style={{ fontSize: '0.95rem', fontWeight: 600, display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              <span style={mono}>{selected.turn_id.slice(0, 8)}</span>
+              <StatusBadge status={badge(selected.status)} label={selected.status} />
+            </h2>
+            <button style={button} onClick={() => setSelected(null)}>
+              Close
+            </button>
+          </div>
+
+          {selected.error && (
+            <p style={{ color: '#fca5a5', fontSize: '0.78rem', marginBottom: '0.6rem' }}>{selected.error}</p>
+          )}
+          <p style={{ color: '#666', fontSize: '0.72rem', marginBottom: '0.5rem' }}>
+            thread <span style={mono}>{selected.thread_id}</span> · attempts {selected.attempts} · started{' '}
+            {selected.started_at}
+          </p>
+          <p style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: '1rem' }}>{selected.input_message}</p>
+
+          <SectionHeader title="Journal" />
+          {selected.journal.length ? (
+            <ol style={{ margin: '0 0 1rem 1.1rem', color: '#ccc', fontSize: '0.78rem', lineHeight: 1.7 }}>
+              {selected.journal.map(entry => {
+                const calls = (entry.message?.tool_calls ?? []).map(call => call.name).join(', ');
+                return (
+                  <li key={entry.seq}>
+                    <span style={mono}>{entry.message?.type ?? '?'}</span>{' '}
+                    {calls || (entry.message?.content ?? '').slice(0, 140) || '—'}
+                  </li>
+                );
+              })}
+            </ol>
+          ) : (
+            <p style={{ color: '#666', fontSize: '0.76rem', marginBottom: '1rem' }}>
+              No journal rows — a finished turn drops them; they exist only while a turn is in flight.
+            </p>
+          )}
+
+          {selected.effects.length > 0 && (
+            <>
+              <SectionHeader title="Recorded external effects" />
+              <p style={{ color: '#666', fontSize: '0.72rem', marginBottom: '0.4rem' }}>
+                These already happened. Resuming this turn will not repeat them.
+              </p>
+              <ul style={{ margin: '0 0 0 1.1rem', color: '#ccc', fontSize: '0.78rem', lineHeight: 1.7 }}>
+                {selected.effects.map(effect => (
+                  <li key={effect.idempotency_key}>
+                    <span style={mono}>{effect.tool}</span>: {effect.result.slice(0, 100)}
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/api/turns.py
+++ b/dashboard/api/turns.py
@@ -1,0 +1,97 @@
+"""Durable turns API — see what is in flight, inspect it, resume or fork it.
+
+Turn state used to be readable only by opening SQLite. Since a stuck turn means
+"a process died and the user is still waiting", it belongs in the control room
+next to health and the audit trail.
+
+Resume and fork mutate state, so they are POSTs behind the same cookie auth as
+everything else here.
+"""
+
+import logging
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+
+from dashboard.auth import verify_token
+from kronos.config import settings
+
+router = APIRouter(prefix="/api/turns", tags=["turns"], dependencies=[Depends(verify_token)])
+log = logging.getLogger("kronos.dashboard.turns")
+
+IN_FLIGHT = {"running", "resuming"}
+
+
+def _store():
+    from kronos.session import SessionStore
+
+    return SessionStore(settings.db_path, agent_name=settings.agent_name)
+
+
+@router.get("")
+async def list_turns(
+    status: str = Query("", description="running|resuming|done|failed|superseded|recovered"),
+    thread: str = Query(""),
+    limit: int = Query(50, ge=1, le=500),
+) -> dict:
+    """Recent durable turns plus the in-flight summary shown on /health."""
+    store = _store()
+    turns = await store.list_turns(status=status, thread_id=thread, limit=limit)
+    stats = await store.running_turn_stats()
+
+    counts: dict[str, int] = {}
+    for turn in turns:
+        key = str(turn.get("status") or "unknown")
+        counts[key] = counts.get(key, 0) + 1
+
+    return {"turns": turns, "counts": counts, "total": len(turns), **stats}
+
+
+@router.get("/{turn_id}")
+async def get_turn(turn_id: str) -> dict:
+    """One turn: journal timeline, memoized tool results, recorded effects."""
+    detail = await _store().get_turn_detail(turn_id)
+    if not detail:
+        raise HTTPException(status_code=404, detail=f"turn {turn_id} not found")
+    return detail
+
+
+@router.post("/{turn_id}/resume")
+async def resume_turn(turn_id: str) -> dict:
+    """Finish an interrupted turn now.
+
+    Only in-flight turns can be resumed: re-running a finished turn would
+    re-answer a question that was already answered.
+    """
+    store = _store()
+    detail = await store.get_turn_detail(turn_id)
+    if not detail:
+        raise HTTPException(status_code=404, detail=f"turn {turn_id} not found")
+    if detail["status"] not in IN_FLIGHT:
+        raise HTTPException(status_code=409, detail=f"turn is '{detail['status']}', only in-flight turns can resume")
+
+    from kronos.graph import KronosAgent
+
+    agent = KronosAgent(session_store=store)
+    answer = await agent.resume_interrupted_turn(
+        {
+            "turn_id": turn_id,
+            "thread_id": detail["thread_id"],
+            "input_message": detail.get("input_message", ""),
+            "attempts": detail.get("attempts", 0),
+        }
+    )
+    if not answer:
+        raise HTTPException(status_code=500, detail="resume produced no answer; the turn was marked failed")
+    return {"ok": True, "turn_id": turn_id, "answer": answer}
+
+
+@router.post("/{turn_id}/fork")
+async def fork_turn(turn_id: str, payload: dict = Body(default={})) -> dict:
+    """Copy a turn's prefix into a new thread, leaving the original intact."""
+    at_seq = int(payload.get("at_seq") or 0)
+    thread = str(payload.get("thread") or "")
+
+    result = await _store().fork_turn(turn_id, at_seq=at_seq, new_thread_id=thread)
+    if not result:
+        raise HTTPException(status_code=404, detail=f"turn {turn_id} not found")
+    return {"ok": True, **result}

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -31,6 +31,7 @@ from dashboard.api.persona import router as persona_router
 from dashboard.api.sandbox import router as sandbox_router
 from dashboard.api.skills import router as skills_router
 from dashboard.api.swarm import router as swarm_router
+from dashboard.api.turns import router as turns_router
 from dashboard.config import (
     DASHBOARD_HOST,
     DASHBOARD_PASSWORD,
@@ -79,6 +80,7 @@ def create_app(scheduler=None, agent=None) -> FastAPI:
     app.include_router(overview_router)
     app.include_router(performance_router)
     app.include_router(audit_trail_router)
+    app.include_router(turns_router)
     app.include_router(anomalies_router)
     app.include_router(persona_router)
     app.include_router(monitoring_router)

--- a/docs/RUNTIME.md
+++ b/docs/RUNTIME.md
@@ -123,3 +123,68 @@ Example path:
 
 If the behavior is only instructions and references, make it a skill instead of
 a Python tool.
+
+## Durable Turns
+
+Every interactive turn is journalled: the input, each model/tool message, and the
+tool results, in `data/<agent>/session.db`. That journal is what makes three
+things possible — recovering from a crash, capturing eval scenarios, and forking
+a conversation.
+
+```bash
+kaos turns list --status running   # what is stuck?
+kaos turns show <turn_id>          # journal, tool results, recorded effects
+kaos turns resume <turn_id>        # finish it now
+kaos turns fork <turn_id> --at 3   # branch from a point, original untouched
+```
+
+`/health` reports `running_turns` and the age of the oldest one, so a turn nobody
+picked up is visible to monitoring instead of only to whoever reads SQLite.
+
+### What happens after a crash
+
+Governed by `durable.resume_mode` in `policy.yaml`:
+
+| Mode | Behaviour |
+|---|---|
+| `report` (default) | Restore the history, note the interruption. The question stays unanswered. |
+| `resume` | Re-execute the unanswered part and deliver the answer. |
+
+`resume` is safe because of two guarantees, in this order:
+
+1. **Tool results are memoized per turn** — a call that already answered is not
+   re-run.
+2. **Side-effecting tools consult an effects ledger** (`external_effects`) — a
+   message already sent, an expense already recorded, a service already
+   restarted is skipped and its recorded result returned instead.
+
+That is why the ledger shipped before resume, not after. A tool declares itself
+side-effecting the same way it declares `needs_approval`:
+
+```python
+tool.metadata["side_effect"] = True
+tool.metadata["idempotency_key"] = lambda args: f"chat:{args['chat_id']}:{args['text']}"
+```
+
+The default key includes `turn_id`: inside one turn a repeat is a retry (skip
+it), while the same call in a later turn is the user asking again (do it). A
+custom key narrows that when the natural identity of the effect is smaller than
+"these arguments" — a retry carrying a regenerated request id is still one send.
+
+Three outcomes are decided when interrupted turns are claimed, in a single
+transaction so two processes cannot both take one:
+
+- **superseded** — the thread already has a newer turn; answering the stale
+  question would be noise.
+- **failed** — `max_resume_attempts` exhausted, so a crash loop cannot resurrect
+  itself.
+- **resuming** — handed to the agent to finish.
+
+### Retention
+
+The weekly `turn-retention` job prunes finished turns per
+`retention.turn_journal_days`. Live turns are never pruned: an unfinished turn
+older than the window is a bug worth looking at, not garbage. In practice the
+journal is already gone by then (a finished turn drops it), so what retention
+reclaims is turn rows and their effects — safe to drop together, because the
+idempotency key contains the turn id.

--- a/kronos/app.py
+++ b/kronos/app.py
@@ -94,6 +94,19 @@ def _ensure_data_dirs() -> None:
     log.info("Data dirs ready: %s (swarm=%s)", db_dir, settings.swarm_db_path)
 
 
+async def _deliver_resumed_answer(thread_id: str, text: str) -> None:
+    """Publish a resumed answer through the same self-webhook reminders use."""
+    import asyncio
+
+    from kronos.cron.notify import send_webhook
+
+    chat_id, _, topic = thread_id.partition(":")
+    try:
+        await asyncio.to_thread(send_webhook, text, int(chat_id), None, int(topic) if topic else None)
+    except (TypeError, ValueError) as e:
+        log.warning("Cannot deliver resumed answer for thread %s: %s", thread_id, e)
+
+
 def _activate_policy_or_exit() -> None:
     """Load policy.yaml before any capability gate is read.
 
@@ -119,7 +132,12 @@ async def main():
     _ensure_data_dirs()
 
     session_store = SessionStore(settings.db_path, agent_name=settings.agent_name)
-    await session_store.recover_abandoned_turns()
+
+    from kronos.policy import get_policy
+
+    durable = get_policy().durable
+    if durable.resume_mode != "resume":
+        await session_store.recover_abandoned_turns()
 
     async with managed_mcp_tools() as tools:
         agent = KronosAgent(
@@ -127,6 +145,17 @@ async def main():
             session_store=session_store,
         )
         log.info("Agent ready: %d tools, db=%s", len(tools), settings.db_path)
+
+        if durable.resume_mode == "resume":
+            # Resume needs a live agent (and its tools), so it happens here rather
+            # than next to the store. Delivery reuses the reminder path: the
+            # session layer must not learn about transports.
+            finished = await agent.resume_abandoned_turns(
+                deliver=_deliver_resumed_answer,
+                max_attempts=durable.max_resume_attempts,
+            )
+            if finished:
+                log.warning("Finished %d interrupted turn(s) after restart", finished)
 
         # Start cron scheduler
         scheduler = Scheduler()

--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -824,12 +824,23 @@ async def _handle_health(request: web.Request) -> web.Response:
     # are reported for visibility but don't fail health on their own (the
     # fallback chain still has other providers).
     healthy = connected
+    # A turn stuck in 'running' means a process died and nothing picked it up.
+    # Without this it stays invisible until someone reads the database.
+    turn_stats = {"running_turns": 0, "oldest_running_age_seconds": None}
+    try:
+        from kronos.session import SessionStore
+
+        turn_stats = await SessionStore(settings.db_path, agent_name=settings.agent_name).running_turn_stats()
+    except Exception as e:
+        log.debug("Could not read running-turn stats: %s", e)
+
     body = {
         "status": "ok" if healthy else "degraded",
         "agent": settings.agent_name,
         "telegram_connected": connected,
         "last_event_age_seconds": last_event_age,
         "providers_in_cooldown": cooldowns,
+        **turn_stats,
     }
     return web.json_response(body, status=200 if healthy else 503)
 

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -984,6 +984,121 @@ def run_import_from(
     return 0
 
 
+def _session_store():
+    from kronos.session import SessionStore
+
+    return SessionStore(settings.db_path, agent_name=settings.agent_name)
+
+
+def run_turns_list(*, status: str, thread: str, limit: int) -> int:
+    """List durable turns so an operator can see what is stuck."""
+    import asyncio as _asyncio
+
+    turns = _asyncio.run(_session_store().list_turns(status=status, thread_id=thread, limit=limit))
+    if not turns:
+        print("No durable turns recorded for this agent.")
+        return 0
+
+    print(f"{'turn_id':<38} {'status':<11} {'att':<4} started              input")
+    for turn in turns:
+        preview = str(turn.get("input_message") or "").replace("\n", " ")[:44]
+        print(
+            f"{turn['turn_id']:<38} {str(turn['status']):<11} {str(turn.get('attempts', 0)):<4} "
+            f"{str(turn.get('started_at') or ''):<20} {preview}"
+        )
+    stuck = [turn for turn in turns if turn["status"] in {"running", "resuming"}]
+    if stuck:
+        print(f"\n{len(stuck)} turn(s) in flight. Finish one with: kaos turns resume <turn_id>")
+    return 0
+
+
+def run_turns_show(turn_id: str) -> int:
+    """Show one turn: journal, memoized results, recorded effects."""
+    import asyncio as _asyncio
+
+    detail = _asyncio.run(_session_store().get_turn_detail(turn_id))
+    if not detail:
+        print(f"Turn not found: {turn_id}")
+        return 1
+
+    print(f"turn {detail['turn_id']}  [{detail['status']}]  thread={detail['thread_id']}")
+    print(f"  started: {detail.get('started_at')}   completed: {detail.get('completed_at') or '—'}")
+    print(f"  attempts: {detail.get('attempts', 0)}")
+    if detail.get("error"):
+        print(f"  error: {detail['error']}")
+    print(f"  input: {str(detail.get('input_message') or '')[:200]}")
+
+    print("\n  journal:")
+    for row in detail["journal"]:
+        message = row["message"] or {}
+        kind = str(message.get("type") or "?")
+        calls = [str(call.get("name", "")) for call in message.get("tool_calls") or []]
+        summary = ", ".join(calls) if calls else str(message.get("content") or "")[:80].replace("\n", " ")
+        print(f"    [{row['seq']:>3}] {kind:<14} {summary}")
+
+    if detail["tool_results"]:
+        print("\n  memoized tool results:")
+        for row in detail["tool_results"]:
+            print(f"    {row['tool_call_id']}: {str(row['content'])[:80]}")
+    if detail["effects"]:
+        print("\n  recorded external effects (will not repeat on resume):")
+        for row in detail["effects"]:
+            print(f"    {row['tool']}: {str(row['result'])[:60]}")
+    return 0
+
+
+def run_turns_fork(turn_id: str, *, at_seq: int, thread: str) -> int:
+    """Fork a turn's prefix into a new thread, leaving the original intact."""
+    import asyncio as _asyncio
+
+    result = _asyncio.run(_session_store().fork_turn(turn_id, at_seq=at_seq, new_thread_id=thread))
+    if not result:
+        print(f"Turn not found: {turn_id}")
+        return 1
+    print(f"Forked {result['source_turn']} → thread '{result['thread_id']}' ({result['messages']} message(s))")
+    print("The original turn is untouched. Continue the fork with: kaos chat")
+    return 0
+
+
+def run_turns_resume(turn_id: str) -> int:
+    """Finish one interrupted turn by hand."""
+    import asyncio as _asyncio
+
+    if not _runtime_llm_configured():
+        _print_missing_runtime_llm()
+        return 1
+
+    async def _resume() -> int:
+        from kronos.graph import KronosAgent
+
+        store = _session_store()
+        detail = await store.get_turn_detail(turn_id)
+        if not detail:
+            print(f"Turn not found: {turn_id}")
+            return 1
+        if detail["status"] not in {"running", "resuming"}:
+            print(f"Turn {turn_id} is '{detail['status']}' — only in-flight turns can be resumed.")
+            return 1
+
+        agent = KronosAgent(session_store=store)
+        answer = await agent.resume_interrupted_turn(
+            {
+                "turn_id": turn_id,
+                "thread_id": detail["thread_id"],
+                "input_message": detail.get("input_message", ""),
+                "attempts": detail.get("attempts", 0),
+            }
+        )
+        if not answer:
+            print("Resume produced no answer — see the log; the turn was marked failed.")
+            return 1
+        print(answer)
+        return 0
+
+    _configure_logging()
+    return _asyncio.run(_resume())
+
+
 def run_policy_report(as_json: bool) -> int:
     """Print the effective governance posture and where each value came from."""
     from kronos.policy import PolicyError, effective_values, load_policy
@@ -1351,6 +1466,21 @@ def build_parser() -> argparse.ArgumentParser:
     import_from.add_argument("--out", "-o", default="", help="keep the intermediate bundle at this path")
     import_from.add_argument("--convert-only", action="store_true", help="write the bundle without importing it")
 
+    turns = sub.add_parser("turns", help="inspect, fork and resume durable turns")
+    turns_sub = turns.add_subparsers(dest="turns_command")
+    turns_list = turns_sub.add_parser("list", help="list recent durable turns")
+    turns_list.add_argument("--status", default="", help="filter: running|resuming|completed|failed|superseded")
+    turns_list.add_argument("--thread", default="", help="filter by thread id")
+    turns_list.add_argument("--limit", type=int, default=20, help="how many to show")
+    turns_show = turns_sub.add_parser("show", help="show one turn's journal and effects")
+    turns_show.add_argument("turn_id")
+    turns_fork = turns_sub.add_parser("fork", help="copy a turn's prefix into a new thread")
+    turns_fork.add_argument("turn_id")
+    turns_fork.add_argument("--at", dest="at_seq", type=int, default=0, help="journal seq to cut at (0 = all)")
+    turns_fork.add_argument("--thread", default="", help="target thread id")
+    turns_resume = turns_sub.add_parser("resume", help="finish an interrupted turn now")
+    turns_resume.add_argument("turn_id")
+
     policy_cmd = sub.add_parser("policy", help="inspect the governance policy")
     policy_sub = policy_cmd.add_subparsers(dest="policy_command")
     policy_report = policy_sub.add_parser("report", help="print the effective policy and value sources")
@@ -1489,6 +1619,17 @@ def main(argv: list[str] | None = None) -> int:
         )
     if args.command == "import":
         return run_import(args.path, merge=args.merge, dry_run=args.dry_run, rebind_chat=args.rebind_chat)
+    if args.command == "turns":
+        if args.turns_command == "list":
+            return run_turns_list(status=args.status, thread=args.thread, limit=args.limit)
+        if args.turns_command == "show":
+            return run_turns_show(args.turn_id)
+        if args.turns_command == "fork":
+            return run_turns_fork(args.turn_id, at_seq=args.at_seq, thread=args.thread)
+        if args.turns_command == "resume":
+            return run_turns_resume(args.turn_id)
+        parser.parse_args(["turns", "--help"])
+        return 0
     if args.command == "policy":
         if args.policy_command == "report":
             return run_policy_report(args.as_json)

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -54,6 +54,7 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     from kronos.cron.sleep_compute import run_sleep_compute
     from kronos.cron.source_quality_audit import run_source_quality_audit
     from kronos.cron.swarm_retention import run_swarm_retention
+    from kronos.cron.turn_retention import run_turn_retention
     from kronos.cron.user_model import run_user_model
 
     me = settings.agent_name
@@ -146,6 +147,10 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     # Swarm Retention — weekly Sunday 03:00 UTC. Prunes swarm_messages
     # older than MESSAGE_RETENTION_DAYS (90d). Safe on all 6 agents.
     scheduler.add_weekly("swarm-retention", run_swarm_retention, weekday=6, hour_utc=3)
+
+    # Turn Retention — weekly Sunday 03:30 UTC. Prunes finished durable turns and
+    # their journal/results/effects per policy.retention.turn_journal_days.
+    scheduler.add_weekly("turn-retention", run_turn_retention, weekday=6, hour_utc=5)
 
     # ── Agent-exclusive jobs (only registered on the owning agent) ──────
     nexus_jobs_registered = 0

--- a/kronos/cron/turn_retention.py
+++ b/kronos/cron/turn_retention.py
@@ -1,0 +1,37 @@
+"""Turn-history retention — prune finished durable turns weekly.
+
+The journal is what makes resume, capture and forking possible, so it grows with
+every turn. Only *finished* turns are pruned: a running or resuming turn is live
+state, and an unfinished turn older than the window is a bug worth looking at,
+not garbage to sweep.
+
+Window comes from the governance policy (``retention.turn_journal_days``).
+"""
+
+import logging
+
+from kronos.config import settings
+from kronos.policy import get_policy
+from kronos.session import SessionStore
+
+log = logging.getLogger("kronos.cron.turn_retention")
+
+
+async def run_turn_retention() -> None:
+    days = get_policy().retention.turn_journal_days
+    try:
+        store = SessionStore(settings.db_path, agent_name=settings.agent_name)
+        pruned = await store.prune_turn_history(older_than_days=days)
+    except Exception as e:
+        log.error("Turn retention failed: %s", e)
+        return
+
+    if pruned.get("turns"):
+        log.info(
+            "Turn retention: %d turn(s), %d journal row(s), %d tool result(s), %d effect(s) older than %dd",
+            pruned["turns"],
+            pruned["journal"],
+            pruned["tool_results"],
+            pruned["effects"],
+            days,
+        )

--- a/kronos/engine.py
+++ b/kronos/engine.py
@@ -42,6 +42,8 @@ ToolCacheGetCallback = Callable[[str], Any]
 ToolCacheSaveCallback = Callable[[str, str], Any]
 ToolApprovalPredicate = Callable[[BaseTool, dict], Any]
 ToolApprovalRequestCallback = Callable[[BaseTool, dict], Any]
+EffectGetCallback = Callable[[str], Any]
+EffectRecordCallback = Callable[[str, str, str], Any]
 
 
 class SubAgentApprovalPause(Exception):  # noqa: N818 - control-flow signal, not an error
@@ -340,6 +342,10 @@ async def execute_tool(
     tool: BaseTool,
     tool_call: dict,
     error_handler: Callable[[Exception], str] = classify_tool_error,
+    *,
+    get_external_effect: EffectGetCallback | None = None,
+    record_external_effect: EffectRecordCallback | None = None,
+    turn_id: str = "",
 ) -> ToolMessage:
     """Execute a single tool call, returning a ToolMessage.
 
@@ -367,6 +373,21 @@ async def execute_tool(
         raise CassetteMissError(
             f"no cassette for external tool '{tool.name}' with these args. Record it first: KAOS_CASSETTE_MODE=record."
         )
+
+    effect_key = ""
+    if tool_has_side_effect(tool) and (get_external_effect or record_external_effect):
+        effect_key = side_effect_key(tool, args, turn_id)
+        if get_external_effect:
+            try:
+                previous = await _maybe_await(get_external_effect(effect_key))
+            except Exception as e:
+                log.warning("Effect lookup failed for %s: %s", tool.name, e)
+                previous = None
+            if previous is not None:
+                # This effect already happened. Re-running the turn must not send
+                # the message, charge the card or restart the service twice.
+                log.info("Skipping repeated side effect: %s", tool.name)
+                return _build_tool_message(str(previous), str(previous), tool_call_id)
 
     try:
         if hasattr(tool, "ainvoke"):
@@ -403,6 +424,14 @@ async def execute_tool(
         recorded_content, is_error = content, True
         log.warning("Tool error %s: %s", tool.name, str(e)[:200])
 
+    if effect_key and record_external_effect and not is_error:
+        # Only successful effects are recorded: a failed send did not happen, so a
+        # retry should be allowed to try again.
+        try:
+            await _maybe_await(record_external_effect(effect_key, tool.name, recorded_content))
+        except Exception as e:
+            log.warning("Could not record side effect for %s: %s", tool.name, e)
+
     if cassettes.recording():
         # Record the pre-wrap content: the untrusted framing is re-applied on
         # replay, so a cassette stays valid if that framing later changes.
@@ -415,6 +444,45 @@ async def execute_tool(
         )
 
     return _build_tool_message(content, raw_content, tool_call_id)
+
+
+SIDE_EFFECT_METADATA_KEY = "side_effect"
+IDEMPOTENCY_KEY_METADATA = "idempotency_key"
+
+
+def tool_has_side_effect(tool: BaseTool) -> bool:
+    """Whether calling this tool changes something outside the process."""
+    metadata = getattr(tool, "metadata", None) or {}
+    declared = metadata.get(SIDE_EFFECT_METADATA_KEY)
+    if declared is None:
+        declared = getattr(tool, SIDE_EFFECT_METADATA_KEY, None)
+    return bool(declared)
+
+
+def side_effect_key(tool: BaseTool, args: dict, turn_id: str = "") -> str:
+    """Idempotency key for one side-effecting call.
+
+    A tool may declare its own key function via
+    ``metadata['idempotency_key'] = lambda args: ...`` when the natural identity
+    of the effect is narrower than "these arguments" — e.g. a message keyed by
+    chat + text, so a retry with a regenerated request id is still recognised.
+
+    The default includes turn_id: within a turn a repeat is a retry (skip it),
+    while the same call in a later turn is the user asking again (do it).
+    """
+    metadata = getattr(tool, "metadata", None) or {}
+    custom = metadata.get(IDEMPOTENCY_KEY_METADATA) or getattr(tool, IDEMPOTENCY_KEY_METADATA, None)
+    if callable(custom):
+        try:
+            declared = custom(args)
+            if declared:
+                return f"{tool.name}:{declared}"
+        except Exception as e:
+            log.warning("idempotency_key callable failed for %s: %s", tool.name, e)
+
+    from kronos.cassettes.store import tool_key
+
+    return f"{tool.name}:{turn_id}:{tool_key(tool_name=tool.name, args=args)}"
 
 
 def _build_tool_message(content: str, raw_content: str, tool_call_id: str) -> ToolMessage:
@@ -473,6 +541,9 @@ async def react_loop(
     save_tool_result: ToolCacheSaveCallback | None = None,
     needs_tool_approval: ToolApprovalPredicate | None = None,
     request_tool_approval: ToolApprovalRequestCallback | None = None,
+    get_external_effect: EffectGetCallback | None = None,
+    record_external_effect: EffectRecordCallback | None = None,
+    turn_id: str = "",
 ) -> AgentResult:
     """Run the ReAct loop: LLM → tool_calls → execute → LLM → ...
 
@@ -706,7 +777,14 @@ async def react_loop(
                             }
                         )
                         try:
-                            tm = await execute_tool(tool, tc, error_handler)
+                            tm = await execute_tool(
+                                tool,
+                                tc,
+                                error_handler,
+                                get_external_effect=get_external_effect,
+                                record_external_effect=record_external_effect,
+                                turn_id=turn_id,
+                            )
                         except SubAgentApprovalPause as pause:
                             # A delegated sub-agent paused for approval: bubble it
                             # up as a top-level pause. The delegate_to_X call (tc)

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -449,6 +449,90 @@ class KronosAgent:
         )
         return result.content
 
+    async def resume_interrupted_turn(self, turn: dict) -> str | None:
+        """Finish a turn whose process died mid-flight.
+
+        Safe to call because two guarantees are already in place: tool results are
+        memoized per turn (an answered call is not re-run) and side-effecting
+        tools consult the effects ledger (a sent message is not re-sent). Without
+        those, re-execution would duplicate real-world actions — which is why
+        this landed after the ledger, not before.
+        """
+        if not self._session_store:
+            return None
+
+        turn_id = str(turn.get("turn_id") or "")
+        thread_id = str(turn.get("thread_id") or "")
+        if not turn_id or not thread_id:
+            return None
+
+        messages = await self._session_store.load_turn_messages(thread_id, turn_id)
+        if not messages:
+            await self._session_store.fail_turn(turn_id, "nothing to resume")
+            return None
+
+        react_loop_kwargs = self._build_durable_react_loop_kwargs(
+            turn_id=turn_id,
+            thread_id=thread_id,
+        )
+        audit_token = set_tool_audit_context(
+            agent=settings.agent_name,
+            thread_id=thread_id,
+            session_id=thread_id,
+            source_kind="durable_resume",
+        )
+        try:
+            result = await self._run_model_loop(
+                messages=messages,
+                source_message=str(turn.get("input_message") or ""),
+                react_loop_kwargs=react_loop_kwargs,
+            )
+        except Exception as e:
+            log.error("Resume failed for turn %s: %s", turn_id, e)
+            await self._session_store.fail_turn(turn_id, f"resume failed: {e}")
+            return None
+        finally:
+            reset_tool_audit_context(audit_token)
+
+        if getattr(result, "waiting_approval", False):
+            # The resumed turn hit an approval gate: leave it pending, exactly as
+            # a first-time run would.
+            self._last_pending_approval_id = result.approval_id
+            return result.content
+
+        save_messages = [message for message in result.messages if not isinstance(message, SystemMessage)]
+        await self._session_store.finalize_turn(
+            thread_id=thread_id,
+            messages=save_messages,
+            turn_id=turn_id,
+        )
+        log.info("Resumed interrupted turn %s (attempt %s)", turn_id, turn.get("attempts"))
+        return result.content
+
+    async def resume_abandoned_turns(self, *, deliver=None, max_attempts: int = 2) -> int:
+        """Claim and finish every interrupted turn. Returns how many completed.
+
+        ``deliver(thread_id, text)`` publishes the answer; without it the turn is
+        still completed and journalled, which is what a CLI or test wants.
+        """
+        if not self._session_store:
+            return 0
+
+        claimed = await self._session_store.claim_turns_for_resume(max_attempts=max_attempts)
+        finished = 0
+        for turn in claimed:
+            answer = await self.resume_interrupted_turn(turn)
+            if not answer:
+                continue
+            finished += 1
+            if deliver:
+                try:
+                    await deliver(turn["thread_id"], answer)
+                except Exception as e:
+                    # The turn is finished and journalled; only delivery failed.
+                    log.error("Could not deliver resumed answer for %s: %s", turn["turn_id"], e)
+        return finished
+
     async def _resume_delegated_approval(
         self,
         *,

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -240,6 +240,17 @@ class KronosAgent:
                 content=content,
             )
 
+        async def get_external_effect(key: str) -> str | None:
+            return await self._session_store.get_external_effect(key)
+
+        async def record_external_effect(key: str, tool_name: str, result: str) -> None:
+            await self._session_store.record_external_effect(
+                key=key,
+                turn_id=turn_id,
+                tool=tool_name,
+                result=result,
+            )
+
         async def request_tool_approval(tool: BaseTool, tool_call: dict) -> str:
             # current_delegation() is set when the approval originates inside a
             # sub-agent — it records the parent delegate_to_X call so the resume
@@ -258,6 +269,9 @@ class KronosAgent:
             "get_cached_tool_result": get_cached_tool_result,
             "save_tool_result": save_tool_result,
             "request_tool_approval": request_tool_approval,
+            "get_external_effect": get_external_effect,
+            "record_external_effect": record_external_effect,
+            "turn_id": turn_id,
         }
         if approved_tool_name:
             kwargs["needs_tool_approval"] = self._approval_scope(approved_tool_name, approved_tool_args)

--- a/kronos/policy.py
+++ b/kronos/policy.py
@@ -116,6 +116,24 @@ class RetentionPolicy(BaseModel):
     swarm_messages_days: int = 30
 
 
+class DurablePolicy(BaseModel):
+    """How an interrupted turn is handled on the next start."""
+
+    # "report" reproduces the historical behaviour (restore history, note the
+    # interruption). "resume" re-executes the unanswered part. Default stays
+    # report so an upgrade never changes what a restart does without being asked.
+    resume_mode: str = "report"
+    max_resume_attempts: int = 2
+
+    @field_validator("resume_mode")
+    @classmethod
+    def _known_mode(cls, value: str) -> str:
+        cleaned = (value or "").strip().lower()
+        if cleaned not in ("report", "resume"):
+            raise ValueError("resume_mode must be 'report' or 'resume'")
+        return cleaned
+
+
 class PiiPolicy(BaseModel):
     mask_in_logs: bool = True
     mask_in_cassettes: bool = True
@@ -131,6 +149,7 @@ class Policy(BaseModel):
     untrusted_output: UntrustedOutputPolicy = Field(default_factory=UntrustedOutputPolicy)
     egress: EgressPolicy = Field(default_factory=EgressPolicy)
     retention: RetentionPolicy = Field(default_factory=RetentionPolicy)
+    durable: DurablePolicy = Field(default_factory=DurablePolicy)
     pii: PiiPolicy = Field(default_factory=PiiPolicy)
 
     # Where this policy came from; "" means "no file, code defaults".

--- a/kronos/security/effects.py
+++ b/kronos/security/effects.py
@@ -1,0 +1,35 @@
+"""Marking tools whose calls change something outside this process.
+
+Durable resume replays the unanswered part of a turn. That is only safe if the
+runtime can tell "this call already happened" from "this call still needs to
+run" — otherwise a crash after sending a message but before journalling the
+result would send it twice on recovery.
+
+Marking is opt-in per tool, like ``needs_approval`` and ``untrusted_output``:
+the runtime cannot infer intent from a function signature, and guessing wrong in
+either direction is bad (a missed mark duplicates effects, a false mark silently
+skips real work).
+"""
+
+import logging
+from collections.abc import Iterable
+from typing import Any
+
+log = logging.getLogger("kronos.security.effects")
+
+SIDE_EFFECT_METADATA_KEY = "side_effect"
+
+
+def mark_side_effect(tools: Iterable[Any], *, reason: str = "") -> list[Any]:
+    """Mark tools as having an external side effect. Returns the marked tools."""
+    marked = []
+    for tool in tools:
+        try:
+            tool.metadata = {**(getattr(tool, "metadata", None) or {}), SIDE_EFFECT_METADATA_KEY: True}
+        except (AttributeError, ValueError) as e:
+            log.error("Cannot mark tool %s as side-effecting: %s", getattr(tool, "name", tool), e)
+            continue
+        marked.append(tool)
+    if marked and reason:
+        log.debug("Marked %d %s tool(s) as side-effecting", len(marked), reason)
+    return marked

--- a/kronos/session.py
+++ b/kronos/session.py
@@ -142,6 +142,16 @@ class SessionStore:
                 CREATE INDEX IF NOT EXISTS idx_active_turns_running
                     ON active_turns(status, started_at)
             """)
+            # attempts arrived with durable resume: a turn that keeps dying must
+            # not be retried forever. Backfill on databases created before it.
+            cursor = await db.execute("PRAGMA table_info(active_turns)")
+            turn_columns = {row[1] for row in await cursor.fetchall()}
+            if "attempts" not in turn_columns:
+                try:
+                    await db.execute("ALTER TABLE active_turns ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0")
+                except sqlite3.OperationalError as e:
+                    if "duplicate column name" not in str(e).lower():
+                        raise
             await db.execute("""
                 CREATE TABLE IF NOT EXISTS turn_journal (
                     turn_id TEXT NOT NULL,
@@ -310,6 +320,91 @@ class SessionStore:
                 (turn_id, tool_call_id, content),
             )
             await db.commit()
+
+    async def claim_turns_for_resume(self, *, max_attempts: int = 2) -> list[dict]:
+        """Claim interrupted turns for re-execution, newest-first per thread.
+
+        Returns rows the caller should finish. Three outcomes are decided here,
+        under one transaction, so two processes cannot both claim a turn:
+
+        * a turn whose thread already saw a newer turn is marked ``superseded`` —
+          the user asked again, and answering the stale question would be noise;
+        * a turn that has already burned its attempts is failed, so a crash loop
+          cannot resurrect itself forever;
+        * anything else flips to ``resuming`` and is handed back.
+        """
+        claimed: list[dict] = []
+        async with self._open_db() as db:
+            await self._ensure_table(db)
+            await db.execute("BEGIN IMMEDIATE")
+            try:
+                cursor = await db.execute(
+                    """
+                    SELECT turn_id, thread_id, input_message, attempts, rowid
+                    FROM active_turns
+                    WHERE status = 'running'
+                    ORDER BY rowid ASC
+                    """
+                )
+                rows = await cursor.fetchall()
+
+                for turn_id, thread_id, input_message, attempts, row_id in rows:
+                    # Ordering by rowid, not started_at: CURRENT_TIMESTAMP has
+                    # second resolution, so two turns in the same second would
+                    # both look "not newer" and a stale one would be resumed.
+                    newer = await db.execute(
+                        """
+                        SELECT 1 FROM active_turns
+                        WHERE thread_id = ? AND rowid > ?
+                        LIMIT 1
+                        """,
+                        (thread_id, row_id),
+                    )
+                    if await newer.fetchone():
+                        await db.execute(
+                            """
+                            UPDATE active_turns
+                            SET status = 'superseded', completed_at = CURRENT_TIMESTAMP,
+                                error = 'superseded by a newer turn in this thread'
+                            WHERE turn_id = ?
+                            """,
+                            (turn_id,),
+                        )
+                        continue
+
+                    if int(attempts or 0) >= max_attempts:
+                        await db.execute(
+                            """
+                            UPDATE active_turns
+                            SET status = 'failed', completed_at = CURRENT_TIMESTAMP,
+                                error = 'gave up after ' || ? || ' resume attempt(s)'
+                            WHERE turn_id = ?
+                            """,
+                            (int(attempts or 0), turn_id),
+                        )
+                        continue
+
+                    await db.execute(
+                        "UPDATE active_turns SET status = 'resuming', attempts = attempts + 1 WHERE turn_id = ?",
+                        (turn_id,),
+                    )
+                    claimed.append(
+                        {
+                            "turn_id": str(turn_id),
+                            "thread_id": str(thread_id),
+                            "input_message": str(input_message or ""),
+                            "attempts": int(attempts or 0) + 1,
+                        }
+                    )
+                await db.commit()
+            except Exception:
+                await db.rollback()
+                raise
+
+        if claimed:
+            log.warning("Claimed %d interrupted turn(s) for resume", len(claimed))
+            self._record_durable_metric("durable_turns_resumed", len(claimed))
+        return claimed
 
     async def get_external_effect(self, key: str) -> str | None:
         """Return the recorded result of a side-effecting call, if it already ran.

--- a/kronos/session.py
+++ b/kronos/session.py
@@ -77,6 +77,15 @@ def _serialize_message(msg: BaseMessage) -> dict:
     return data
 
 
+def _safe_json(raw: str) -> dict:
+    """Parse a journal payload, tolerating a corrupted row."""
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
 def _deserialize_message(data: dict) -> BaseMessage:
     """Deserialize a dict back to a LangChain message."""
     msg_type = data.get("type", "HumanMessage")
@@ -320,6 +329,176 @@ class SessionStore:
                 (turn_id, tool_call_id, content),
             )
             await db.commit()
+
+    async def list_turns(self, *, status: str = "", thread_id: str = "", limit: int = 20) -> list[dict]:
+        """Recent durable turns, newest first."""
+        clauses, params = [], []
+        if status:
+            clauses.append("status = ?")
+            params.append(status)
+        if thread_id:
+            clauses.append("thread_id = ?")
+            params.append(thread_id)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(limit)
+
+        async with self._open_db() as db:
+            await self._ensure_table(db)
+            cursor = await db.execute(
+                f"""
+                SELECT turn_id, thread_id, status, input_message, attempts, started_at, completed_at, error
+                FROM active_turns {where} ORDER BY rowid DESC LIMIT ?
+                """,
+                tuple(params),
+            )
+            rows = await cursor.fetchall()
+
+        keys = ("turn_id", "thread_id", "status", "input_message", "attempts", "started_at", "completed_at", "error")
+        return [dict(zip(keys, row, strict=False)) for row in rows]
+
+    async def get_turn_detail(self, turn_id: str) -> dict | None:
+        """One turn with its journal, memoized tool results and effects."""
+        async with self._open_db() as db:
+            await self._ensure_table(db)
+            cursor = await db.execute(
+                """
+                SELECT turn_id, thread_id, status, input_message, attempts, started_at, completed_at, error
+                FROM active_turns WHERE turn_id = ?
+                """,
+                (turn_id,),
+            )
+            row = await cursor.fetchone()
+            if not row:
+                return None
+            keys = (
+                "turn_id",
+                "thread_id",
+                "status",
+                "input_message",
+                "attempts",
+                "started_at",
+                "completed_at",
+                "error",
+            )
+            turn = dict(zip(keys, row, strict=False))
+
+            journal_cursor = await db.execute(
+                "SELECT seq, message_json, status, created_at FROM turn_journal WHERE turn_id = ? ORDER BY seq",
+                (turn_id,),
+            )
+            turn["journal"] = [
+                {"seq": entry[0], "message": _safe_json(entry[1]), "status": entry[2], "created_at": str(entry[3])}
+                for entry in await journal_cursor.fetchall()
+            ]
+
+            results_cursor = await db.execute(
+                "SELECT tool_call_id, content FROM tool_results WHERE turn_id = ?",
+                (turn_id,),
+            )
+            turn["tool_results"] = [
+                {"tool_call_id": entry[0], "content": entry[1]} for entry in await results_cursor.fetchall()
+            ]
+
+        turn["effects"] = await self.list_external_effects(turn_id)
+        return turn
+
+    async def fork_turn(self, turn_id: str, *, at_seq: int = 0, new_thread_id: str = "") -> dict | None:
+        """Copy a turn's history prefix into a new thread.
+
+        The original is left untouched — the point of a fork is to try a
+        different continuation without destroying the evidence of the first one.
+        """
+        detail = await self.get_turn_detail(turn_id)
+        if not detail:
+            return None
+
+        prefix = detail["journal"] if at_seq <= 0 else [row for row in detail["journal"] if int(row["seq"]) <= at_seq]
+        messages: list[BaseMessage] = [HumanMessage(content=str(detail.get("input_message") or ""))]
+        for row in prefix:
+            try:
+                messages.append(_deserialize_message(row["message"]))
+            except (KeyError, TypeError):
+                continue
+
+        target = new_thread_id or f"{detail['thread_id']}:fork-{at_seq or len(prefix)}"
+        await self.save(target, messages)
+        log.info("Forked turn %s into thread %s (%d message(s))", turn_id, target, len(messages))
+        return {"thread_id": target, "messages": len(messages), "source_turn": turn_id}
+
+    async def running_turn_stats(self) -> dict:
+        """Counts and oldest age for turns in flight — surfaced on /health.
+
+        A turn stuck in 'running' means a process died and nothing picked it up;
+        without this it is invisible until someone reads the database.
+        """
+        async with self._open_db() as db:
+            await self._ensure_table(db)
+            cursor = await db.execute(
+                """
+                SELECT COUNT(*), MIN(started_at)
+                FROM active_turns WHERE status IN ('running', 'resuming')
+                """
+            )
+            count, oldest = await cursor.fetchone()
+
+        age_seconds = None
+        if oldest:
+            from datetime import UTC, datetime
+
+            for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S.%f"):
+                try:
+                    # SQLite CURRENT_TIMESTAMP is UTC but naive, so attach UTC
+                    # rather than comparing against a naive local clock.
+                    started = datetime.strptime(str(oldest), fmt).replace(tzinfo=UTC)
+                    age_seconds = round((datetime.now(UTC) - started).total_seconds(), 1)
+                    break
+                except ValueError:
+                    continue
+        return {"running_turns": int(count or 0), "oldest_running_age_seconds": age_seconds}
+
+    async def prune_turn_history(self, *, older_than_days: int = 30) -> dict:
+        """Delete finished turns and whatever still hangs off them.
+
+        Only finished turns: a running or resuming turn is live state, and an
+        unfinished turn older than the window is a bug to look at, not garbage to
+        sweep.
+
+        In practice the journal and memoized results are already gone —
+        ``finish_turn`` drops them when a turn completes — so the rows this
+        actually reclaims are ``active_turns`` and ``external_effects``. Effects
+        are safe to drop with their turn: the idempotency key contains the
+        turn_id, so a later turn never looks up an older turn's effect.
+        """
+        async with self._open_db() as db:
+            await self._ensure_table(db)
+            cutoff = f"-{int(older_than_days)} days"
+            cursor = await db.execute(
+                """
+                SELECT turn_id FROM active_turns
+                WHERE status NOT IN ('running', 'resuming')
+                  AND COALESCE(completed_at, started_at) < datetime('now', ?)
+                """,
+                (cutoff,),
+            )
+            turn_ids = [row[0] for row in await cursor.fetchall()]
+            if not turn_ids:
+                return {"turns": 0, "journal": 0, "tool_results": 0, "effects": 0}
+
+            placeholders = ",".join("?" for _ in turn_ids)
+            journal = await db.execute(f"DELETE FROM turn_journal WHERE turn_id IN ({placeholders})", turn_ids)
+            results = await db.execute(f"DELETE FROM tool_results WHERE turn_id IN ({placeholders})", turn_ids)
+            effects = await db.execute(f"DELETE FROM external_effects WHERE turn_id IN ({placeholders})", turn_ids)
+            turns = await db.execute(f"DELETE FROM active_turns WHERE turn_id IN ({placeholders})", turn_ids)
+            await db.commit()
+
+        pruned = {
+            "turns": turns.rowcount,
+            "journal": journal.rowcount,
+            "tool_results": results.rowcount,
+            "effects": effects.rowcount,
+        }
+        log.info("Turn retention: pruned %s", pruned)
+        return pruned
 
     async def claim_turns_for_resume(self, *, max_attempts: int = 2) -> list[dict]:
         """Claim interrupted turns for re-execution, newest-first per thread.

--- a/kronos/session.py
+++ b/kronos/session.py
@@ -206,6 +206,19 @@ class SessionStore:
                 CREATE INDEX IF NOT EXISTS idx_pending_approvals_status
                     ON pending_approvals(status, requested_at)
             """)
+            await db.execute("""
+                CREATE TABLE IF NOT EXISTS external_effects (
+                    idempotency_key TEXT PRIMARY KEY,
+                    turn_id         TEXT NOT NULL,
+                    tool            TEXT NOT NULL,
+                    result          TEXT NOT NULL,
+                    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            await db.execute("""
+                CREATE INDEX IF NOT EXISTS idx_external_effects_turn
+                    ON external_effects(turn_id, created_at)
+            """)
             await db.commit()
             self._initialized = True
 
@@ -297,6 +310,61 @@ class SessionStore:
                 (turn_id, tool_call_id, content),
             )
             await db.commit()
+
+    async def get_external_effect(self, key: str) -> str | None:
+        """Return the recorded result of a side-effecting call, if it already ran.
+
+        This is what makes re-running a turn safe: a message that was already
+        sent must not be sent twice just because the process died before the
+        journal recorded the answer.
+        """
+        if not key:
+            return None
+        async with self._open_db() as db:
+            await self._ensure_table(db)
+            cursor = await db.execute(
+                "SELECT result FROM external_effects WHERE idempotency_key = ?",
+                (key,),
+            )
+            row = await cursor.fetchone()
+        return str(row[0]) if row else None
+
+    async def record_external_effect(self, *, key: str, turn_id: str, tool: str, result: str) -> bool:
+        """Record that a side effect happened. Returns False if it already was.
+
+        INSERT OR IGNORE rather than a check-then-write: two concurrent retries of
+        the same call must not both conclude they are first.
+        """
+        if not key:
+            return False
+        async with self._open_db() as db:
+            await self._ensure_table(db)
+            cursor = await db.execute(
+                """
+                INSERT OR IGNORE INTO external_effects
+                    (idempotency_key, turn_id, tool, result)
+                VALUES (?, ?, ?, ?)
+                """,
+                (key, turn_id, tool, result),
+            )
+            await db.commit()
+            return bool(cursor.rowcount)
+
+    async def list_external_effects(self, turn_id: str) -> list[dict]:
+        """Effects recorded for one turn (dashboard / debugging)."""
+        async with self._open_db() as db:
+            await self._ensure_table(db)
+            cursor = await db.execute(
+                """
+                SELECT idempotency_key, tool, result, created_at
+                FROM external_effects WHERE turn_id = ? ORDER BY created_at
+                """,
+                (turn_id,),
+            )
+            rows = await cursor.fetchall()
+        return [
+            {"idempotency_key": row[0], "tool": row[1], "result": row[2], "created_at": str(row[3])} for row in rows
+        ]
 
     def _pending_approval_from_row(self, row) -> dict | None:
         """Convert a pending_approvals row into a JSON-safe dict."""

--- a/kronos/tools/council.py
+++ b/kronos/tools/council.py
@@ -10,6 +10,7 @@ from langchain_core.tools import tool
 from kronos.audit import get_tool_audit_context
 from kronos.config import settings
 from kronos.group_router import AGENT_PROFILES
+from kronos.security.effects import mark_side_effect
 from kronos.swarm_store import get_swarm
 
 
@@ -72,3 +73,8 @@ def convene_council(question: str, participants: list[str]) -> str:
     )
     swarm.incr_metric("councils_convened")
     return f"🏛 Созвал консилиум #{session_id}: {', '.join(names)}. Соберу их позиции и синтезирую единый ответ здесь."
+
+
+# Re-running a turn must not repeat these: a duplicate reminder, handoff or MCP
+# mutation is a visible bug, not a harmless retry.
+mark_side_effect([convene_council], reason="swarm council")

--- a/kronos/tools/gateway_tools.py
+++ b/kronos/tools/gateway_tools.py
@@ -6,6 +6,7 @@ import logging
 from langchain_core.tools import tool
 
 from kronos.config import settings
+from kronos.security.effects import mark_side_effect
 from kronos.tools.gateway import get_gateway
 
 log = logging.getLogger("kronos.tools.gateway_tools")
@@ -99,3 +100,8 @@ def get_gateway_tools() -> list:
     if not settings.enable_mcp_gateway_management:
         return [mcp_list_servers]
     return [mcp_add_server, mcp_remove_server, mcp_list_servers, mcp_reload]
+
+
+# Re-running a turn must not repeat these: a duplicate reminder, handoff or MCP
+# mutation is a visible bug, not a harmless retry.
+mark_side_effect([mcp_add_server, mcp_remove_server], reason="mcp mutation")

--- a/kronos/tools/handoff.py
+++ b/kronos/tools/handoff.py
@@ -11,6 +11,7 @@ from langchain_core.tools import tool
 from kronos.audit import get_tool_audit_context
 from kronos.config import settings
 from kronos.group_router import AGENT_PROFILES
+from kronos.security.effects import mark_side_effect
 from kronos.swarm_store import get_swarm
 
 
@@ -67,3 +68,8 @@ def handoff_to_agent(to_agent: str, why: str) -> str:
     role = AGENT_PROFILES[to_agent].get("role", "")
     role_txt = f" ({role})" if role else ""
     return f"↪️ Передал запрос агенту {to_agent}{role_txt} — он ответит здесь. #{handoff_id}"
+
+
+# Re-running a turn must not repeat these: a duplicate reminder, handoff or MCP
+# mutation is a visible bug, not a harmless retry.
+mark_side_effect([handoff_to_agent], reason="swarm handoff")

--- a/kronos/tools/memory_ask.py
+++ b/kronos/tools/memory_ask.py
@@ -10,6 +10,7 @@ from langchain_core.tools import tool
 from kronos.audit import get_tool_audit_context
 from kronos.config import settings
 from kronos.group_router import AGENT_PROFILES
+from kronos.security.effects import mark_side_effect
 from kronos.swarm_store import get_swarm
 
 
@@ -55,3 +56,8 @@ def ask_agent_memory(to_agent: str, query: str) -> str:
     )
     swarm.incr_metric("memory_requests_created")
     return f"🧠 Спросил {to_agent}, что у него есть про это — он поделится здесь. #{request_id}"
+
+
+# Re-running a turn must not repeat these: a duplicate reminder, handoff or MCP
+# mutation is a visible bug, not a harmless retry.
+mark_side_effect([ask_agent_memory], reason="swarm memory request")

--- a/kronos/tools/reminders.py
+++ b/kronos/tools/reminders.py
@@ -13,6 +13,7 @@ from langchain_core.tools import tool
 from kronos import scheduled_tasks
 from kronos.audit import get_tool_audit_context
 from kronos.config import settings
+from kronos.security.effects import mark_side_effect
 
 
 def _recur_name(recur_seconds: int) -> str:
@@ -143,3 +144,8 @@ def cancel_scheduled_task(task_id: int) -> str:
     """Cancel a pending scheduled task or follow-up by its id."""
     ok = scheduled_tasks.cancel_task(task_id, settings.agent_name)
     return f"Отменил задачу #{task_id}." if ok else f"Задача #{task_id} не найдена или уже неактивна."
+
+
+# Re-running a turn must not repeat these: a duplicate reminder, handoff or MCP
+# mutation is a visible bug, not a harmless retry.
+mark_side_effect([schedule_task, schedule_followup, cancel_scheduled_task], reason="scheduling")

--- a/policy.example.yaml
+++ b/policy.example.yaml
@@ -67,6 +67,17 @@ retention:
   audit_jsonl_days: 90
   swarm_messages_days: 30
 
+# What happens to a turn whose process died mid-flight.
+#   report (default) — restore the history and note the interruption; the user's
+#                      question stays unanswered. This is the historical
+#                      behaviour, kept as default so an upgrade changes nothing.
+#   resume           — finish the turn. Safe because answered tool calls are
+#                      memoized per turn and side-effecting tools consult the
+#                      effects ledger, so nothing is sent or charged twice.
+durable:
+  resume_mode: report                 # report | resume
+  max_resume_attempts: 2              # then the turn is failed, not retried forever
+
 pii:
   mask_in_logs: true
   mask_in_cassettes: true

--- a/tests/test_dashboard_turns.py
+++ b/tests/test_dashboard_turns.py
@@ -1,0 +1,168 @@
+"""Durable turns in the control room (moat phase 10.4)."""
+
+import pytest
+from fastapi.testclient import TestClient
+from langchain_core.messages import AIMessage, ToolMessage
+
+from kronos.config import settings
+from kronos.session import SessionStore
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "swarm_db_path", str(tmp_path / "swarm.db"))
+    monkeypatch.setattr(settings, "agent_name", "dash-turns")
+    import kronos.db as _db
+
+    _db._instances.clear()
+
+    from dashboard.server import create_app
+
+    app = create_app()
+    # Auth is covered by test_dashboard_auth; here we exercise the endpoints.
+    from dashboard import auth
+
+    app.dependency_overrides[auth.verify_token] = lambda: True
+    yield TestClient(app)
+    _db._instances.clear()
+
+
+def _store():
+    return SessionStore(settings.db_path, agent_name="dash-turns")
+
+
+async def _turn(store, *, thread_id="chat-3", text="собери отчёт"):
+    turn_id = await store.begin_turn(thread_id, text)
+    await store.append_turn_messages(
+        turn_id=turn_id,
+        thread_id=thread_id,
+        messages=[
+            AIMessage(content="", tool_calls=[{"name": "send_report", "args": {}, "id": "c1"}]),
+            ToolMessage(content="ok", tool_call_id="c1"),
+        ],
+    )
+    await store.record_external_effect(key="k1", turn_id=turn_id, tool="send_report", result="delivered")
+    return turn_id
+
+
+def test_requires_auth(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
+    from dashboard.server import create_app
+
+    unauthenticated = TestClient(create_app())
+
+    assert unauthenticated.get("/api/turns").status_code == 401
+
+
+def test_list_reports_counts_and_in_flight(client):
+    import asyncio
+
+    store = _store()
+    turn_id = asyncio.run(_turn(store))
+
+    payload = client.get("/api/turns").json()
+
+    assert payload["total"] == 1
+    assert payload["running_turns"] == 1
+    assert payload["oldest_running_age_seconds"] is not None
+    assert payload["counts"]["running"] == 1
+    assert payload["turns"][0]["turn_id"] == turn_id
+
+
+def test_list_filters_by_status(client):
+    import asyncio
+
+    store = _store()
+    asyncio.run(_turn(store))
+
+    assert client.get("/api/turns?status=failed").json()["total"] == 0
+    assert client.get("/api/turns?status=running").json()["total"] == 1
+
+
+def test_detail_exposes_journal_and_effects(client):
+    import asyncio
+
+    turn_id = asyncio.run(_turn(_store()))
+
+    detail = client.get(f"/api/turns/{turn_id}").json()
+
+    assert detail["thread_id"] == "chat-3"
+    assert [row["seq"] for row in detail["journal"]] == [1, 2]
+    assert detail["effects"][0]["tool"] == "send_report"
+
+
+def test_detail_404_for_unknown_turn(client):
+    assert client.get("/api/turns/nope").status_code == 404
+
+
+def test_fork_creates_a_thread_and_keeps_the_original(client):
+    import asyncio
+
+    turn_id = asyncio.run(_turn(_store()))
+
+    response = client.post(f"/api/turns/{turn_id}/fork", json={"at_seq": 1, "thread": "experiment"})
+
+    assert response.status_code == 200
+    assert response.json()["thread_id"] == "experiment"
+    detail = client.get(f"/api/turns/{turn_id}").json()
+    assert len(detail["journal"]) == 2, "fork must not modify the source turn"
+
+
+def test_resume_refuses_a_finished_turn(client):
+    import asyncio
+
+    store = _store()
+    turn_id = asyncio.run(_turn(store))
+    asyncio.run(store.finish_turn(turn_id))
+
+    response = client.post(f"/api/turns/{turn_id}/resume")
+
+    assert response.status_code == 409
+    assert "only in-flight" in response.json()["detail"]
+
+
+def test_resume_404_for_unknown_turn(client):
+    assert client.post("/api/turns/nope/resume").status_code == 404
+
+
+def test_resume_finishes_an_in_flight_turn(client, monkeypatch):
+    import asyncio
+
+    turn_id = asyncio.run(_turn(_store()))
+
+    class FakeAgent:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def resume_interrupted_turn(self, turn):
+            assert turn["turn_id"] == turn_id
+            return "Отчёт собран."
+
+    monkeypatch.setattr("kronos.graph.KronosAgent", FakeAgent)
+
+    response = client.post(f"/api/turns/{turn_id}/resume")
+
+    assert response.status_code == 200
+    assert response.json()["answer"] == "Отчёт собран."
+
+
+def test_resume_failure_is_reported(client, monkeypatch):
+    import asyncio
+
+    turn_id = asyncio.run(_turn(_store()))
+
+    class FailingAgent:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def resume_interrupted_turn(self, turn):
+            return None
+
+    monkeypatch.setattr("kronos.graph.KronosAgent", FailingAgent)
+
+    response = client.post(f"/api/turns/{turn_id}/resume")
+
+    assert response.status_code == 500
+    assert "marked failed" in response.json()["detail"]

--- a/tests/test_durable_resume.py
+++ b/tests/test_durable_resume.py
@@ -49,13 +49,25 @@ class ScriptedModel:
         return asyncio.get_event_loop().run_until_complete(self.ainvoke(messages))
 
 
-def _use_scripted_model(monkeypatch, agent, responses):
-    """Point graph at a scripted model and keep the prompt/supervisor out of it."""
+def _agent_with_scripted_model(monkeypatch, store, responses, *, tools=None):
+    """Build an agent that never needs a provider key.
+
+    The supervisor is built inside KronosAgent.__init__ and constructs a model,
+    so patching after construction is too late — that is what made these tests
+    pass locally (where .env has a key) and fail in CI.
+    """
     import kronos.graph as graph_module
+    from kronos.graph import KronosAgent
 
     monkeypatch.setattr(graph_module, "get_model", lambda tier: ScriptedModel(responses))
+    agent = KronosAgent(
+        tools=tools or [],
+        enable_memory=False,
+        enable_supervisor=False,
+        session_store=store,
+    )
     monkeypatch.setattr(agent, "_get_system_prompt", lambda: "system")
-    monkeypatch.setattr(agent, "_supervisor", None)
+    return agent
 
 
 @pytest.fixture
@@ -135,14 +147,11 @@ async def test_superseded_turn_is_not_resumed(store):
 
 @pytest.mark.asyncio
 async def test_resume_finishes_the_turn_and_delivers(store, monkeypatch):
-    from kronos.graph import KronosAgent
-
     turn_id = await _interrupted_turn(store)
     sender = Sender()
     mark_side_effect([sender])
 
-    agent = KronosAgent(tools=[sender], enable_memory=False, session_store=store)
-    _use_scripted_model(monkeypatch, agent, [AIMessage(content="Отчёт отправлен.")])
+    agent = _agent_with_scripted_model(monkeypatch, store, [AIMessage(content="Отчёт отправлен.")], tools=[sender])
 
     delivered: list[tuple[str, str]] = []
 
@@ -163,7 +172,6 @@ async def test_resume_finishes_the_turn_and_delivers(store, monkeypatch):
 async def test_resume_does_not_repeat_a_recorded_side_effect(store, monkeypatch):
     """The whole reason the ledger landed first."""
     from kronos.engine import side_effect_key
-    from kronos.graph import KronosAgent
 
     turn_id = await _interrupted_turn(store)
     sender = Sender()
@@ -173,8 +181,7 @@ async def test_resume_does_not_repeat_a_recorded_side_effect(store, monkeypatch)
     key = side_effect_key(sender, {"text": "отчёт"}, turn_id)
     await store.record_external_effect(key=key, turn_id=turn_id, tool=sender.name, result="sent #1")
 
-    agent = KronosAgent(tools=[sender], enable_memory=False, session_store=store)
-    _use_scripted_model(monkeypatch, agent, [AIMessage(content="Готово.")])
+    agent = _agent_with_scripted_model(monkeypatch, store, [AIMessage(content="Готово.")], tools=[sender])
 
     await agent.resume_abandoned_turns()
 
@@ -197,11 +204,8 @@ async def test_report_mode_keeps_the_old_behaviour(store):
 
 @pytest.mark.asyncio
 async def test_delivery_failure_still_completes_the_turn(store, monkeypatch):
-    from kronos.graph import KronosAgent
-
     await _interrupted_turn(store)
-    agent = KronosAgent(tools=[], enable_memory=False, session_store=store)
-    _use_scripted_model(monkeypatch, agent, [AIMessage(content="Ответ.")])
+    agent = _agent_with_scripted_model(monkeypatch, store, [AIMessage(content="Ответ.")])
 
     async def broken_deliver(thread_id, text):
         raise RuntimeError("telegram down")

--- a/tests/test_durable_resume.py
+++ b/tests/test_durable_resume.py
@@ -1,0 +1,232 @@
+"""Real resume of interrupted turns (moat phase 10.2).
+
+Until now `recover_abandoned_turns` restored the history and noted the
+interruption; the user's question stayed unanswered. Resume finishes the turn —
+which is only safe because tool results are memoized per turn and side-effecting
+tools consult the effects ledger.
+"""
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.tools import BaseTool
+
+from kronos.config import settings
+from kronos.security.effects import mark_side_effect
+from kronos.session import SessionStore
+
+
+class Sender(BaseTool):
+    name: str = "send_message"
+    description: str = "send"
+    calls: int = 0
+
+    def _run(self, **kwargs) -> str:
+        self.calls += 1
+        return f"sent #{self.calls}"
+
+
+class ScriptedModel:
+    """Returns queued responses; records how many times it was asked."""
+
+    model_name = "scripted"
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    def bind_tools(self, tools):
+        return self
+
+    async def ainvoke(self, messages, *args, **kwargs):
+        self.calls += 1
+        if not self._responses:
+            return AIMessage(content="нечего добавить")
+        return self._responses.pop(0)
+
+    def invoke(self, messages, *args, **kwargs):
+        import asyncio
+
+        return asyncio.get_event_loop().run_until_complete(self.ainvoke(messages))
+
+
+def _use_scripted_model(monkeypatch, agent, responses):
+    """Point graph at a scripted model and keep the prompt/supervisor out of it."""
+    import kronos.graph as graph_module
+
+    monkeypatch.setattr(graph_module, "get_model", lambda tier: ScriptedModel(responses))
+    monkeypatch.setattr(agent, "_get_system_prompt", lambda: "system")
+    monkeypatch.setattr(agent, "_supervisor", None)
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "swarm_db_path", str(tmp_path / "swarm.db"))
+    monkeypatch.setattr(settings, "tool_approvals_enabled", False)
+    import kronos.db as _db
+    import kronos.swarm_store as _swarm
+
+    _db._instances.clear()
+    _swarm._singleton = None
+    yield SessionStore(str(tmp_path / "session.db"), agent_name="test")
+    _db._instances.clear()
+    _swarm._singleton = None
+
+
+async def _interrupted_turn(store, *, thread_id="chat-1", text="отправь отчёт"):
+    """A turn that started, called a tool, and never finished."""
+    turn_id = await store.begin_turn(thread_id, text)
+    await store.append_turn_messages(
+        turn_id=turn_id,
+        thread_id=thread_id,
+        messages=[AIMessage(content="", tool_calls=[{"name": "send_message", "args": {"text": "отчёт"}, "id": "c1"}])],
+    )
+    return turn_id
+
+
+@pytest.mark.asyncio
+async def test_claim_flips_status_and_counts_attempts(store):
+    turn_id = await _interrupted_turn(store)
+
+    claimed = await store.claim_turns_for_resume()
+
+    assert [row["turn_id"] for row in claimed] == [turn_id]
+    assert claimed[0]["attempts"] == 1
+    # A second claim finds nothing: the turn is no longer 'running'.
+    assert await store.claim_turns_for_resume() == []
+
+
+@pytest.mark.asyncio
+async def test_attempts_are_capped(store):
+    """A turn that keeps dying must not resurrect itself forever."""
+    turn_id = await _interrupted_turn(store)
+
+    for _ in range(2):
+        await store.claim_turns_for_resume(max_attempts=2)
+        # Simulate another crash: back to running with the attempt recorded.
+        async with store._open_db() as db:
+            await db.execute("UPDATE active_turns SET status = 'running' WHERE turn_id = ?", (turn_id,))
+            await db.commit()
+
+    assert await store.claim_turns_for_resume(max_attempts=2) == []
+
+    async with store._open_db() as db:
+        cursor = await db.execute("SELECT status, error FROM active_turns WHERE turn_id = ?", (turn_id,))
+        status, error = await cursor.fetchone()
+    assert status == "failed"
+    assert "gave up" in error
+
+
+@pytest.mark.asyncio
+async def test_superseded_turn_is_not_resumed(store):
+    """If the user asked again, answering the stale question is noise."""
+    stale = await _interrupted_turn(store, text="первый вопрос")
+    fresh = await store.begin_turn("chat-1", "второй вопрос")
+
+    claimed = await store.claim_turns_for_resume()
+
+    assert [row["turn_id"] for row in claimed] == [fresh]
+    async with store._open_db() as db:
+        cursor = await db.execute("SELECT status FROM active_turns WHERE turn_id = ?", (stale,))
+        (status,) = await cursor.fetchone()
+    assert status == "superseded"
+
+
+@pytest.mark.asyncio
+async def test_resume_finishes_the_turn_and_delivers(store, monkeypatch):
+    from kronos.graph import KronosAgent
+
+    turn_id = await _interrupted_turn(store)
+    sender = Sender()
+    mark_side_effect([sender])
+
+    agent = KronosAgent(tools=[sender], enable_memory=False, session_store=store)
+    _use_scripted_model(monkeypatch, agent, [AIMessage(content="Отчёт отправлен.")])
+
+    delivered: list[tuple[str, str]] = []
+
+    async def deliver(thread_id, text):
+        delivered.append((thread_id, text))
+
+    finished = await agent.resume_abandoned_turns(deliver=deliver)
+
+    assert finished == 1
+    assert delivered and delivered[0][0] == "chat-1"
+    async with store._open_db() as db:
+        cursor = await db.execute("SELECT status FROM active_turns WHERE turn_id = ?", (turn_id,))
+        (status,) = await cursor.fetchone()
+    assert status in {"completed", "done", "finished"}
+
+
+@pytest.mark.asyncio
+async def test_resume_does_not_repeat_a_recorded_side_effect(store, monkeypatch):
+    """The whole reason the ledger landed first."""
+    from kronos.engine import side_effect_key
+    from kronos.graph import KronosAgent
+
+    turn_id = await _interrupted_turn(store)
+    sender = Sender()
+    mark_side_effect([sender])
+
+    # The crash happened after the send but before the result was journalled.
+    key = side_effect_key(sender, {"text": "отчёт"}, turn_id)
+    await store.record_external_effect(key=key, turn_id=turn_id, tool=sender.name, result="sent #1")
+
+    agent = KronosAgent(tools=[sender], enable_memory=False, session_store=store)
+    _use_scripted_model(monkeypatch, agent, [AIMessage(content="Готово.")])
+
+    await agent.resume_abandoned_turns()
+
+    assert sender.calls == 0, "a message already sent must not be sent again"
+
+
+@pytest.mark.asyncio
+async def test_report_mode_keeps_the_old_behaviour(store):
+    """Default stays report so an upgrade does not change what a restart does."""
+    turn_id = await _interrupted_turn(store)
+
+    recovered = await store.recover_abandoned_turns()
+
+    assert recovered == 1
+    async with store._open_db() as db:
+        cursor = await db.execute("SELECT status FROM active_turns WHERE turn_id = ?", (turn_id,))
+        (status,) = await cursor.fetchone()
+    assert status == "recovered"
+
+
+@pytest.mark.asyncio
+async def test_delivery_failure_still_completes_the_turn(store, monkeypatch):
+    from kronos.graph import KronosAgent
+
+    await _interrupted_turn(store)
+    agent = KronosAgent(tools=[], enable_memory=False, session_store=store)
+    _use_scripted_model(monkeypatch, agent, [AIMessage(content="Ответ.")])
+
+    async def broken_deliver(thread_id, text):
+        raise RuntimeError("telegram down")
+
+    finished = await agent.resume_abandoned_turns(deliver=broken_deliver)
+
+    assert finished == 1  # the answer exists and is journalled; only delivery failed
+
+
+def test_policy_exposes_resume_mode(tmp_path, monkeypatch):
+    import yaml
+
+    from kronos.policy import ENV_POLICY_FILE, PolicyError, load_policy, reset_policy
+
+    path = tmp_path / "policy.yaml"
+    path.write_text(yaml.safe_dump({"durable": {"resume_mode": "resume", "max_resume_attempts": 3}}), encoding="utf-8")
+    monkeypatch.setenv(ENV_POLICY_FILE, str(path))
+    reset_policy()
+
+    policy = load_policy()
+    assert policy.durable.resume_mode == "resume"
+    assert policy.durable.max_resume_attempts == 3
+
+    path.write_text(yaml.safe_dump({"durable": {"resume_mode": "maybe"}}), encoding="utf-8")
+    reset_policy()
+    with pytest.raises(PolicyError, match="resume_mode must be"):
+        load_policy()
+    reset_policy()

--- a/tests/test_external_effects.py
+++ b/tests/test_external_effects.py
@@ -1,0 +1,230 @@
+"""Idempotency for side-effecting tools (moat phase 10.1).
+
+Durable resume re-runs the unanswered part of a turn. That is only safe if a call
+that already happened is recognised as such — otherwise a crash between "message
+sent" and "result journalled" sends it twice on recovery.
+"""
+
+import pytest
+from langchain_core.tools import BaseTool, tool
+
+from kronos.config import settings
+from kronos.engine import execute_tool, side_effect_key, tool_has_side_effect
+from kronos.security.effects import mark_side_effect
+from kronos.session import SessionStore
+
+
+class SendingTool(BaseTool):
+    """Stands in for anything the outside world notices."""
+
+    name: str = "send_message"
+    description: str = "send a message"
+    calls: int = 0
+
+    def _run(self, **kwargs) -> str:
+        self.calls += 1
+        return f"sent #{self.calls}"
+
+
+class FailingTool(BaseTool):
+    name: str = "send_flaky"
+    description: str = "send, badly"
+    calls: int = 0
+
+    def _run(self, **kwargs) -> str:
+        self.calls += 1
+        raise RuntimeError("smtp down")
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    return SessionStore(str(tmp_path / "session.db"), agent_name="test")
+
+
+def _sending() -> SendingTool:
+    sender = SendingTool()
+    mark_side_effect([sender])
+    return sender
+
+
+async def _run(tool, store, *, turn_id="turn-1", args=None, call_id="c1"):
+    return await execute_tool(
+        tool,
+        {"id": call_id, "args": args or {"chat_id": 1, "text": "привет"}},
+        get_external_effect=store.get_external_effect,
+        record_external_effect=lambda key, name, result: store.record_external_effect(
+            key=key, turn_id=turn_id, tool=name, result=result
+        ),
+        turn_id=turn_id,
+    )
+
+
+def test_marking_is_opt_in():
+    @tool
+    def plain() -> str:
+        """Local tool."""
+        return "ok"
+
+    assert tool_has_side_effect(plain) is False
+    mark_side_effect([plain])
+    assert tool_has_side_effect(plain) is True
+
+
+def test_key_is_stable_for_the_same_call():
+    sender = _sending()
+    args = {"chat_id": 1, "text": "привет"}
+
+    assert side_effect_key(sender, args, "turn-1") == side_effect_key(sender, dict(args), "turn-1")
+
+
+def test_key_differs_by_args_and_by_turn():
+    """Within a turn a repeat is a retry; in a later turn it is a new request."""
+    sender = _sending()
+
+    same_turn = side_effect_key(sender, {"text": "a"}, "turn-1")
+    other_args = side_effect_key(sender, {"text": "b"}, "turn-1")
+    later_turn = side_effect_key(sender, {"text": "a"}, "turn-2")
+
+    assert same_turn != other_args
+    assert same_turn != later_turn
+
+
+def test_custom_key_function_narrows_identity():
+    """A regenerated request id must not make a retry look like a new effect."""
+    sender = SendingTool()
+    sender.metadata = {"side_effect": True, "idempotency_key": lambda args: f"chat:{args['chat_id']}:{args['text']}"}
+
+    first = side_effect_key(sender, {"chat_id": 7, "text": "привет", "request_id": "abc"})
+    second = side_effect_key(sender, {"chat_id": 7, "text": "привет", "request_id": "xyz"})
+
+    assert first == second == "send_message:chat:7:привет"
+
+
+def test_broken_key_function_falls_back_instead_of_failing(caplog):
+    sender = SendingTool()
+    sender.metadata = {"side_effect": True, "idempotency_key": lambda args: 1 / 0}
+
+    key = side_effect_key(sender, {"text": "a"}, "turn-1")
+
+    assert key.startswith("send_message:turn-1:")
+    assert "idempotency_key callable failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_repeated_call_does_not_run_twice(store):
+    sender = _sending()
+
+    first = await _run(sender, store)
+    second = await _run(sender, store)
+
+    assert sender.calls == 1
+    assert first.content == "sent #1"
+    assert second.content == "sent #1"  # the recorded result, not a new send
+
+
+@pytest.mark.asyncio
+async def test_different_arguments_still_run(store):
+    sender = _sending()
+
+    await _run(sender, store, args={"chat_id": 1, "text": "первое"})
+    await _run(sender, store, args={"chat_id": 1, "text": "второе"})
+
+    assert sender.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_a_later_turn_runs_again(store):
+    """The user asking twice is not a retry."""
+    sender = _sending()
+
+    await _run(sender, store, turn_id="turn-1")
+    await _run(sender, store, turn_id="turn-2")
+
+    assert sender.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_unmarked_tool_is_never_deduplicated(store):
+    """Read-only tools must stay repeatable — dedup would serve stale data."""
+    plain = SendingTool()
+    plain.name = "get_status"
+
+    await _run(plain, store)
+    await _run(plain, store)
+
+    assert plain.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_failed_effect_is_not_recorded(store):
+    """A send that raised did not happen, so a retry must be allowed."""
+    failing = FailingTool()
+    mark_side_effect([failing])
+
+    first = await _run(failing, store)
+    second = await _run(failing, store)
+
+    assert failing.calls == 2
+    assert "[ERROR]" in first.content or "smtp" in first.content
+    assert first.content == second.content
+
+
+@pytest.mark.asyncio
+async def test_effects_are_listed_per_turn(store):
+    sender = _sending()
+    await _run(sender, store, turn_id="turn-A")
+    await _run(sender, store, turn_id="turn-B", args={"chat_id": 2, "text": "b"})
+
+    effects_a = await store.list_external_effects("turn-A")
+    effects_b = await store.list_external_effects("turn-B")
+
+    assert len(effects_a) == 1 and effects_a[0]["tool"] == "send_message"
+    assert len(effects_b) == 1
+    assert effects_a[0]["idempotency_key"] != effects_b[0]["idempotency_key"]
+
+
+@pytest.mark.asyncio
+async def test_recording_the_same_key_twice_reports_not_new(store):
+    """Concurrent retries must not both conclude they are first."""
+    created = await store.record_external_effect(key="k1", turn_id="t", tool="send_message", result="sent")
+    again = await store.record_external_effect(key="k1", turn_id="t", tool="send_message", result="sent again")
+
+    assert created is True
+    assert again is False
+    assert await store.get_external_effect("k1") == "sent"  # first result wins
+
+
+@pytest.mark.asyncio
+async def test_without_callbacks_behaviour_is_unchanged(store):
+    """Paths that do not pass the ledger (sub-agents, cron) keep working."""
+    sender = _sending()
+
+    first = await execute_tool(sender, {"id": "c1", "args": {"text": "a"}})
+    second = await execute_tool(sender, {"id": "c2", "args": {"text": "a"}})
+
+    assert sender.calls == 2
+    assert first.content == "sent #1" and second.content == "sent #2"
+
+
+@pytest.mark.asyncio
+async def test_side_effect_tools_are_marked_in_production():
+    """Inventory: a new mutating tool must not slip in unmarked."""
+    from kronos.tools.council import convene_council
+    from kronos.tools.gateway_tools import mcp_add_server, mcp_remove_server
+    from kronos.tools.handoff import handoff_to_agent
+    from kronos.tools.memory_ask import ask_agent_memory
+    from kronos.tools.reminders import cancel_scheduled_task, schedule_followup, schedule_task
+
+    for tool_obj in (
+        schedule_task,
+        schedule_followup,
+        cancel_scheduled_task,
+        handoff_to_agent,
+        convene_council,
+        ask_agent_memory,
+        mcp_add_server,
+        mcp_remove_server,
+    ):
+        assert tool_has_side_effect(tool_obj), tool_obj.name

--- a/tests/test_turns_cli.py
+++ b/tests/test_turns_cli.py
@@ -1,0 +1,219 @@
+"""Turn inspection, forking and retention (moat phases 10.3 and 10.5)."""
+
+import pytest
+from langchain_core.messages import AIMessage, ToolMessage
+
+from kronos.cli import build_parser, main
+from kronos.config import settings
+from kronos.session import SessionStore
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "swarm_db_path", str(tmp_path / "swarm.db"))
+    monkeypatch.setattr(settings, "agent_name", "turns-test")
+    import kronos.db as _db
+
+    _db._instances.clear()
+    yield SessionStore(str(tmp_path / "session.db"), agent_name="turns-test")
+    _db._instances.clear()
+
+
+async def _turn_with_journal(store, *, thread_id="chat-7", text="покажи расходы"):
+    turn_id = await store.begin_turn(thread_id, text)
+    await store.append_turn_messages(
+        turn_id=turn_id,
+        thread_id=thread_id,
+        messages=[
+            AIMessage(content="", tool_calls=[{"name": "get_expenses", "args": {"scope": "day"}, "id": "c1"}]),
+            ToolMessage(content="12.5 USD", tool_call_id="c1"),
+            AIMessage(content="За день 12.5 USD."),
+        ],
+    )
+    await store.save_tool_result(turn_id=turn_id, tool_call_id="c1", content="12.5 USD")
+    await store.record_external_effect(key="k1", turn_id=turn_id, tool="send_message", result="sent")
+    return turn_id
+
+
+def test_parser_exposes_turn_commands():
+    parser = build_parser()
+
+    assert parser.parse_args(["turns", "list", "--status", "running"]).status == "running"
+    assert parser.parse_args(["turns", "show", "t1"]).turn_id == "t1"
+    forked = parser.parse_args(["turns", "fork", "t1", "--at", "2", "--thread", "new"])
+    assert forked.at_seq == 2 and forked.thread == "new"
+    assert parser.parse_args(["turns", "resume", "t1"]).turns_command == "resume"
+
+
+@pytest.mark.asyncio
+async def test_list_and_filter_turns(store):
+    running = await _turn_with_journal(store)
+    await store.finish_turn(running)
+    pending = await store.begin_turn("chat-9", "второй запрос")
+
+    all_turns = await store.list_turns(limit=10)
+    only_running = await store.list_turns(status="running")
+    by_thread = await store.list_turns(thread_id="chat-9")
+
+    assert {turn["turn_id"] for turn in all_turns} == {running, pending}
+    assert [turn["turn_id"] for turn in only_running] == [pending]
+    assert [turn["turn_id"] for turn in by_thread] == [pending]
+
+
+@pytest.mark.asyncio
+async def test_turn_detail_includes_journal_results_and_effects(store):
+    turn_id = await _turn_with_journal(store)
+
+    detail = await store.get_turn_detail(turn_id)
+
+    assert detail["thread_id"] == "chat-7"
+    assert [row["seq"] for row in detail["journal"]] == [1, 2, 3]
+    assert detail["journal"][0]["message"]["tool_calls"][0]["name"] == "get_expenses"
+    assert detail["tool_results"][0]["tool_call_id"] == "c1"
+    assert detail["effects"][0]["tool"] == "send_message"
+    assert await store.get_turn_detail("nope") is None
+
+
+@pytest.mark.asyncio
+async def test_fork_copies_prefix_and_leaves_the_original(store):
+    turn_id = await _turn_with_journal(store)
+
+    forked = await store.fork_turn(turn_id, at_seq=2, new_thread_id="fork-thread")
+
+    assert forked["thread_id"] == "fork-thread"
+    assert forked["messages"] == 3  # input + two journal entries up to seq 2
+    original = await store.get_turn_detail(turn_id)
+    assert len(original["journal"]) == 3, "forking must not touch the source turn"
+    assert len(await store.load("fork-thread")) == 3
+
+
+@pytest.mark.asyncio
+async def test_fork_default_thread_name_is_derived(store):
+    turn_id = await _turn_with_journal(store)
+
+    forked = await store.fork_turn(turn_id)
+
+    assert forked["thread_id"].startswith("chat-7:fork-")
+
+
+@pytest.mark.asyncio
+async def test_running_turn_stats_expose_stuck_work(store):
+    assert await store.running_turn_stats() == {"running_turns": 0, "oldest_running_age_seconds": None}
+
+    await store.begin_turn("chat-1", "висит")
+    stats = await store.running_turn_stats()
+
+    assert stats["running_turns"] == 1
+    assert stats["oldest_running_age_seconds"] is not None
+
+
+@pytest.mark.asyncio
+async def test_retention_prunes_finished_turns_only(store):
+    finished = await _turn_with_journal(store, text="старый завершённый")
+    await store.finish_turn(finished)
+    running = await store.begin_turn("chat-1", "ещё в работе")
+
+    # Age both turns past the window.
+    async with store._open_db() as db:
+        await db.execute("UPDATE active_turns SET started_at = datetime('now', '-60 days')")
+        await db.execute(
+            "UPDATE active_turns SET completed_at = datetime('now', '-60 days') WHERE turn_id = ?", (finished,)
+        )
+        await db.commit()
+
+    pruned = await store.prune_turn_history(older_than_days=30)
+
+    assert pruned["turns"] == 1
+    # finish_turn already dropped the journal and memoized results, so what
+    # retention actually reclaims here is the turn row and its effects.
+    assert pruned["journal"] == 0
+    assert pruned["effects"] == 1
+    assert await store.get_turn_detail(finished) is None
+    assert await store.get_turn_detail(running) is not None, "live state must survive retention"
+
+
+@pytest.mark.asyncio
+async def test_retention_keeps_recent_turns(store):
+    finished = await _turn_with_journal(store)
+    await store.finish_turn(finished)
+
+    pruned = await store.prune_turn_history(older_than_days=30)
+
+    assert pruned["turns"] == 0
+    assert await store.get_turn_detail(finished) is not None
+
+
+@pytest.mark.asyncio
+async def test_retention_job_reads_the_policy(store, tmp_path, monkeypatch):
+    import yaml
+
+    from kronos.cron.turn_retention import run_turn_retention
+    from kronos.policy import ENV_POLICY_FILE, reset_policy
+
+    finished = await _turn_with_journal(store)
+    await store.finish_turn(finished)
+    async with store._open_db() as db:
+        await db.execute("UPDATE active_turns SET completed_at = datetime('now', '-10 days')")
+        await db.commit()
+
+    path = tmp_path / "policy.yaml"
+    path.write_text(yaml.safe_dump({"retention": {"turn_journal_days": 7}}), encoding="utf-8")
+    monkeypatch.setenv(ENV_POLICY_FILE, str(path))
+    reset_policy()
+
+    await run_turn_retention()
+
+    assert await store.get_turn_detail(finished) is None
+    reset_policy()
+
+
+def test_cli_list_and_show(store, capsys):
+    import asyncio
+
+    turn_id = asyncio.run(_turn_with_journal(store))
+
+    assert main(["turns", "list"]) == 0
+    listed = capsys.readouterr().out
+    assert turn_id in listed
+    assert "kaos turns resume" in listed  # the turn is in flight
+
+    assert main(["turns", "show", turn_id]) == 0
+    shown = capsys.readouterr().out
+    assert "get_expenses" in shown
+    assert "recorded external effects" in shown
+    assert "send_message" in shown
+
+
+def test_cli_show_unknown_turn(store, capsys):
+    assert main(["turns", "show", "missing"]) == 1
+    assert "Turn not found" in capsys.readouterr().out
+
+
+def test_cli_fork(store, capsys):
+    import asyncio
+
+    turn_id = asyncio.run(_turn_with_journal(store))
+
+    assert main(["turns", "fork", turn_id, "--at", "1", "--thread", "experiment"]) == 0
+    out = capsys.readouterr().out
+
+    assert "experiment" in out
+    assert "original turn is untouched" in out
+
+
+def test_cli_resume_refuses_a_finished_turn(store, capsys, monkeypatch):
+    import asyncio
+
+    monkeypatch.setattr("kronos.cli._runtime_llm_configured", lambda: True)
+    turn_id = asyncio.run(_turn_with_journal(store))
+    asyncio.run(store.finish_turn(turn_id))
+
+    assert main(["turns", "resume", turn_id]) == 1
+    assert "only in-flight turns can be resumed" in capsys.readouterr().out
+
+
+def test_cli_list_on_empty_store(store, capsys):
+    assert main(["turns", "list"]) == 0
+    assert "No durable turns recorded" in capsys.readouterr().out


### PR DESCRIPTION
`recover_abandoned_turns` restored the history and noted the interruption — the
user's question stayed unanswered forever. This finishes the turn instead, and
adds the machinery that makes that safe and observable.

## Order matters: ledger first, resume second

Re-executing a turn is only safe if the runtime can tell "this already happened"
from "this still needs to run". Without that, a crash between sending a message
and journalling the result sends it twice on recovery. So the `external_effects`
ledger landed first (`12b8cf7`), and resume second (`a381bfd`) — a test asserts
the actual property: a recorded send is **not** repeated.

- Default key contains `turn_id`: inside a turn a repeat is a retry (skip it), in
  a later turn it is the user asking again (do it).
- A tool can narrow identity with `metadata['idempotency_key']` so a retry
  carrying a regenerated request id is still one send.
- Only successful effects are recorded — a send that raised did not happen.
- Marking is opt-in, like `needs_approval` and `untrusted_output`: guessing wrong
  is bad both ways (a missed mark duplicates effects, a false mark silently skips
  real work). Read-only tools stay repeatable, pinned by a test.

## Claiming decides three outcomes

In one IMMEDIATE transaction, so two processes cannot both take a turn:

- **superseded** — the thread already has a newer turn; answering the stale
  question would be noise;
- **failed** — `max_resume_attempts` burned, so a crash loop cannot resurrect
  itself;
- **resuming** — handed to the agent.

Default stays `durable.resume_mode: report`: an upgrade must not silently change
what a restart does to someone's pending turns.

## Visibility

`kaos turns list/show/fork/resume`, a Durable Turns page in the control room, and
`running_turns` + oldest-age on `/health` — a stuck turn used to be invisible
until someone opened SQLite while the 15-minute health check reported "ok".

`show` and the detail panel list recorded effects explicitly: that is the answer
to "will resuming this send the message again?", visible rather than trusted.

New weekly `turn-retention` job prunes finished turns per
`retention.turn_journal_days`; live turns are never pruned.

## Bugs found while building this

- Claiming ordered by `started_at`, but `CURRENT_TIMESTAMP` has second
  resolution — two turns in the same second both looked "not newer", so a stale
  turn would have been resumed alongside the fresh one. Now ordered by `rowid`.
- `running_turn_stats` compared a naive SQLite UTC timestamp against a local
  clock.
- Every className in the new page was invented: this dashboard styles with inline
  objects plus KPICard/SectionHeader/StatusBadge, so the page rendered as
  unstyled HTML while the API tests passed. Caught by opening it in a browser,
  not by the suite.
- Row-click to open detail did not fire and was the wrong pattern anyway (not
  keyboard-reachable) — replaced with an explicit Details button.

## Verification

- Full suite **1088 passed**, `pytest -m eval` 8, ruff clean, eslint clean, UI builds.
- Live check against seeded turn data (removed afterwards): list, filters, detail
  with journal and recorded effects, in-flight KPIs.
- Docs: [Runtime](docs/RUNTIME.md) — lifecycle, resume semantics, the
  side_effect/idempotency contract, retention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)