### PR TITLE
Swarm 3.0: the org chart is config — ownership, SLA escalation, budgets, dissent, reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to Kronos Agent OS are documented here.
 
 ### Added
 
+- **Swarm 3.0 — the org chart is config** — `agents.yaml` gained `owns`,
+  `escalates_to`, `sla_minutes`, `budget_usd_daily`, `dissent` and
+  `max_implicit_replies`, validated at startup (a broken `escalates_to` raises;
+  contested ownership and over-committed budgets warn). A subject someone owns is
+  answered by the owner without a relevance check and on the fast lane, other
+  agents defer instead of talking over them, and a missed `sla_minutes` escalates
+  to the owner's cover through the existing hand-off queue. Per-agent budgets add
+  quiet mode: out of its own money, an agent still answers when addressed but
+  stops volunteering. `dissent: require` sends a draft answer to a different role
+  before it is sent. New `kaos swarm report [--day|--week] [--json]` and a Sunday
+  push, `kaos demo --swarm` to see all of it without Telegram accounts. Docs:
+  [Swarm](docs/SWARM.md).
 - **Durable execution v2** — an interrupted turn can now be finished instead of
   only reported. New `external_effects` ledger makes re-execution safe (a
   message already sent is not re-sent; `side_effect` + optional
@@ -80,6 +92,13 @@ All notable changes to Kronos Agent OS are documented here.
 
 ### Fixed
 
+- Two agents could answer each other without end. A peer replying to my message
+  sets `reply_to_me` → `explicit_to_me` → Tier 1, and Tier 1 deliberately
+  bypasses the cooldown, the implicit-reply cap and arbitration; my answer is
+  itself a reply to theirs, so the loop had no exit. Peer-sourced Tier 1 is now
+  bounded per window (`MAX_PEER_EXCHANGES` / `PEER_EXCHANGE_WINDOW`); the user's
+  explicit address is untouched. Found by the new local swarm bus on its first
+  run.
 - `kronos.portability.export` and `import_` resolve `kronos.workspace.ws` at
   call time instead of binding it at import time; a module-level binding
   ignored a swapped workspace, which also made an earlier test pass against

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ kaos eval run         # replay golden scenarios (no keys, no network)
 kaos eval diff --base origin/main # what did my change move?
 kaos policy report    # effective governance posture and value sources
 kaos audit verify     # has the audit trail been edited?
+kaos swarm report --week # who answered, how well, at what cost
+kaos demo --swarm     # swarm coordination locally: no Telegram, no keys
 kaos connect telegram # guided Telegram setup check
 kaos templates list  # list bundled agent templates
 kaos skills packs    # list bundled skill packs
@@ -275,7 +277,20 @@ KAOS Swarm Mode is the optional multi-agent coordination layer inside the broade
 - SQLite `IMMEDIATE` transactions prevent duplicate implicit replies.
 - Peer reactions let agents disagree or add perspective without polluting long-term memory.
 
-This is useful for multi-persona group chats and expert panels, but the default KAOS runtime also works as a single durable agent.
+The org chart is config. `agents.yaml` can declare what an agent `owns`, who it
+`escalates_to` after `sla_minutes` of silence, its own `budget_usd_daily`, and
+whether answers there need a peer's review (`dissent: require`). All optional —
+omit them and routing behaves as it always has.
+
+```bash
+kaos demo --swarm            # see arbitration, ownership and escalation locally
+kaos swarm report --week     # who answered, how well, at what cost
+```
+
+The demo needs no Telegram accounts and no provider keys: it runs three agents on
+an in-process bus over a temporary ledger, through the production router.
+
+This is useful for multi-persona group chats and expert panels, but the default KAOS runtime also works as a single durable agent. See [Sub-Agents & Swarm](docs/SWARM.md).
 
 ## Governance
 

--- a/agents.example.yaml
+++ b/agents.example.yaml
@@ -1,10 +1,22 @@
 # Agent profiles — define your swarm members here.
 # Copy to agents.yaml and customize.
 #
-# Each agent needs:
+# Identity (this is what stops two agents from answering the same message):
 #   username: Telegram @username (for cross-agent addressing detection)
 #   aliases:  natural-language names (word-boundary matched in messages)
 #   role:     one-line description used by LLM for topic relevance scoring
+#
+# Organisation (all optional — omitting them keeps the plain routing):
+#   owns:                 topics this agent answers without a relevance check,
+#                         and wins arbitration for against non-owners
+#   escalates_to:         who picks the topic up when this agent stays silent
+#                         (must name another agent in this file)
+#   sla_minutes:          how long "silent" is before escalation (default 15)
+#   budget_usd_daily:     this agent's slice of the swarm budget; 0 or absent
+#                         means it is bounded only by the swarm-wide cap
+#   dissent:              allow (default) | require — require means a final
+#                         answer on an owned topic waits for a challenge
+#   max_implicit_replies: per-agent override of the global implicit-reply cap
 #
 # You can have 1 to N agents. Each runs as a separate process.
 
@@ -12,13 +24,24 @@ strategist:
   username: strategist_bot
   aliases: ["strategist", "стратег"]
   role: "strategic advisor — priorities, planning, decision analysis"
+  owns: ["planning", "priorities", "strategy"]
+  escalates_to: analyst
+  sla_minutes: 15
+  budget_usd_daily: 1.5
+  dissent: require
 
 analyst:
   username: analyst_bot
   aliases: ["analyst", "аналитик"]
   role: "data analyst — metrics, research, competitive intelligence"
+  owns: ["metrics", "research"]
+  escalates_to: strategist
+  budget_usd_daily: 1.5
 
 creative:
   username: creative_bot
   aliases: ["creative", "креатив"]
   role: "creative director — brand, naming, product vision"
+  owns: ["brand", "naming"]
+  escalates_to: strategist
+  max_implicit_replies: 1

--- a/agents.yaml
+++ b/agents.yaml
@@ -1,9 +1,15 @@
 # Agent profiles — single source of truth for swarm coordination.
 #
-# Each agent needs:
+# Identity:
 #   username: Telegram @username (for cross-agent addressing detection)
 #   aliases:  natural-language names (word-boundary matched in messages)
 #   role:     one-line description used by LLM for topic relevance scoring
+#
+# Organisation (see agents.example.yaml for the full field list):
+#   owns:             subjects this agent answers without a relevance check
+#   escalates_to:     who covers the topic when this agent stays silent
+#   sla_minutes:      how long "silent" is (default 15)
+#   budget_usd_daily: this agent's slice of the swarm budget (0 = swarm cap only)
 #
 # Usernames can be overridden per-agent via env: AGENT_USERNAME_KRONOS=..., etc.
 
@@ -11,28 +17,46 @@ kronos:
   username: kronosagnt
   aliases: ["кронос", "kronos", "стратег"]
   role: "strategic advisor, chief of staff — priorities, planning, multi-model analysis"
+  owns: ["planning", "priorities", "strategy"]
+  escalates_to: nexus
+  sla_minutes: 15
 
 nexus:
   username: nexusagnt
   aliases: ["нексус", "nexus", "аналитик"]
   role: "data analyst — business metrics, SEO, competitive intelligence, market trends"
+  owns: ["metrics", "analytics", "competitors"]
+  escalates_to: kronos
+  sla_minutes: 20
 
 lacuna:
   username: lacunaagnt
   aliases: ["лакуна", "lacuna", "иконоборец"]
   role: "creative director — brand, product meaning, authenticity, naming, creative vision"
+  owns: ["brand", "naming", "positioning"]
+  escalates_to: resonant
+  sla_minutes: 30
 
 resonant:
   username: resonantagnt
   aliases: ["резонант", "resonant", "хранитель"]
   role: "UX advocate — user experience, people, culture, tone of voice, onboarding"
+  owns: ["ux", "onboarding", "tone of voice"]
+  escalates_to: lacuna
+  sla_minutes: 30
 
 keystone:
   username: keystoneagnt
   aliases: ["кистоун", "keystone", "строитель"]
   role: "quality engineer — code architecture, standards, technical debt, performance"
+  owns: ["architecture", "tech debt", "performance"]
+  escalates_to: kronos
+  sla_minutes: 20
 
 impulse:
   username: impulseagnt
   aliases: ["импульс", "impulse", "энерджайзер"]
   role: "action catalyst — momentum, quick wins, ideation, overcoming blockers"
+  owns: ["blockers", "quick wins"]
+  escalates_to: kronos
+  sla_minutes: 15

--- a/docs/CRON-JOBS.md
+++ b/docs/CRON-JOBS.md
@@ -24,6 +24,12 @@ All core cron jobs are registered in `kronos/cron/setup.py` and run by the built
 | 16 | market-review | Weekly Fri 10:00 UTC (18:00 UTC+8) | Weekly | `market_review.py` |
 | 17 | source-quality-audit | Weekly Sun 04:00 UTC with 13-day guard | Weekly | `source_quality_audit.py` |
 | 18 | swarm-retention | Weekly Sun 03:00 UTC (11:00 UTC+8) | Weekly | `swarm_retention.py` |
+| 19 | turn-retention | Weekly Sun 05:00 UTC (13:00 UTC+8) | Weekly | `turn_retention.py` |
+| 20 | swarm-weekly-report | Weekly Sun 06:00 UTC (14:00 UTC+8) | Weekly | `swarm_weekly.py` |
+| 21 | sla-escalation | Every 60 s | Periodic | `escalation.py` |
+
+Intake pollers registered alongside these: `user-reminders` (60 s),
+`handoff-intake`, `council-intake`, `memory-intake` (30 s each).
 
 ## Job Details
 
@@ -276,6 +282,43 @@ Retention cleanup:
 3. Run safely on all agents; empty per-agent stores are harmless.
 
 **Notification:** Silent unless logs/errors require investigation.
+
+### 19. turn-retention
+**Schedule:** Weekly Sunday 05:00 UTC
+**Module:** `kronos/cron/turn_retention.py`
+
+Prunes finished durable turns and their journal / tool results / effects rows per
+`policy.retention.turn_journal_days`. A turn's effects are dropped with the turn
+because the default idempotency key contains its `turn_id`.
+
+**Notification:** Silent unless logs/errors require investigation.
+
+### 20. swarm-weekly-report
+**Schedule:** Weekly Sunday 06:00 UTC
+**Module:** `kronos/cron/swarm_weekly.py`
+
+The same post-mortem as `kaos swarm report --week`: who answered and at which
+tier, spend and cost per reply, reactions, owned-topic activity and missed SLAs,
+hand-offs, councils and reviews.
+
+All six processes run this job, so it first claims the ISO week in the shared
+`job_claims` table — the one whose INSERT won sends, the rest return. A week with
+no replies and no watched topics is not pushed at all.
+
+**Notification:** Bot API → Telegram `Digest` topic + NTFY summary.
+
+### 21. sla-escalation
+**Schedule:** Every 60 seconds
+**Module:** `kronos/cron/escalation.py`
+
+For each `sla_watch` row whose deadline passed with no answer, hands the topic to
+the owner's `escalates_to` through the existing hand-off queue. An owner that
+answered late closes the watch as `answered`; an owner with no cover is dropped
+once and counted rather than rechecked forever. Cross-process safety comes from a
+compare-and-set on the watch row, so exactly one of the six pollers creates the
+hand-off. A no-op ledger read when `agents.yaml` declares no ownership.
+
+**Notification:** none directly — delivery is the hand-off itself.
 
 ## Scheduler Implementation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@ Then read:
 | Automations | `kronos/cron/`, `docs/CRON-JOBS.md` | scheduled jobs and notifications |
 | Dashboard API | `dashboard/`, `tests/test_dashboard_config.py` | local control-room backend |
 | Dashboard UI | `dashboard-ui/` | React UI, Node 18.18+ |
-| Sub-agents/swarm | `kronos/group_router.py`, `kronos/swarm_store.py`, `tests/test_swarm_store.py` | optional coordination mode |
+| Sub-agents/swarm | `kronos/group_router.py`, `kronos/swarm_config.py`, `kronos/swarm_store.py`, `kronos/swarm_local.py`, `tests/test_swarm_store.py` | optional coordination mode, org chart and offline bus |
 | Public surface | `README.md`, `.github/`, community files | launch trust and contributor onboarding |
 
 ## Contributor Notes

--- a/docs/SWARM.md
+++ b/docs/SWARM.md
@@ -57,18 +57,119 @@ Group-chat coordination uses `kronos/swarm_store.py`:
 This keeps multi-agent chats readable while preserving enough state for
 debugging and metrics.
 
-## Configuration
+## Organization As Config
 
-Agent profiles are configured in a local, gitignored `agents.yaml`.
-
-Use `agents.example.yaml` as the public template.
+`agents.yaml` is the org chart, not just a username table. Identity fields make
+agents distinguishable; the organisational fields make them a team. Every one of
+them is optional — a registry written before they existed loads unchanged, which
+is what makes this safe to roll out to a running swarm.
 
 ```yaml
 strategist:
   username: strategist_bot
   aliases: ["strategist"]
   role: "strategy, prioritization, and tradeoff analysis"
+  owns: ["planning", "priorities"]   # subjects this agent answers on sight
+  escalates_to: analyst              # who covers a silence here
+  sla_minutes: 15                    # how long "silent" is
+  budget_usd_daily: 1.5              # personal slice of the swarm budget
+  dissent: require                   # answers here need a peer's review
+  max_implicit_replies: 2            # this agent's own tolerance for peers
 ```
+
+Validation is split by consequence (`kronos/swarm_config.py`). A broken
+`escalates_to` **raises at startup** — it names a delivery path that does not
+exist. Contested ownership and per-agent budgets summing above the swarm cap only
+**warn**: both are legitimate transitional states, and refusing to start would be
+worse than saying so in the log. A contested topic has no owner, so routing falls
+back to plain relevance.
+
+### Ownership and escalation
+
+Two different things are called "topic" and they do not mix:
+
+| | Telegram forum topic | `owns` subject |
+|---|---|---|
+| Identified by | topic id in env (`TOPIC_*`) | recognised from the message |
+| Enforcement | hard — non-owners never reach the router | soft — owner answers first |
+| Where it applies | configured topics | the shared stream and DMs |
+
+An owned subject gets three things:
+
+- **Owner-first.** The owner answers without the relevance threshold and on the
+  fast lane (1–4s), so it wins arbitration against agents who merely scored the
+  topic highly.
+- **Deference.** A non-owner that would have answered waits 90s instead of
+  talking over the specialist. Not the full SLA: a claim older than
+  `CLAIM_EXPIRY_SECONDS` (120) can never win arbitration, so a longer sleep would
+  mean "never answer" while still costing a task and an LLM call. Inside the
+  window a live owner always wins; past it, an owner whose process is down no
+  longer leaves the user waiting.
+- **A deadline.** The first agent to recognise the subject registers an
+  `sla_watch` row — including a non-owner, and including when it has nothing to
+  say, because the case worth covering is the owner's process being down. The
+  `sla-escalation` job (60s) hands a missed deadline to the owner's
+  `escalates_to` through the existing hand-off queue. All six processes poll it;
+  a compare-and-set on the watch row means exactly one creates the hand-off.
+
+Subject recognition costs nothing when no agent declares `owns` (the map is
+empty, every branch is a no-op) and nothing for @-addressed messages. Otherwise
+it is one lite-tier call, cached per process for five minutes.
+
+### Budgets and quiet mode
+
+An agent may have a personal daily slice — `budget_usd_daily` here, or
+`budgets.per_agent_daily_usd` in `policy.yaml`, which wins. Exhausting it does
+**not** block: the agent enters quiet mode, still answering when addressed
+(Tier 1) and no longer volunteering (Tier 2/3). A hard stop would mean the user's
+direct question goes unanswered because the agent spent its allowance on opinions
+nobody asked for. `should_degrade()` also fires at 80% of the personal slice, so
+the soft brake exists for the agent doing the spending and not only for the swarm.
+`/stats` shows the personal slice and whether quiet mode is on.
+
+### Dissent
+
+With `dissent: require`, the owner's draft answer goes to an agent with a
+different role (its `escalates_to`, by default) before it is sent. An objection is
+appended to the answer; agreement changes nothing visible, so the absence of the
+"без ревью" mark is what says the answer passed a second pair of eyes. A silent
+reviewer never eats the answer — on timeout (90s) it is sent with the mark.
+
+The reviewer side rides the council intake pass rather than a fourth poller: the
+queue shape is identical, and a review is a one-participant council with the
+opposite exit (a council ends in synthesis posted to the chat, a review ends in a
+verdict handed back to the author).
+
+### Post-mortem
+
+```bash
+kaos swarm report --week          # markdown digest
+kaos swarm report --day --json    # machine-readable
+```
+
+Who answered and at which tier, spend and cost per reply per agent, 👍/👎,
+owned-topic activity and missed SLAs, hand-offs, councils, reviews and
+objections. The same report is pushed every Sunday by the `swarm-weekly-report`
+job, which claims the ISO week in the ledger first so the digest arrives once
+rather than six times.
+
+There is no cost-per-topic column on purpose: spend is recorded per agent and per
+day, never attributed to a subject, so that table would be an invention.
+
+### Seeing it without Telegram
+
+```bash
+kaos demo --swarm
+```
+
+Three agents on an in-process bus over a temporary `swarm.db`: cap arbitration,
+the ownership shortcut, a Tier 3 reaction, a non-owner registering the watch for a
+dead owner, escalation through the hand-off queue, and the weekly report. Every
+routing decision goes through the production `GroupRouter` and every claim
+through the production ledger; only the transport, the delays and the model calls
+are local (see `kronos/swarm_local.py` for exactly what is not reproduced).
+
+## Telegram Topic Configuration
 
 Telegram forum topics can be made explicit so personal topics do not run
 through the smart group router:

--- a/kronos/app.py
+++ b/kronos/app.py
@@ -125,10 +125,31 @@ def _activate_policy_or_exit() -> None:
         log.info("Governance policy active: %s", policy.source_path)
 
 
+def _load_swarm_registry_or_exit() -> None:
+    """Validate agents.yaml before the router imports it.
+
+    The registry is read at import time and a contradiction raises there, which
+    would surface as a traceback from whichever module happened to import the
+    router first. Checking it here turns that into one readable line.
+    """
+    from kronos.swarm_config import SwarmConfigError, load_profiles
+
+    try:
+        profiles = load_profiles()
+    except SwarmConfigError as e:
+        log.error("Refusing to start: %s", e)
+        raise SystemExit(1) from e
+
+    if profiles:
+        owned = sum(1 for profile in profiles.values() if profile.owns)
+        log.info("Swarm registry: %d agent(s), %d with topic ownership", len(profiles), owned)
+
+
 async def main():
     """Start Kronos Agent OS: build agent, start bridge + cron scheduler."""
     log.info("Starting Kronos Agent OS v%s", __version__)
     _activate_policy_or_exit()
+    _load_swarm_registry_or_exit()
     _ensure_data_dirs()
 
     session_store = SessionStore(settings.db_path, agent_name=settings.agent_name)

--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -66,6 +66,7 @@ from kronos.bridge_topics import (
     _topic_owner_agents,
 )
 from kronos.config import settings
+from kronos.dissent import review_before_send
 from kronos.graph import KronosAgent
 from kronos.observer.capture import CaptureDecision, classify_capture, record_capture
 from kronos.security.cost_guardian import get_guardian
@@ -1453,6 +1454,20 @@ async def run_bridge(agent: KronosAgent) -> None:
         validation = validate_output(reply)
         if not validation.is_clean:
             reply = validation.redacted_text
+
+        # Dissent gate (moat 11.4): an owner that declares `dissent: require`
+        # shows its answer to another role before sending. Opt-in and owner-only,
+        # so this is a cheap early return for everyone else.
+        if not is_dm and decision is not None and reply and decision.topic_owner == settings.agent_name:
+            reply = await review_before_send(
+                answer=reply,
+                chat_id=event.chat_id,
+                topic_id=topic_id_inbound,
+                thread_id=_thread_id_for(event.chat_id, topic_id_inbound),
+                root_msg_id=event.message.id,
+                topic=decision.topic,
+                author_agent=settings.agent_name,
+            )
 
         approval_id = _last_pending_approval_id()
         approval_buttons = _approval_buttons(approval_id) if approval_id else None

--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -1181,13 +1181,17 @@ async def run_bridge(agent: KronosAgent) -> None:
                     swarm.incr_metric("duplicate_replies_avoided")
                     return
 
-                # Atomic arbitration across all agents.
+                # Atomic arbitration across all agents. The cap is this agent's
+                # own tolerance (agents.yaml max_implicit_replies): it decides
+                # when *I* stand down, so a talkative generalist can be told to
+                # yield sooner without touching anyone else's routing.
                 outcome = swarm.can_send_claim(
                     chat_id=event.chat_id,
                     topic_id=topic_id_inbound,
                     root_msg_id=root_msg_id,
                     agent_name=settings.agent_name,
                     tier=decision.tier,
+                    max_implicit_replies=_group_router.max_implicit_replies,
                 )
                 if not outcome.won:
                     log.info("[Swarm] %s stands down: %s", settings.agent_name, outcome.reason)

--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -61,6 +61,7 @@ from kronos.bridge_topics import (
     _positive_int,
     _resolve_topic_route,
     _same_telegram_chat,
+    _thread_id_for,
     _topic_id_from_env_or_setting,
     _topic_owner_agents,
 )
@@ -111,6 +112,7 @@ __all__ = [
     "_positive_int",
     "_resolve_topic_route",
     "_same_telegram_chat",
+    "_thread_id_for",
     "_topic_id_from_env_or_setting",
     "_topic_owner_agents",
     "_transcribe_voice",
@@ -496,7 +498,7 @@ async def _clear_context(chat_id: int, topic_id: int | None = None) -> str:
     swarm message ledger. Learned user facts (Mem0 / shared_user_facts) are
     cross-conversation and are NOT removed here — see clear_context's message.
     """
-    thread_id = f"{chat_id}:{topic_id}" if topic_id else str(chat_id)
+    thread_id = _thread_id_for(chat_id, topic_id)
     result = await _agent.clear_context(thread_id)
     try:
         from kronos.swarm_store import get_swarm
@@ -640,7 +642,7 @@ async def _ask_agent(
     history and causing verbatim-parrot replies.
     """
     # Topic-aware thread isolation
-    thread_id = f"{chat_id}:{topic_id}" if topic_id else str(chat_id)
+    thread_id = _thread_id_for(chat_id, topic_id)
 
     # Start typing indicator + live progress reporter
     stop_typing = asyncio.Event()
@@ -1106,6 +1108,22 @@ async def run_bridge(agent: KronosAgent) -> None:
             elif _group_router:
                 # Multi-agent group routing (all group types)
                 decision = await _group_router.decide(event, _client)
+
+                # An owned topic gets a deadline, registered even when this agent
+                # skips: the silence worth escalating is the owner's, and the
+                # owner may be the process that is down.
+                if decision.topic_owner:
+                    swarm.watch_sla(
+                        chat_id=event.chat_id,
+                        topic_id=topic_id_inbound,
+                        root_msg_id=event.message.id,
+                        thread_id=_thread_id_for(event.chat_id, topic_id_inbound),
+                        topic=decision.topic,
+                        owner_agent=decision.topic_owner,
+                        request=text,
+                        sla_minutes=decision.owner_sla_minutes,
+                    )
+
                 if not decision.should_respond:
                     # Count "skipped because another agent was addressed" as
                     # a successful addressing-correctness event, and count

--- a/kronos/bridge_commands.py
+++ b/kronos/bridge_commands.py
@@ -110,7 +110,15 @@ async def _handle_stats_command(text: str) -> str | None:
     daily = status["daily_cost"]
     limit = status["daily_limit"] or 0
     pct = (daily / limit * 100) if limit else 0
-    lines.append(f"\nДневной бюджет: ${daily:.2f} / ${limit:.2f} ({pct:.0f}%)")
+    lines.append(f"\nДневной бюджет роя: ${daily:.2f} / ${limit:.2f} ({pct:.0f}%)")
+
+    personal_limit = status.get("personal_limit") or 0
+    if personal_limit:
+        personal = status.get("personal_cost", 0)
+        personal_pct = personal / personal_limit * 100
+        lines.append(f"Свой лимит: ${personal:.2f} / ${personal_limit:.2f} ({personal_pct:.0f}%)")
+        if status.get("quiet"):
+            lines.append("🔇 Тихий режим: отвечаю только на прямые обращения.")
 
     swarm = swarm_cost_by_agent(period)
     if len(swarm) > 1:

--- a/kronos/bridge_topics.py
+++ b/kronos/bridge_topics.py
@@ -80,6 +80,11 @@ def _topic_owner_agents(owner_agent: str) -> set[str]:
     return {agent.strip().lower() for agent in (owner_agent or "").replace(";", ",").split(",") if agent.strip()}
 
 
+def _thread_id_for(chat_id: int, topic_id: int | None) -> str:
+    """Thread id for a chat/topic pair — the inverse of the parser below."""
+    return f"{chat_id}:{topic_id}" if topic_id else str(chat_id)
+
+
 def _chat_topic_from_thread_id(thread_id: str) -> tuple[int | None, int | None]:
     """Parse a Telegram thread id into chat/topic ids when possible."""
     try:

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -1177,6 +1177,23 @@ def run_audit_verify(as_json: bool) -> int:
     return 0
 
 
+def run_swarm_report(period: str, as_json: bool) -> int:
+    """Post-mortem of the swarm's period: who answered, how well, at what cost."""
+    from kronos.swarm_report import build_report, render_markdown
+
+    try:
+        report = build_report(period)
+    except ValueError as e:
+        print(f"[FAIL] {e}")
+        return 1
+
+    if as_json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(render_markdown(report))
+    return 0
+
+
 DEFAULT_EVAL_SUITE = "tests/evals/suites/golden"
 
 
@@ -1486,6 +1503,21 @@ def build_parser() -> argparse.ArgumentParser:
     policy_report = policy_sub.add_parser("report", help="print the effective policy and value sources")
     policy_report.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
 
+    swarm_cmd = sub.add_parser("swarm", help="swarm coordination reports")
+    swarm_sub = swarm_cmd.add_subparsers(dest="swarm_command")
+    swarm_report = swarm_sub.add_parser("report", help="who answered, how well, at what cost")
+    from kronos.swarm_report import PERIOD_DAYS
+
+    swarm_report.add_argument(
+        "--period",
+        default="week",
+        choices=sorted(PERIOD_DAYS),
+        help="reporting window (default: week)",
+    )
+    swarm_report.add_argument("--day", dest="period", action="store_const", const="day", help="shorthand for a day")
+    swarm_report.add_argument("--week", dest="period", action="store_const", const="week", help="shorthand for a week")
+    swarm_report.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
+
     audit_cmd = sub.add_parser("audit", help="audit trail integrity")
     audit_sub = audit_cmd.add_subparsers(dest="audit_command")
     audit_verify = audit_sub.add_parser("verify", help="verify the audit log hash chain")
@@ -1634,6 +1666,11 @@ def main(argv: list[str] | None = None) -> int:
         if args.policy_command == "report":
             return run_policy_report(args.as_json)
         parser.parse_args(["policy", "--help"])
+        return 0
+    if args.command == "swarm":
+        if args.swarm_command == "report":
+            return run_swarm_report(args.period, args.as_json)
+        parser.parse_args(["swarm", "--help"])
         return 0
     if args.command == "audit":
         if args.audit_command == "verify":

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -255,6 +255,135 @@ def _demo_reply(prompt: str) -> str:
     return "KAOS demo: runtime + memory + skills + MCP + automations + optional swarm, with risky capabilities disabled until explicit opt-in."
 
 
+_DEMO_SWARM = (
+    # name, role, owns, escalates_to
+    ("strategist", "strategy and priorities", ["planning"], "analyst"),
+    ("analyst", "metrics and research", ["metrics"], "strategist"),
+    ("operator", "momentum and unblocking", [], "strategist"),
+)
+
+
+def run_demo_swarm() -> int:
+    """Show swarm coordination locally: no Telegram accounts, no LLM keys.
+
+    Three agents on one in-process bus over a temporary swarm ledger. Everything
+    printed is the production routing — the same tier rules, the same claim
+    arbitration, the same escalation job — driven through EventFacts instead of
+    Telethon events.
+    """
+    import tempfile
+
+    from kronos.group_router import AGENT_PROFILES
+
+    _force_demo_safety()
+
+    with tempfile.TemporaryDirectory(prefix="kaos-swarm-demo-") as tmp:
+        settings.swarm_db_path = str(Path(tmp) / "swarm.db")
+        settings.db_dir = tmp
+        import kronos.db as _db
+        import kronos.swarm_store as _swarm_store
+
+        # The escalation job reads the process-wide store, so the demo must own
+        # that singleton — otherwise the job would poll a different ledger than
+        # the bus writes to and find nothing due.
+        _db._instances.clear()
+        _swarm_store._singleton = None
+
+        original = {name: dict(prof) for name, prof in AGENT_PROFILES.items()}
+        AGENT_PROFILES.clear()
+        AGENT_PROFILES.update(
+            {
+                name: {
+                    "username": f"{name}bot",
+                    "aliases": [name],
+                    "role": role,
+                    "owns": owns,
+                    "escalates_to": escalates_to,
+                    "sla_minutes": 15,
+                }
+                for name, role, owns, escalates_to in _DEMO_SWARM
+            }
+        )
+        try:
+            asyncio.run(_run_demo_swarm_rounds())
+        finally:
+            AGENT_PROFILES.clear()
+            AGENT_PROFILES.update(original)
+            _db._instances.clear()
+            _swarm_store._singleton = None
+    return 0
+
+
+async def _run_demo_swarm_rounds() -> None:
+    from kronos.cron.escalation import run_sla_escalation
+    from kronos.swarm_local import LocalSwarmBus
+    from kronos.swarm_store import get_swarm
+
+    store = get_swarm()
+    bus = LocalSwarmBus(store=store)
+    for name, _role, _owns, _escalates in _DEMO_SWARM:
+        bus.add_agent(
+            name,
+            username=f"{name}bot",
+            relevance=lambda agent, text: 9,  # everyone wants to answer
+            react=lambda agent, text: agent == "operator",
+        )
+
+    print("KAOS swarm demo — three agents, one shared ledger, no Telegram.\n")
+    print("Registry: strategist owns 'planning', analyst owns 'metrics',")
+    print("operator owns nothing; both owners escalate to each other.\n")
+
+    async def round_of(label: str, text: str, *, topic_label: str = "") -> list[dict]:
+        print(f"--- {label}")
+        print(f"user> {text}" + (f"   [topic: {topic_label}]" if topic_label else ""))
+        sent = await bus.user_says(text, topic_label=topic_label)
+        for entry in sent:
+            print(f"  {entry['agent']} (tier {entry['tier']}, {entry['reason']}): {entry['text']}")
+        if not sent:
+            print("  (nobody answered)")
+        return sent
+
+    await round_of("Three eager agents, two replies — the swarm cap decides", "что делать с ростом?")
+    print("    (the third agent stood down: arbitration, not luck)\n")
+
+    # Only the owner is keen now, so the ownership shortcut is what shows.
+    for agent in bus.agents.values():
+        agent.relevance = lambda name, text: 5
+    owned = await round_of(
+        "Owned topic — the specialist answers below the relevance threshold",
+        "распланируй следующий квартал",
+        topic_label="planning",
+    )
+    if owned:
+        for entry in await bus.run_round(owned[0]["reply_facts"]):
+            print(f"  {entry['agent']} (tier {entry['tier']}, {entry['reason']}): {entry['text']}")
+        print("    (a peer added a Tier 3 reaction — it spends the same reply budget)\n")
+
+    print("--- Owner's process is down — the deadline is still watched, then escalates")
+    print("user> нужны свежие метрики по воронке   [topic: metrics]")
+    del bus.agents["analyst"]  # the owner of 'metrics' is not running
+    for agent in bus.agents.values():
+        agent.relevance = lambda name, text: 1  # and nobody else volunteers
+    await bus.user_says("нужны свежие метрики по воронке", topic_label="metrics")
+    print("  (nobody answered — the watch was registered by a NON-owner, which is")
+    print("   the whole point: the owner could not register anything)")
+    watch = next(row for row in store.sla_watches() if row["topic"] == "metrics")
+    store._db.write("UPDATE sla_watch SET deadline_ts = 0 WHERE id = ?", (watch["id"],))
+    settings.agent_name = "operator"
+    await run_sla_escalation()
+    for handoff in store.pending_handoffs("strategist"):
+        print(f"  → escalated to strategist: {handoff['context'].splitlines()[0]}")
+
+    print("\n--- Ledger")
+    for metric, value in sorted(store.get_metrics().items()):
+        print(f"  {metric}: {value}")
+
+    from kronos.swarm_report import build_report, render_markdown
+
+    print("\n--- The same post-mortem production sends weekly\n")
+    print(render_markdown(build_report("day")))
+
+
 def run_demo(interactive: bool = False, live: bool = False, use_tools: bool = False) -> int:
     """Run a safe local demo that does not require Telegram, Docker, or LLM keys."""
     _force_demo_safety()
@@ -1407,6 +1536,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     demo = sub.add_parser("demo", help="run safe local demo")
     demo.add_argument("--interactive", action="store_true", help="open deterministic offline demo prompt")
+    demo.add_argument("--swarm", action="store_true", help="show swarm coordination locally (no Telegram, no keys)")
     demo.add_argument("--live", action="store_true", help="start real LLM-backed chat with demo safety gates")
     demo.add_argument("--tools", action="store_true", help="load configured static MCP tools in --live mode")
 
@@ -1615,6 +1745,8 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "chat":
         return asyncio.run(run_cli(use_tools=args.tools, prompt=args.prompt, enable_memory=not args.no_memory))
     if args.command == "demo":
+        if args.swarm:
+            return run_demo_swarm()
         return run_demo(interactive=args.interactive, live=args.live, use_tools=args.tools)
     if args.command == "demo-seed":
         return run_demo_seed(args.data_dir, args.workspace, args.swarm_db, reset=args.reset)

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -583,6 +583,24 @@ def run_doctor() -> int:
     else:
         ok("Telegram topic policy", "not configured; legacy group routing")
 
+    from kronos.swarm_config import SwarmConfigError, load_profiles, validate_profiles
+
+    try:
+        _profiles = load_profiles()
+        if not _profiles:
+            ok("Swarm registry", "no agents.yaml; single-agent mode")
+        else:
+            _owned = sorted({topic for prof in _profiles.values() for topic in prof.owns})
+            _detail = f"{len(_profiles)} agent(s)"
+            _detail += f"; owned topics: {', '.join(_owned)}" if _owned else "; no topic ownership declared"
+            _warnings = validate_profiles(_profiles)
+            if _warnings:
+                warn("Swarm registry", f"{_detail}; {_warnings[0]}")
+            else:
+                ok("Swarm registry", _detail)
+    except SwarmConfigError as e:
+        fail("Swarm registry", str(e).splitlines()[0])
+
     from kronos.portability import BUNDLE_SCHEMA_VERSION
     from kronos.portability.importers import available as _importers
 

--- a/kronos/cron/council.py
+++ b/kronos/cron/council.py
@@ -1,8 +1,11 @@
 """Council intake — contribute positions and synthesize (roadmap 5.2).
 
-Polled by the Scheduler. Each agent plays two roles against the shared ledger:
+Polled by the Scheduler. Each agent plays three roles against the shared ledger:
   1. participant — answer councils it's invited to, independently;
-  2. initiator — once all positions are in, synthesize one answer for the chat.
+  2. initiator — once all positions are in, synthesize one answer for the chat;
+  3. reviewer — poke holes in a peer's draft answer when it asked for dissent
+     (moat 11.4). It rides this pass instead of getting its own scheduler job:
+     the queue shape is identical and a second 30s poller would buy nothing.
 Synthesis is claimed under an IMMEDIATE transaction so it fires exactly once.
 """
 
@@ -11,6 +14,7 @@ import logging
 
 from kronos.config import settings
 from kronos.cron.notify import send_webhook
+from kronos.dissent import run_challenge_intake
 from kronos.swarm_store import get_swarm
 
 log = logging.getLogger("kronos.cron.council")
@@ -89,3 +93,7 @@ async def run_council_intake() -> None:
         ok = await _synthesize(agent, swarm, claimed)
         swarm.complete_council(claimed["id"], success=ok)
         swarm.incr_metric("councils_completed" if ok else "councils_failed")
+
+    # Role 3: review draft answers from agents that require dissent (moat 11.4).
+    # The author is blocking on this, so it runs on every pass.
+    await run_challenge_intake(agent, swarm, reviewer_agent=me, max_per_poll=_MAX_PER_POLL)

--- a/kronos/cron/escalation.py
+++ b/kronos/cron/escalation.py
@@ -1,0 +1,92 @@
+"""SLA escalation for owned topics (moat 11.2).
+
+Ownership without escalation is worse than no ownership: it teaches the other
+agents to stay quiet and then relies on one process being alive. This poller
+closes that loop — when a message on an owned topic has no answer by the owner's
+deadline, the topic is handed to the owner's `escalates_to`.
+
+It reuses the hand-off queue rather than inventing a second delivery path, so an
+escalated request arrives at the covering agent exactly like a manual hand-off
+and comes back through the same webhook.
+
+All six processes run this poller against the same ledger. Correctness comes
+from `resolve_sla_watch`, a compare-and-set on the watch row: every process sees
+the same due rows, and only the one whose UPDATE changed a row creates the
+hand-off.
+"""
+
+import logging
+
+from kronos.config import settings
+from kronos.swarm_store import get_swarm
+
+log = logging.getLogger("kronos.cron.escalation")
+
+# Safety bound per poll — a backlog drains over several cycles instead of
+# monopolising one.
+_MAX_PER_POLL = 10
+
+
+def _escalation_context(watch: dict, target: str) -> str:
+    """What the covering agent is asked to do."""
+    return (
+        f"Тема «{watch['topic']}» закреплена за агентом {watch['owner_agent']}, "
+        f"но он не ответил за отведённое время. Ты подстраховка ({target}) — "
+        f"ответь по существу.\n\nЗапрос пользователя:\n{watch['request']}"
+    )
+
+
+async def run_sla_escalation() -> None:
+    """One poll: escalate every owned topic whose deadline has passed."""
+    from kronos.swarm_config import all_profiles
+
+    swarm = get_swarm()
+    due = swarm.due_sla_watches(limit=_MAX_PER_POLL)
+    if not due:
+        return
+
+    profiles = all_profiles()
+
+    for watch in due:
+        # The owner may have answered between the deadline and this poll.
+        answered = swarm.count_sent_replies(
+            chat_id=watch["chat_id"],
+            topic_id=watch["topic_id"] or None,
+            root_msg_id=watch["root_msg_id"],
+        )
+        if answered:
+            swarm.resolve_sla_watch(watch["id"], state="answered")
+            continue
+
+        owner = profiles.get(watch["owner_agent"])
+        target = owner.escalates_to if owner else ""
+        if not target or target not in profiles:
+            # Nobody covers this owner — record it and stop re-checking the row.
+            swarm.resolve_sla_watch(watch["id"], state="dropped")
+            log.info(
+                "SLA missed on '%s' (owner=%s) with no escalation target",
+                watch["topic"],
+                watch["owner_agent"],
+            )
+            swarm.incr_metric("escalations_undeliverable")
+            continue
+
+        # Cross-process arbitration: exactly one poller proceeds past this line.
+        if not swarm.resolve_sla_watch(watch["id"], state="escalated"):
+            continue
+
+        swarm.create_handoff(
+            chat_id=watch["chat_id"],
+            topic_id=watch["topic_id"] or None,
+            thread_id=watch["thread_id"],
+            from_agent=settings.agent_name,
+            to_agent=target,
+            context=_escalation_context(watch, target),
+        )
+        swarm.incr_metric("escalations_triggered")
+        log.info(
+            "Escalated '%s' from %s to %s after SLA",
+            watch["topic"],
+            watch["owner_agent"],
+            target,
+        )

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -30,6 +30,7 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     # DISABLED 2026-07-07: group-digest paused — duplicate of news-monitor on Digest:News.
     # from kronos.cron.group_digest import run_group_digest
     from kronos.cron.council import run_council_intake
+    from kronos.cron.escalation import run_sla_escalation
     from kronos.cron.expense_digest import run_expense_digest
     from kronos.cron.expenses.processor import run_email_expenses
     from kronos.cron.handoff import run_handoff_intake
@@ -73,6 +74,10 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
 
     # Cross-agent memory query intake — poll every 30s (roadmap 5.3)
     scheduler.add_periodic("memory-intake", run_memory_intake, interval_seconds=30)
+
+    # SLA escalation for owned topics — poll every 60s (moat 11.2). A no-op
+    # ledger read when agents.yaml declares no ownership.
+    scheduler.add_periodic("sla-escalation", run_sla_escalation, interval_seconds=60)
 
     # News Monitor — daily at 00:00 UTC (was: kronos-news-monitor.timer)
     scheduler.add_daily("news-monitor", run_news_monitor, hour_utc=0)
@@ -179,6 +184,6 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
         nexus_jobs_registered = 4
 
     total = (
-        19 + nexus_jobs_registered
-    )  # +reminders +handoff/council/memory intake +persona-evolution; signal-jobs, travel insights, people-scout and group-digest paused
+        20 + nexus_jobs_registered
+    )  # +reminders +handoff/council/memory intake +sla-escalation +persona-evolution; signal-jobs, travel insights, people-scout and group-digest paused
     log.info("%d cron jobs registered for agent '%s'", total, me)

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -55,6 +55,7 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     from kronos.cron.sleep_compute import run_sleep_compute
     from kronos.cron.source_quality_audit import run_source_quality_audit
     from kronos.cron.swarm_retention import run_swarm_retention
+    from kronos.cron.swarm_weekly import run_swarm_weekly_report
     from kronos.cron.turn_retention import run_turn_retention
     from kronos.cron.user_model import run_user_model
 
@@ -157,6 +158,10 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     # their journal/results/effects per policy.retention.turn_journal_days.
     scheduler.add_weekly("turn-retention", run_turn_retention, weekday=6, hour_utc=5)
 
+    # Swarm post-mortem — weekly Sunday 06:00 UTC (moat 11.4). Claims the week in
+    # the shared ledger first, so the digest is sent once, not once per agent.
+    scheduler.add_weekly("swarm-weekly-report", run_swarm_weekly_report, weekday=6, hour_utc=6)
+
     # ── Agent-exclusive jobs (only registered on the owning agent) ──────
     nexus_jobs_registered = 0
 
@@ -184,6 +189,6 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
         nexus_jobs_registered = 4
 
     total = (
-        20 + nexus_jobs_registered
-    )  # +reminders +handoff/council/memory intake +sla-escalation +persona-evolution; signal-jobs, travel insights, people-scout and group-digest paused
+        21 + nexus_jobs_registered
+    )  # +reminders +handoff/council/memory intake +sla-escalation +swarm-weekly-report +persona-evolution; signal-jobs, travel insights, people-scout and group-digest paused
     log.info("%d cron jobs registered for agent '%s'", total, me)

--- a/kronos/cron/swarm_weekly.py
+++ b/kronos/cron/swarm_weekly.py
@@ -1,0 +1,55 @@
+"""Weekly swarm post-mortem, delivered once (moat 11.4).
+
+Same report as `kaos swarm report --week`, pushed to the chat on Sunday so the
+organisation gets reviewed without anyone remembering to ask.
+
+All six agents run this scheduler, so the job first claims the week in the
+shared ledger — the one whose INSERT won sends, the other five return. Without
+that the digest would arrive six times.
+"""
+
+import asyncio
+import logging
+import time
+
+from kronos.config import settings
+from kronos.cron.notify import TOPIC_DIGEST, send_bot_api, send_ntfy
+from kronos.swarm_report import build_report, render_summary
+from kronos.swarm_store import get_swarm
+
+log = logging.getLogger("kronos.cron.swarm_weekly")
+
+JOB_NAME = "swarm-weekly-report"
+
+
+def _week_key(now: float | None = None) -> str:
+    """ISO year-week, so a retry inside the same week does not re-send."""
+    return time.strftime("%G-W%V", time.gmtime(time.time() if now is None else now))
+
+
+async def run_swarm_weekly_report() -> None:
+    swarm = get_swarm()
+    period_key = _week_key()
+
+    if not swarm.claim_periodic_job(job=JOB_NAME, period_key=period_key, agent_name=settings.agent_name):
+        owner = swarm.periodic_job_owner(job=JOB_NAME, period_key=period_key)
+        log.info("Weekly swarm report for %s already claimed by %s", period_key, owner or "another agent")
+        return
+
+    report = build_report("week")
+    if not report["totals"]["replies"] and not report["ownership"]["watched"]:
+        log.info("Weekly swarm report: nothing happened this week, skipping the push")
+        return
+
+    body = render_summary(report)
+    delivered = await asyncio.to_thread(send_bot_api, body, topic_id=TOPIC_DIGEST)
+    if not delivered:
+        log.warning("Weekly swarm report was not delivered to Telegram")
+
+    totals = report["totals"]
+    await asyncio.to_thread(
+        send_ntfy,
+        f"Ответов {totals['replies']}, расход ${totals['cost_usd']:.2f}, эскалаций {report['ownership']['escalated']}",
+        title="Отчёт роя за неделю",
+        tags="bar_chart",
+    )

--- a/kronos/dissent.py
+++ b/kronos/dissent.py
@@ -1,0 +1,200 @@
+"""Mandatory review before answering (moat 11.4).
+
+Ownership makes one agent the authority on a topic, and an authority nobody
+contradicts is how a swarm of six converges on one blind spot. When the owner
+declares `dissent: require`, its draft answer is shown to an agent with a
+different role first — the objection reaches the user together with the answer,
+not three days later.
+
+Design constraints that shaped this:
+
+* **Opt-in.** `dissent: allow` (the default) makes every function here a cheap
+  early return, so nothing changes for a swarm that does not ask for it.
+* **No new poller.** The reviewer side rides the council intake pass, which
+  already polls a shared queue every 30s and answers with the agent's own
+  expertise. A challenge is a one-participant council with the opposite exit:
+  a council ends in synthesis posted to the chat, a review ends in a verdict
+  handed back to the author.
+* **A timeout must not eat the answer.** If nobody reviews in time, the answer
+  is sent with a visible "не прошло ревью" mark. Silence from a reviewer is not
+  a reason to leave the user with nothing.
+"""
+
+import asyncio
+import logging
+
+from kronos.swarm_store import get_swarm
+
+log = logging.getLogger("kronos.dissent")
+
+# How long the author waits. The reviewer is picked up by a 30s poll and then
+# has to think, so anything under a minute would time out most of the time.
+DISSENT_TIMEOUT_SECONDS = 90
+DISSENT_POLL_SECONDS = 3
+
+UNREVIEWED_MARK = "⚠️ Отправлено без ревью — коллега не ответил вовремя."
+
+AGREE_PREFIX = "согласен"
+
+
+def pick_reviewer(profiles: dict, author: str) -> str:
+    """Who reviews this agent's answers.
+
+    Prefers the escalation counterpart — the agent already designated as this
+    one's cover, so the pairing stays declared rather than random. Falls back to
+    the first other agent by name for determinism.
+    """
+    profile = profiles.get(author)
+    counterpart = profile.escalates_to if profile else ""
+    if counterpart and counterpart in profiles and counterpart != author:
+        return counterpart
+    others = sorted(name for name in profiles if name != author)
+    return others[0] if others else ""
+
+
+def classify_verdict(response: str) -> str:
+    """ "agree" when the reviewer had nothing to add, else "challenge"."""
+    head = response.strip().lower().lstrip("*_ ").strip()
+    return "agree" if head.startswith(AGREE_PREFIX) else "challenge"
+
+
+def format_reviewed_answer(answer: str, *, reviewer: str, verdict: str, response: str) -> str:
+    """An objection is information the user needs; agreement is not.
+
+    So agreement changes nothing visible — the absence of the unreviewed mark is
+    what says "this went past a second pair of eyes".
+    """
+    if verdict != "challenge" or not response.strip():
+        return answer
+    return f"{answer}\n\n⚖️ Возражение от {reviewer}:\n{response.strip()}"
+
+
+async def review_before_send(
+    *,
+    answer: str,
+    chat_id: int,
+    topic_id: int | None,
+    thread_id: str,
+    root_msg_id: int,
+    topic: str,
+    author_agent: str,
+    timeout: float = DISSENT_TIMEOUT_SECONDS,
+) -> str:
+    """Return the answer to send, possibly carrying a peer's objection.
+
+    Only called when this agent owns the topic; returns the answer untouched
+    unless the owner's profile requires dissent.
+    """
+    from kronos.swarm_config import all_profiles
+
+    if not answer.strip():
+        return answer
+
+    profiles = all_profiles()
+    profile = profiles.get(author_agent)
+    if profile is None or profile.dissent != "require":
+        return answer
+
+    reviewer = pick_reviewer(profiles, author_agent)
+    if not reviewer:
+        log.info("Dissent required for '%s' but there is no other agent to ask", topic)
+        return answer
+
+    swarm = get_swarm()
+    challenge_id = swarm.request_challenge(
+        chat_id=chat_id,
+        topic_id=topic_id,
+        thread_id=thread_id,
+        root_msg_id=root_msg_id,
+        topic=topic,
+        author_agent=author_agent,
+        reviewer_agent=reviewer,
+        claim=answer,
+    )
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        row = swarm.get_challenge(challenge_id) or {}
+        if row.get("state") == "answered":
+            swarm.incr_metric("dissent_reviews_agree" if row["verdict"] == "agree" else "dissent_reviews_challenge")
+            return format_reviewed_answer(
+                answer,
+                reviewer=reviewer,
+                verdict=row["verdict"],
+                response=row.get("response", ""),
+            )
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
+        # Never sleep past the deadline: the user is waiting on this.
+        await asyncio.sleep(min(DISSENT_POLL_SECONDS, remaining))
+
+    # Nobody answered in time. Closing the row is a compare-and-set, so a
+    # reviewer finishing in this same instant still keeps its verdict recorded.
+    if swarm.timeout_challenge(challenge_id):
+        swarm.incr_metric("dissent_timeouts")
+        log.info("Dissent timeout on '%s': %s did not review in %.0fs", topic, reviewer, timeout)
+        return f"{answer}\n\n{UNREVIEWED_MARK}"
+
+    row = swarm.get_challenge(challenge_id) or {}
+    if row.get("state") == "answered":
+        return format_reviewed_answer(
+            answer,
+            reviewer=reviewer,
+            verdict=row["verdict"],
+            response=row.get("response", ""),
+        )
+    return answer
+
+
+async def run_challenge_intake(agent, swarm, *, reviewer_agent: str, max_per_poll: int = 3) -> int:
+    """Reviewer side: answer pending challenges. Returns how many were handled.
+
+    Called from the council intake pass rather than its own scheduler job — the
+    queue shape is identical and a second 30s poller would buy nothing.
+    """
+    framing = (
+        "Коллега-агент просит ревью своего ответа перед отправкой. Найди самое "
+        "слабое место: неверную предпосылку, пропущенный риск, ошибку в выводе. "
+        "Отвечай КРАТКО (2–3 предложения). Если возражений нет — начни ответ "
+        "словом «Согласен»."
+    )
+
+    handled = 0
+    while handled < max_per_poll:
+        challenge = swarm.accept_next_challenge(reviewer_agent)
+        if challenge is None:
+            break
+        handled += 1
+
+        prompt = (
+            f"Тема: {challenge['topic'] or 'без темы'}\n"
+            f"Автор: {challenge['author_agent']}\n\n"
+            f"Черновик ответа:\n{challenge['claim']}"
+        )
+        try:
+            response = await agent.ainvoke(
+                message=prompt,
+                thread_id=challenge["thread_id"],
+                user_id="dissent",
+                session_id=str(challenge["chat_id"]),
+                # Ephemeral, like a council position: a review is not the user's
+                # turn and must not enter this agent's own history.
+                source_kind="peer_reaction",
+                persist_user_turn=False,
+                extra_system_context=framing,
+            )
+        except Exception as e:
+            log.error("Challenge #%s review failed: %s", challenge["id"], e)
+            continue
+
+        if not response:
+            continue
+        swarm.answer_challenge(
+            challenge["id"],
+            verdict=classify_verdict(response),
+            response=response,
+        )
+
+    return handled

--- a/kronos/group_router.py
+++ b/kronos/group_router.py
@@ -226,6 +226,11 @@ class GroupRouter:
             # Tier 3: auto-react if meaningfully disagree (with guards)
             msg_id = event.message.id
 
+            # Guard 0: quiet mode — out of personal budget, so no volunteering.
+            quiet = self._quiet_reason()
+            if quiet:
+                return RoutingDecision(False, 0, 0, f"quiet mode ({quiet})", addressing=addressing)
+
             # Guard 1: cooldown — max 1 peer reaction per 5 minutes
             now = time.monotonic()
             if now - self._last_peer_reaction < PEER_REACTION_COOLDOWN:
@@ -283,6 +288,13 @@ class GroupRouter:
                 addressing=addressing,
             )
 
+        # Quiet mode: an agent that spent its personal budget still answers when
+        # addressed (Tier 1, above) but stops volunteering. Checked before the
+        # classification and relevance calls, because those are the spend.
+        quiet = self._quiet_reason()
+        if quiet:
+            return RoutingDecision(False, 0, 0, f"quiet mode ({quiet})", addressing=addressing)
+
         # Ownership: recognise the subject before spending a relevance call.
         topic = await self._topic_key(event, text)
         owner = self._topic_owners.get(topic, "")
@@ -333,6 +345,27 @@ class GroupRouter:
             owner_sla_minutes=owner_sla,
         )
 
+    @property
+    def max_implicit_replies(self) -> int:
+        """How many peer replies this agent tolerates before standing down.
+
+        Per-agent override from agents.yaml, so a chatty generalist can be told
+        to yield sooner than the swarm default without changing anyone else.
+        """
+        mine = self._profiles[self.agent_name].max_implicit_replies if self.agent_name in self._profiles else None
+        return MAX_PEER_REPLIES if mine is None else mine
+
+    def _quiet_reason(self) -> str:
+        """Non-empty when this agent has spent its personal daily budget."""
+        try:
+            from kronos.security.cost_guardian import get_guardian
+
+            return get_guardian().quiet_reason(self.agent_name)
+        except Exception as e:  # pragma: no cover - defensive
+            # A budget read must never be the reason an agent goes mute.
+            log.debug("[GroupRouter] Quiet-mode check failed: %s", e)
+            return ""
+
     async def should_still_respond(self, event, client, tier: int) -> bool:
         """Re-check after delay: did too many peers already respond?
 
@@ -342,7 +375,7 @@ class GroupRouter:
         if tier == 1:
             return True
         count = await self._count_peer_replies(event, client)
-        if count >= MAX_PEER_REPLIES:
+        if count >= self.max_implicit_replies:
             log.info(
                 "[GroupRouter] %s: %d peers already replied (tier=%d), skipping",
                 self.agent_name,

--- a/kronos/group_router.py
+++ b/kronos/group_router.py
@@ -50,6 +50,15 @@ MAX_PEER_REPLIES = 2
 # Tier 3: cooldown between peer reactions per agent (seconds).
 PEER_REACTION_COOLDOWN = 300  # 5 minutes
 
+# A peer replying to my message reads as an explicit address, and my answer is
+# itself a reply to them — which is how two agents ping-pong forever. Every
+# other loop guard is bypassed at Tier 1 by design, because Tier 1 exists so the
+# *user's* explicit address is always honoured; a peer's does not earn that.
+# Bounded per window instead: a real exchange gets a couple of turns, a loop
+# cannot outlive the window.
+PEER_EXCHANGE_WINDOW = 600  # 10 minutes
+MAX_PEER_EXCHANGES = 2
+
 # Topic classification is agent-independent and messages repeat (edits, retries),
 # so the lite-tier answer is cached per process for five minutes.
 TOPIC_CACHE_TTL = 300
@@ -221,6 +230,8 @@ class GroupRouter:
         # falsely treat the FIRST reaction as cooled-down and never react.
         self._last_peer_reaction: float = float("-inf")
         self._reacted_to_msgs: set[int] = set()
+        # Monotonic timestamps of Tier-1 replies to peers, for the exchange bound.
+        self._peer_exchanges: list[float] = []
 
         # Ownership map, read once like the alias index above. An empty map is
         # the common case for a registry without `owns`, and it makes every
@@ -272,8 +283,19 @@ class GroupRouter:
 
         # --- Peer bot messages ---
         if is_peer:
-            # Tier 1: explicit @mention from peer → always respond
+            # Tier 1: explicit @mention or reply from a peer → respond, but not
+            # forever: my answer is a reply to them, which reads as an address
+            # back to me on their side.
             if addressing.explicit_to_me:
+                if not self._peer_exchange_allowed():
+                    return RoutingDecision(
+                        False,
+                        0,
+                        0,
+                        f"peer exchange budget spent ({MAX_PEER_EXCHANGES} per {PEER_EXCHANGE_WINDOW}s)",
+                        addressing=addressing,
+                    )
+                self._peer_exchanges.append(time.monotonic())
                 return RoutingDecision(
                     True,
                     random.uniform(3, 8),
@@ -412,6 +434,12 @@ class GroupRouter:
         """
         mine = self._profiles[self.agent_name].max_implicit_replies if self.agent_name in self._profiles else None
         return MAX_PEER_REPLIES if mine is None else mine
+
+    def _peer_exchange_allowed(self) -> bool:
+        """Room left in this window for another Tier-1 reply to a peer."""
+        cutoff = time.monotonic() - PEER_EXCHANGE_WINDOW
+        self._peer_exchanges = [ts for ts in self._peer_exchanges if ts > cutoff]
+        return len(self._peer_exchanges) < MAX_PEER_EXCHANGES
 
     def _quiet_reason(self) -> str:
         """Non-empty when this agent has spent its personal daily budget."""

--- a/kronos/group_router.py
+++ b/kronos/group_router.py
@@ -7,7 +7,12 @@ Tier 1: Explicit addressing (1-5s delay)
   - @mention of my username, reply to my message
 
 Tier 2: Topic relevance (5-20s delay, user messages only)
-  - LLM quick-check: is this my domain? Score 1-10, respond if ≥7
+  - Owner-first: if the message is about a topic this agent `owns`, it answers
+    without the relevance check and on the fast lane, so it wins arbitration
+    against agents who merely find the topic interesting
+  - Otherwise LLM quick-check: is this my domain? Score 1-10, respond if ≥7
+  - A non-owner who would answer an owned topic waits, giving the owner a head
+    start; if the owner is down, the deferred reply still lands
   - Skipped entirely when another known agent is addressed
   - After delay: check if ≥MAX_PEER_REPLIES peers already replied → skip
 
@@ -20,8 +25,16 @@ Cross-agent addressing guard
   - If the user @-addresses specific known agents (by username or alias),
     only those agents pass Tier 1; everyone else skips silently. This is
     the guard that fixes "Impulse answers when Nexus was addressed".
+
+Two kinds of "topic" meet here, and they are not the same thing. A Telegram
+forum topic is routed by id in `bridge_topics` (`TOPIC_*` + `*_agent`): a hard
+assignment where non-owners never even reach this router. What `owns` in
+agents.yaml describes is a *subject* — "planning", "metrics" — recognised from
+the message itself, which is what the shared stream needs, because there every
+agent sees every message.
 """
 
+import hashlib
 import logging
 import random
 import re
@@ -36,6 +49,18 @@ MAX_PEER_REPLIES = 2
 
 # Tier 3: cooldown between peer reactions per agent (seconds).
 PEER_REACTION_COOLDOWN = 300  # 5 minutes
+
+# Topic classification is agent-independent and messages repeat (edits, retries),
+# so the lite-tier answer is cached per process for five minutes.
+TOPIC_CACHE_TTL = 300
+
+# How long a non-owner defers to the topic owner. Bounded below the swarm's
+# CLAIM_EXPIRY_SECONDS on purpose: a claim held longer than that expires and can
+# never win arbitration, so a literal SLA-long sleep would mean "never answer"
+# while still costing a task and an LLM call. Within this window a live owner
+# always wins (their eta is seconds away); past it, an owner whose process is
+# down no longer leaves the user waiting for the escalation job.
+OWNER_DEFERENCE_SECONDS = 90
 
 # Agent profiles loaded from agents.yaml (see agents.example.yaml for format).
 # Usernames can be overridden per-agent via env: AGENT_USERNAME_KRONOS=..., etc.
@@ -82,6 +107,12 @@ class RoutingDecision:
     tier: int  # 0=skip, 1=explicit, 2=relevance, 3=peer-reaction
     reason: str = ""
     addressing: AddressingInfo | None = None
+    # Recognised subject and its owner, when ownership is configured. The
+    # transport uses them to register the SLA watch — including on a skip, so a
+    # topic stays watched even when this agent has nothing to say about it.
+    topic: str = ""
+    topic_owner: str = ""
+    owner_sla_minutes: int = 0
 
 
 # Word-boundary alias matching — stops "импульс" substring from firing on
@@ -136,6 +167,21 @@ class GroupRouter:
         # falsely treat the FIRST reaction as cooled-down and never react.
         self._last_peer_reaction: float = float("-inf")
         self._reacted_to_msgs: set[int] = set()
+
+        # Ownership map, read once like the alias index above. An empty map is
+        # the common case for a registry without `owns`, and it makes every
+        # ownership branch below a no-op — including the classification call.
+        from kronos.swarm_config import all_profiles
+
+        self._profiles = all_profiles()
+        self._topic_owners: dict[str, str] = {}
+        for name, prof in self._profiles.items():
+            for topic in prof.owns:
+                # A contested topic has no single owner; swarm_config warned at
+                # load time and routing falls back to plain relevance.
+                self._topic_owners[topic] = "" if topic in self._topic_owners else name
+        self._topic_owners = {topic: owner for topic, owner in self._topic_owners.items() if owner}
+        self._topic_cache: dict[str, tuple[float, str]] = {}
 
     # ------------------------------------------------------------------
     # Public API
@@ -237,15 +283,43 @@ class GroupRouter:
                 addressing=addressing,
             )
 
-        # Tier 2: Topic relevance → respond with delay
-        relevance = await self._check_relevance(text)
-        if relevance >= 7:
+        # Ownership: recognise the subject before spending a relevance call.
+        topic = await self._topic_key(event, text)
+        owner = self._topic_owners.get(topic, "")
+        owner_sla = self._profiles[owner].sla_minutes if owner in self._profiles else 0
+
+        # Tier 2a: the owner answers its own topic — no relevance threshold, and
+        # on the fast lane so it outranks non-owners in arbitration by eta.
+        if owner and owner == self.agent_name:
             return RoutingDecision(
                 True,
-                random.uniform(5, 20),
+                random.uniform(1, 4),
                 2,
-                f"relevance={relevance}",
+                f"owner of '{topic}'",
                 addressing=addressing,
+                topic=topic,
+                topic_owner=owner,
+                owner_sla_minutes=owner_sla,
+            )
+
+        # Tier 2b: relevance as before.
+        relevance = await self._check_relevance(text)
+        if relevance >= 7:
+            delay = random.uniform(5, 20)
+            reason = f"relevance={relevance}"
+            if owner:
+                # Defer to the owner rather than answering over them.
+                delay = OWNER_DEFERENCE_SECONDS
+                reason = f"relevance={relevance}, deferring to owner {owner} of '{topic}'"
+            return RoutingDecision(
+                True,
+                delay,
+                2,
+                reason,
+                addressing=addressing,
+                topic=topic,
+                topic_owner=owner,
+                owner_sla_minutes=owner_sla,
             )
 
         return RoutingDecision(
@@ -254,6 +328,9 @@ class GroupRouter:
             0,
             f"low relevance={relevance}",
             addressing=addressing,
+            topic=topic,
+            topic_owner=owner,
+            owner_sla_minutes=owner_sla,
         )
 
     async def should_still_respond(self, event, client, tier: int) -> bool:
@@ -395,6 +472,67 @@ class GroupRouter:
         except Exception as e:
             log.warning("[GroupRouter] Relevance check failed: %s", e)
             return 5  # neutral — don't respond on error
+
+    # ------------------------------------------------------------------
+    # Ownership: which declared subject is this message about?
+    # ------------------------------------------------------------------
+
+    async def _topic_key(self, event, text: str) -> str:
+        """One of the topics declared in `owns`, or "" when none applies.
+
+        Free when the registry declares no ownership, which keeps the whole
+        feature invisible to swarms that do not use it.
+        """
+        if not self._topic_owners:
+            return ""
+
+        # An event may name its subject directly (the local swarm bus and eval
+        # scenarios do). Trust it when it matches a declared topic — no LLM.
+        declared = str(getattr(event, "topic_label", "") or "").strip().lower()
+        if declared in self._topic_owners:
+            return declared
+
+        return await self._classify_topic(text)
+
+    async def _classify_topic(self, text: str) -> str:
+        """Lite-tier classification of the message into a declared topic."""
+        if not text.strip():
+            return ""
+
+        topics = sorted(self._topic_owners)
+        cache_key = hashlib.sha256("|".join([text[:500], *topics]).encode("utf-8")).hexdigest()
+        cached = self._topic_cache.get(cache_key)
+        now = time.monotonic()
+        if cached and cached[0] > now:
+            return cached[1]
+
+        from langchain_core.messages import HumanMessage
+
+        from kronos.llm import ModelTier, get_model
+
+        prompt = (
+            "Classify the message into exactly one of these topics:\n"
+            f"{', '.join(topics)}\n"
+            "Reply with ONLY the topic label, or NONE if none of them fits.\n\n"
+            f"Message: {text[:500]}"
+        )
+
+        try:
+            model = get_model(ModelTier.LITE)
+            response = await model.ainvoke([HumanMessage(content=prompt)])
+            raw = response.content if isinstance(response.content, str) else str(response.content)
+            answer = raw.strip().strip(".\"'").lower()
+            # The model can invent a label; only a declared one counts.
+            topic = answer if answer in self._topic_owners else ""
+        except Exception as e:
+            # Fail open: a classification glitch must not silence the swarm.
+            log.warning("[GroupRouter] Topic classification failed: %s", e)
+            return ""
+
+        if len(self._topic_cache) > 500:
+            self._topic_cache.clear()
+        self._topic_cache[cache_key] = (now + TOPIC_CACHE_TTL, topic)
+        return topic
 
     # ------------------------------------------------------------------
     # Tier 3: Peer reaction (LLM, lite model)

--- a/kronos/group_router.py
+++ b/kronos/group_router.py
@@ -115,6 +115,60 @@ class RoutingDecision:
     owner_sla_minutes: int = 0
 
 
+@dataclass
+class EventFacts:
+    """Everything the router reads from an incoming message.
+
+    The one place that knows about Telethon's shape. Extracting it means the
+    in-process swarm bus (and eval scenarios) can drive the real routing logic
+    with a plain object instead of a mock that has to imitate a Telethon event —
+    the tier and arbitration rules below are then provably the same in both.
+    """
+
+    text: str = ""
+    sender_id: int = 0
+    msg_id: int = 0
+    is_reply: bool = False
+    reply_sender_id: int | None = None
+    mentioned_usernames: set[str] = field(default_factory=set)
+    mentioned_user_ids: set[int] = field(default_factory=set)
+    topic_label: str = ""
+
+
+async def event_facts(event) -> EventFacts:
+    """Read an event once: Telethon's, the local bus's, or a test's stub."""
+    if isinstance(event, EventFacts):
+        return event
+
+    facts = EventFacts(
+        text=event.raw_text or "",
+        sender_id=getattr(event, "sender_id", 0) or 0,
+        msg_id=getattr(getattr(event, "message", None), "id", 0) or 0,
+        is_reply=bool(getattr(event, "is_reply", False)),
+        topic_label=str(getattr(event, "topic_label", "") or ""),
+    )
+
+    from telethon.tl.types import MessageEntityMention, MessageEntityMentionName
+
+    entities = getattr(getattr(event, "message", None), "entities", None) or []
+    for ent in entities:
+        if isinstance(ent, MessageEntityMentionName):
+            facts.mentioned_user_ids.add(ent.user_id)
+        elif isinstance(ent, MessageEntityMention):
+            raw = facts.text[ent.offset : ent.offset + ent.length]
+            facts.mentioned_usernames.add(raw.lstrip("@").lower())
+
+    if facts.is_reply:
+        try:
+            replied = await event.get_reply_message()
+        except Exception:
+            replied = None
+        if replied is not None:
+            facts.reply_sender_id = getattr(replied, "sender_id", None)
+
+    return facts
+
+
 # Word-boundary alias matching — stops "импульс" substring from firing on
 # unrelated words. Accepts letters/numbers/underscore on either side as
 # non-match, unicode-aware via re.UNICODE (default in py3).
@@ -188,15 +242,20 @@ class GroupRouter:
     # ------------------------------------------------------------------
 
     async def decide(self, event, client) -> RoutingDecision:
-        """Main entry: should this agent respond to the group message?"""
-        text = event.raw_text or ""
-        sender_id = event.sender_id
+        """Main entry: should this agent respond to the group message?
+
+        Accepts a Telethon event or an EventFacts — the local swarm bus passes
+        the latter, so demos and eval scenarios exercise this exact logic.
+        """
+        facts = await event_facts(event)
+        text = facts.text
+        sender_id = facts.sender_id
 
         # Never respond to self
         if sender_id == self.my_id:
             return RoutingDecision(False, 0, 0, "own message")
 
-        addressing = await self._analyze_addressing(event, text)
+        addressing = self._addressing_from_facts(facts)
         is_peer = self._is_peer(sender_id)
 
         # --- Cross-agent addressing guard (fires for both user and peer src) ---
@@ -224,7 +283,7 @@ class GroupRouter:
                 )
 
             # Tier 3: auto-react if meaningfully disagree (with guards)
-            msg_id = event.message.id
+            msg_id = facts.msg_id
 
             # Guard 0: quiet mode — out of personal budget, so no volunteering.
             quiet = self._quiet_reason()
@@ -242,8 +301,7 @@ class GroupRouter:
 
             # Guard 3: Tier 3 requires a user-root. Peer-to-peer chains do
             # not trigger reactions (otherwise bots debate each other forever).
-            replied_to_user = await self._peer_replies_to_user(event)
-            if not replied_to_user:
+            if not self._facts_reply_to_user(facts):
                 return RoutingDecision(
                     False,
                     0,
@@ -296,7 +354,7 @@ class GroupRouter:
             return RoutingDecision(False, 0, 0, f"quiet mode ({quiet})", addressing=addressing)
 
         # Ownership: recognise the subject before spending a relevance call.
-        topic = await self._topic_key(event, text)
+        topic = await self._topic_key(facts, text)
         owner = self._topic_owners.get(topic, "")
         owner_sla = self._profiles[owner].sla_minutes if owner in self._profiles else 0
 
@@ -390,27 +448,24 @@ class GroupRouter:
     # ------------------------------------------------------------------
 
     async def _analyze_addressing(self, event, text: str) -> AddressingInfo:
+        """Kept for callers that hold an event; the logic lives on facts."""
+        return self._addressing_from_facts(await event_facts(event))
+
+    def _addressing_from_facts(self, facts: "EventFacts") -> AddressingInfo:
         info = AddressingInfo()
-        text_lower = text.lower()
+        text_lower = facts.text.lower()
 
         # 1. Telegram mention entities — authoritative for @username and
         #    MentionName (explicit user_id resolution).
-        from telethon.tl.types import MessageEntityMention, MessageEntityMentionName
-
-        entities = event.message.entities or []
-        for ent in entities:
-            if isinstance(ent, MessageEntityMentionName):
-                if ent.user_id == self.my_id:
-                    info.explicit_to_me = True
-                    info.target_agents.add(self.agent_name)
-            elif isinstance(ent, MessageEntityMention):
-                raw = event.raw_text[ent.offset : ent.offset + ent.length]
-                uname = raw.lstrip("@").lower()
-                if uname == self.my_username:
-                    info.explicit_to_me = True
-                    info.target_agents.add(self.agent_name)
-                elif uname in self._username_to_agent:
-                    info.target_agents.add(self._username_to_agent[uname])
+        if self.my_id in facts.mentioned_user_ids:
+            info.explicit_to_me = True
+            info.target_agents.add(self.agent_name)
+        for uname in facts.mentioned_usernames:
+            if uname == self.my_username:
+                info.explicit_to_me = True
+                info.target_agents.add(self.agent_name)
+            elif uname in self._username_to_agent:
+                info.target_agents.add(self._username_to_agent[uname])
 
         # 2. Fallback: raw-text @username scan (covers cases where the
         #    message came through a path without entities).
@@ -428,15 +483,10 @@ class GroupRouter:
                     info.explicit_to_me = True
 
         # 4. Reply-to-me
-        if event.is_reply:
-            try:
-                replied = await event.get_reply_message()
-                if replied is not None and replied.sender_id == self.my_id:
-                    info.reply_to_me = True
-                    info.explicit_to_me = True
-                    info.target_agents.add(self.agent_name)
-            except Exception:
-                pass
+        if facts.is_reply and facts.reply_sender_id == self.my_id:
+            info.reply_to_me = True
+            info.explicit_to_me = True
+            info.target_agents.add(self.agent_name)
 
         info.explicit_to_other = bool(info.target_agents) and self.agent_name not in info.target_agents
         return info
@@ -445,26 +495,18 @@ class GroupRouter:
     # Tier 3 guard: peer must reply to a user-root message
     # ------------------------------------------------------------------
 
-    async def _peer_replies_to_user(self, event) -> bool:
-        """True if this peer message is a reply to a user message.
+    def _facts_reply_to_user(self, facts: EventFacts) -> bool:
+        """True if this peer message is a reply to a whitelisted user.
 
-        Also accepts the case where the peer message is standalone (no reply)
-        only if it appeared right after a user message — we approximate that
-        by saying: if there's no reply linkage at all, treat as NOT user-rooted.
-        This is stricter than before and intentionally so; it prevents bots
-        from reacting to each other without a user anchor.
+        A peer message with no reply linkage is NOT treated as user-rooted. That
+        is deliberately strict: it prevents bots from reacting to each other
+        without a user anchor.
         """
-        if not event.is_reply:
-            return False
-        try:
-            replied = await event.get_reply_message()
-            if replied is None:
-                return False
-            # If the message being replied to is from a whitelisted user,
-            # this is a user-rooted thread.
-            return replied.sender_id in self.allowed_user_ids
-        except Exception:
-            return False
+        return facts.is_reply and facts.reply_sender_id in self.allowed_user_ids
+
+    async def _peer_replies_to_user(self, event) -> bool:
+        """Event-level wrapper around the fact check above."""
+        return self._facts_reply_to_user(await event_facts(event))
 
     # ------------------------------------------------------------------
     # Sender classification
@@ -514,12 +556,13 @@ class GroupRouter:
         """One of the topics declared in `owns`, or "" when none applies.
 
         Free when the registry declares no ownership, which keeps the whole
-        feature invisible to swarms that do not use it.
+        feature invisible to swarms that do not use it. Takes an EventFacts or
+        anything with a `topic_label`.
         """
         if not self._topic_owners:
             return ""
 
-        # An event may name its subject directly (the local swarm bus and eval
+        # A message may name its subject directly (the local swarm bus and eval
         # scenarios do). Trust it when it matches a declared topic — no LLM.
         declared = str(getattr(event, "topic_label", "") or "").strip().lower()
         if declared in self._topic_owners:

--- a/kronos/group_router.py
+++ b/kronos/group_router.py
@@ -23,13 +23,10 @@ Cross-agent addressing guard
 """
 
 import logging
-import os
 import random
 import re
 import time
 from dataclasses import dataclass, field
-
-import yaml
 
 log = logging.getLogger("kronos.group_router")
 
@@ -45,32 +42,16 @@ PEER_REACTION_COOLDOWN = 300  # 5 minutes
 
 
 def _load_profiles() -> dict[str, dict]:
-    """Load agent profiles from agents.yaml, apply env overrides."""
-    config_path = os.environ.get(
-        "AGENTS_CONFIG_PATH",
-        os.path.join(os.path.dirname(__file__), "..", "agents.yaml"),
-    )
-    config_path = os.path.normpath(config_path)
+    """Load agent profiles from agents.yaml, apply env overrides.
 
-    if os.path.exists(config_path):
-        with open(config_path, encoding="utf-8") as f:
-            raw = yaml.safe_load(f) or {}
-    else:
-        log.warning("agents.yaml not found at %s — using empty profile set", config_path)
-        raw = {}
+    Parsing and validation live in `kronos.swarm_config`; the router keeps the
+    plain-dict shape because tools index it by key and tests replace it
+    wholesale. `swarm_config.profile_for()` gives the typed view of an entry
+    when the extended fields (ownership, SLA, budget) matter.
+    """
+    from kronos.swarm_config import load_profiles
 
-    resolved: dict[str, dict] = {}
-    for name, base in raw.items():
-        username = os.environ.get(
-            f"AGENT_USERNAME_{name.upper()}",
-            base.get("username", f"{name}agnt"),
-        )
-        resolved[name] = {
-            "username": username.lower().lstrip("@"),
-            "aliases": [a.lower() for a in base.get("aliases", [name])],
-            "role": base.get("role", ""),
-        }
-    return resolved
+    return {name: profile.model_dump() for name, profile in load_profiles().items()}
 
 
 AGENT_PROFILES: dict[str, dict] = _load_profiles()

--- a/kronos/security/cost_guardian.py
+++ b/kronos/security/cost_guardian.py
@@ -4,6 +4,13 @@ The daily cap reads the shared swarm cost ledger (``swarm_costs``), so the
 limit is swarm-wide rather than per-process; the session cap reads a
 per-process tally fed by the cost-tracking callback. Blocks requests when
 either limit is exceeded.
+
+On top of those, an agent may have a personal daily slice (``budget_usd_daily``
+in agents.yaml, overridable by ``budgets.per_agent_daily_usd`` in the policy).
+Exhausting it does **not** block: it puts the agent in quiet mode, where it
+still answers when addressed directly but stops volunteering. A hard stop would
+mean the user's explicit question goes unanswered because the agent spent its
+allowance on unprompted opinions, which is the wrong thing to protect.
 """
 
 import logging
@@ -37,6 +44,17 @@ DEFAULT_SESSION_LIMIT_USD = 1.0
 # (soft) instead of blocking — the hard block stays at 100%. Overridable via
 # policy.budgets.degrade_at_fraction; kept as the code default.
 DEGRADE_RATIO = 0.8
+
+
+def _swarm_per_agent_cost() -> dict[str, float]:
+    """Today's spend per agent from the shared ledger. Fails open (empty)."""
+    try:
+        from kronos.swarm_store import get_swarm
+
+        return get_swarm().per_agent_daily_cost()
+    except Exception as e:  # pragma: no cover - defensive
+        log.debug("Swarm per-agent cost read failed, treating as $0: %s", e)
+        return {}
 
 
 def _policy_budgets():
@@ -105,10 +123,63 @@ class CostGuardian:
         """True once daily spend crosses the policy degrade fraction.
 
         Soft degradation: keep answering (cheaper) instead of blocking, until
-        the hard daily limit in check_budget kicks in.
+        the hard daily limit in check_budget kicks in. An agent that burned most
+        of its *personal* slice degrades too, even while the swarm total is
+        comfortable — otherwise the first agent to wake up spends at full price
+        until the shared budget is gone.
         """
+        fraction = _policy_budgets().degrade_at_fraction
         daily_cost = _swarm_daily_cost().get("cost_usd", 0)
-        return daily_cost >= self.daily_limit * _policy_budgets().degrade_at_fraction
+        if daily_cost >= self.daily_limit * fraction:
+            return True
+
+        personal_limit = self.personal_limit()
+        return bool(personal_limit) and self.personal_spend() >= personal_limit * fraction
+
+    # ------------------------------------------------------------------
+    # Personal slice of the swarm budget (moat 11.3)
+    # ------------------------------------------------------------------
+
+    def personal_limit(self, agent: str = "") -> float:
+        """This agent's own daily cap. 0 means "only the swarm cap applies".
+
+        Precedence matches the rest of the governance stack: an explicit policy
+        entry overrides what the registry declares.
+        """
+        from kronos.config import settings
+
+        name = agent or settings.agent_name
+        from_policy = _policy_budgets().per_agent_daily_usd.get(name)
+        if from_policy:
+            return float(from_policy)
+
+        try:
+            from kronos.swarm_config import profile_for
+
+            return float(profile_for(name).budget_usd_daily)
+        except Exception as e:  # pragma: no cover - defensive
+            log.debug("Could not read the agent profile budget: %s", e)
+            return 0.0
+
+    def personal_spend(self, agent: str = "") -> float:
+        from kronos.config import settings
+
+        name = agent or settings.agent_name
+        return float(_swarm_per_agent_cost().get(name, 0.0))
+
+    def quiet_reason(self, agent: str = "") -> str:
+        """Why this agent should stay quiet, or "" when it may volunteer.
+
+        Quiet mode is deliberately one-way information: the router asks before
+        spending a relevance call, which is where the saving is.
+        """
+        limit = self.personal_limit(agent)
+        if limit <= 0:
+            return ""
+        spent = self.personal_spend(agent)
+        if spent < limit:
+            return ""
+        return f"personal daily budget spent: ${spent:.2f} / ${limit:.2f}"
 
     def get_status(self) -> dict:
         """Get current cost status."""
@@ -118,6 +189,9 @@ class CostGuardian:
             "daily_limit": self.daily_limit,
             "daily_requests": daily.get("requests", 0),
             "session_count": len(self._session_costs),
+            "personal_cost": self.personal_spend(),
+            "personal_limit": self.personal_limit(),
+            "quiet": bool(self.quiet_reason()),
         }
 
 

--- a/kronos/swarm_config.py
+++ b/kronos/swarm_config.py
@@ -1,0 +1,264 @@
+"""The swarm's org chart as a validated config file.
+
+`agents.yaml` used to answer one question: which @username belongs to which
+agent. That is enough to stop two agents from answering the same message, but
+not enough to make them a team — nobody owns a topic, silence has no
+consequence, and one agent can spend the whole swarm's daily budget.
+
+This module extends the same file with the organisational facts:
+
+* `owns` — topics where this agent answers without waiting for a relevance
+  score, and wins arbitration against agents who merely find the topic
+  interesting.
+* `escalates_to` — who picks the topic up when the owner stays silent.
+* `sla_minutes` — how long "silent" is.
+* `budget_usd_daily` — the agent's own slice of the swarm budget.
+* `dissent` — whether a final answer here needs a challenge from another role.
+* `max_implicit_replies` — per-agent override of the global implicit-reply cap.
+
+**Absent fields keep today's behaviour.** A file written before this module
+loads with defaults that make the extended routing a no-op, which is what makes
+this safe to ship to a running swarm.
+
+Validation is deliberately split. A broken `escalates_to` is an error: it names
+a delivery path that does not exist, so failing loudly beats routing an
+escalation into the void. Overlapping ownership and over-committed budgets are
+warnings: both are legitimate transitional states (two agents sharing a topic
+during a handover; a budget sum above the cap when the cap is about to be
+raised), and refusing to start would be worse than saying so in the log.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+log = logging.getLogger("kronos.swarm_config")
+
+DEFAULT_AGENTS_FILE = "agents.yaml"
+ENV_AGENTS_FILE = "AGENTS_CONFIG_PATH"
+
+DISSENT_MODES = ("allow", "require")
+
+# Owner-first routing defaults. 15 minutes is short enough that a silent owner
+# does not strand the user, long enough that a non-owner does not answer over
+# the specialist while they are still typing.
+DEFAULT_SLA_MINUTES = 15
+
+
+class SwarmConfigError(Exception):
+    """Raised when agents.yaml cannot be loaded or contradicts itself."""
+
+
+class AgentProfile(BaseModel):
+    """One agent's entry in the swarm registry."""
+
+    username: str = ""
+    aliases: list[str] = Field(default_factory=list)
+    role: str = ""
+
+    owns: list[str] = Field(default_factory=list)
+    escalates_to: str = ""
+    sla_minutes: int = DEFAULT_SLA_MINUTES
+    # 0 means "no personal cap" — the agent is bounded only by the swarm budget.
+    budget_usd_daily: float = 0.0
+    dissent: str = "allow"
+    # None means "use the router's global cap" rather than "no replies".
+    max_implicit_replies: int | None = None
+
+    @field_validator("username")
+    @classmethod
+    def _normalise_username(cls, value: str) -> str:
+        return value.lower().lstrip("@")
+
+    @field_validator("aliases")
+    @classmethod
+    def _normalise_aliases(cls, value: list[str]) -> list[str]:
+        return [alias.lower() for alias in value]
+
+    @field_validator("owns")
+    @classmethod
+    def _normalise_topics(cls, value: list[str]) -> list[str]:
+        return [topic.strip().lower() for topic in value if topic.strip()]
+
+    @field_validator("dissent")
+    @classmethod
+    def _known_dissent_mode(cls, value: str) -> str:
+        if value not in DISSENT_MODES:
+            raise ValueError(f"dissent must be one of {DISSENT_MODES}, got {value!r}")
+        return value
+
+    @field_validator("sla_minutes")
+    @classmethod
+    def _positive_sla(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("sla_minutes must be positive")
+        return value
+
+    @field_validator("budget_usd_daily")
+    @classmethod
+    def _non_negative_budget(cls, value: float) -> float:
+        if value < 0:
+            raise ValueError("budget_usd_daily cannot be negative")
+        return value
+
+    @field_validator("max_implicit_replies")
+    @classmethod
+    def _non_negative_cap(cls, value: int | None) -> int | None:
+        if value is not None and value < 0:
+            raise ValueError("max_implicit_replies cannot be negative")
+        return value
+
+    def owns_topic(self, topic: str) -> bool:
+        """Case-insensitive membership — topics arrive from chat, not from code."""
+        return bool(topic) and topic.strip().lower() in self.owns
+
+
+def profile_from_dict(name: str, raw: dict[str, Any]) -> AgentProfile:
+    """Coerce one registry entry into a profile, applying env overrides.
+
+    Tolerates entries that predate the extended schema (and the bare dicts that
+    tests inject into ``AGENT_PROFILES``) — every new field has a default.
+    """
+    if raw and not isinstance(raw, dict):
+        raise SwarmConfigError(f"agent '{name}' must be a mapping of fields, got {type(raw).__name__}")
+    data = dict(raw or {})
+    username = os.environ.get(
+        f"AGENT_USERNAME_{name.upper()}",
+        data.get("username") or f"{name}agnt",
+    )
+    data["username"] = username
+    if not data.get("aliases"):
+        data["aliases"] = [name]
+    try:
+        return AgentProfile(**data)
+    except ValidationError as e:
+        raise SwarmConfigError(f"agent '{name}' has an invalid profile: {e}") from e
+
+
+def agents_file_path(path: str | Path | None = None) -> Path:
+    """Where the registry lives: explicit argument > env > package-relative."""
+    if path is not None:
+        return Path(path)
+    from_env = os.environ.get(ENV_AGENTS_FILE)
+    if from_env:
+        return Path(from_env)
+    return (Path(__file__).resolve().parent.parent / DEFAULT_AGENTS_FILE).resolve()
+
+
+def load_profiles(path: str | Path | None = None) -> dict[str, AgentProfile]:
+    """Load and validate the registry.
+
+    A missing file yields an empty swarm (the packaged distribution ships
+    without one), an unparsable or self-contradicting file raises.
+    """
+    config_path = agents_file_path(path)
+
+    if not config_path.exists():
+        log.warning("agents.yaml not found at %s — using empty profile set", config_path)
+        return {}
+
+    try:
+        raw = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as e:
+        raise SwarmConfigError(f"{config_path} is not valid YAML: {e}") from e
+
+    if not isinstance(raw, dict):
+        raise SwarmConfigError(f"{config_path} must map agent names to profiles, got {type(raw).__name__}")
+
+    profiles = {name: profile_from_dict(name, entry) for name, entry in raw.items()}
+    validate_profiles(profiles)
+    return profiles
+
+
+def validate_profiles(profiles: dict[str, AgentProfile]) -> list[str]:
+    """Check cross-agent consistency. Raises on errors, returns warnings."""
+    for name, profile in profiles.items():
+        target = profile.escalates_to
+        if not target:
+            continue
+        if target == name:
+            raise SwarmConfigError(f"agent '{name}' escalates to itself — escalation would never leave the agent")
+        if target not in profiles:
+            known = ", ".join(sorted(profiles)) or "none"
+            raise SwarmConfigError(f"agent '{name}' escalates to unknown agent '{target}' (known agents: {known})")
+
+    warnings = _ownership_warnings(profiles) + _budget_warnings(profiles)
+    for warning in warnings:
+        log.warning("agents.yaml: %s", warning)
+    return warnings
+
+
+def _ownership_warnings(profiles: dict[str, AgentProfile]) -> list[str]:
+    """Two owners for one topic is legal but ambiguous — say so once per topic."""
+    owners: dict[str, list[str]] = {}
+    for name, profile in profiles.items():
+        for topic in profile.owns:
+            owners.setdefault(topic, []).append(name)
+
+    return [
+        f"topic '{topic}' is owned by {', '.join(sorted(names))} — arbitration between them falls back to relevance"
+        for topic, names in sorted(owners.items())
+        if len(names) > 1
+    ]
+
+
+def _budget_warnings(profiles: dict[str, AgentProfile]) -> list[str]:
+    """Per-agent budgets summing above the swarm cap cannot all be spent."""
+    committed = sum(profile.budget_usd_daily for profile in profiles.values())
+    if committed <= 0:
+        return []
+    try:
+        from kronos.policy import get_policy
+
+        swarm_limit = get_policy().budgets.daily_usd
+    except Exception as e:  # pragma: no cover - policy is optional at load time
+        log.debug("Could not read the swarm budget while validating agents.yaml: %s", e)
+        return []
+
+    if committed > swarm_limit:
+        return [
+            f"per-agent budgets total ${committed:.2f}, above the swarm daily cap ${swarm_limit:.2f} — "
+            f"the swarm limit will bind first"
+        ]
+    return []
+
+
+def all_profiles() -> dict[str, AgentProfile]:
+    """Extended view of the live registry.
+
+    `group_router.AGENT_PROFILES` stays a dict of plain dicts — tools index it
+    by key and tests replace its contents wholesale — so the typed view is
+    derived on demand instead of becoming a second source of truth.
+    """
+    from kronos.group_router import AGENT_PROFILES
+
+    return {name: profile_from_dict(name, raw) for name, raw in AGENT_PROFILES.items()}
+
+
+def profile_for(agent_name: str) -> AgentProfile:
+    """Extended profile for one agent (defaults when it is not registered)."""
+    from kronos.group_router import AGENT_PROFILES
+
+    return profile_from_dict(agent_name, AGENT_PROFILES.get(agent_name, {}))
+
+
+def escalation_target(profiles: dict[str, AgentProfile], agent_name: str) -> str:
+    """Who covers for this agent. Empty string means "nobody"."""
+    profile = profiles.get(agent_name)
+    return profile.escalates_to if profile else ""
+
+
+def topic_owner(profiles: dict[str, AgentProfile], topic: str) -> str:
+    """The single owner of a topic, or "" when unowned or contested.
+
+    Contested topics deliberately return "" — the ownership shortcut only makes
+    sense when it points at one agent, and `validate_profiles` already warned.
+    """
+    if not topic:
+        return ""
+    owners = [name for name, profile in profiles.items() if profile.owns_topic(topic)]
+    return owners[0] if len(owners) == 1 else ""

--- a/kronos/swarm_local.py
+++ b/kronos/swarm_local.py
@@ -1,0 +1,274 @@
+"""The swarm without Telegram (moat 11.5).
+
+Coordination was physically tied to one transport: `GroupRouter.decide` took a
+Telethon event and the pollers delivered through the bridge's webhook. That made
+the most distinctive part of this system the least demonstrable — you could not
+show arbitration, ownership or escalation without six Telegram accounts, and none
+of it could go into an eval.
+
+This module runs the same routing in one process against a real `swarm.db`. It is
+a bus, not a second implementation: the tier rules, the ownership shortcut and the
+claim arbitration are the production ones, reached through `EventFacts` (see
+`group_router.event_facts`). What it deliberately does not reproduce:
+
+* **Real delays.** Claims are ordered by their eta and resolved immediately, so a
+  round is instant. Production sleeps.
+* **The post-delay peer recount.** That reads chat history through a Telegram
+  client; here the claim ledger is the only source of truth, which is the
+  stricter of the two checks anyway.
+* **Model calls.** Replies, relevance and peer reactions come from deterministic
+  callbacks — a demo must not need provider keys.
+"""
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from kronos.group_router import EventFacts, GroupRouter
+from kronos.swarm_store import SwarmStore
+
+log = logging.getLogger("kronos.swarm_local")
+
+DEMO_CHAT_ID = -100_900_001
+DEMO_TOPIC_ID = 0
+USER_ID = 1
+
+ReplyFn = Callable[[str, str], str]  # (agent_name, incoming text) -> reply
+RelevanceFn = Callable[[str, str], int]  # (agent_name, incoming text) -> 1..10
+ReactFn = Callable[[str, str], bool]  # (agent_name, peer text) -> react?
+
+
+def _default_reply(agent: str, text: str) -> str:
+    """Name-free on purpose.
+
+    An agent's own alias inside a message body is read by the router as an
+    address to that agent, so "[nexus] ..." in a reply would make every peer skip
+    the thread as "addressed to nexus". Who spoke is in the transcript instead.
+    """
+    return f"Отвечаю по своей части: {text[:60]}"
+
+
+def _default_relevance(agent: str, text: str) -> int:
+    """Deterministic stand-in for the lite-tier relevance call."""
+    return 8 if agent.lower() in text.lower() else 4
+
+
+def _never_react(agent: str, text: str) -> bool:
+    return False
+
+
+@dataclass
+class LocalAgent:
+    """One participant: its router plus how it answers."""
+
+    name: str
+    router: GroupRouter
+    reply: ReplyFn = _default_reply
+    relevance: RelevanceFn = _default_relevance
+    react: ReactFn = _never_react
+
+
+@dataclass
+class LocalSwarmBus:
+    """In-process message bus over the real swarm ledger."""
+
+    store: SwarmStore
+    chat_id: int = DEMO_CHAT_ID
+    topic_id: int = DEMO_TOPIC_ID
+    agents: dict[str, LocalAgent] = field(default_factory=dict)
+    transcript: list[dict] = field(default_factory=list)
+    _next_msg_id: int = 1000
+    _sender_ids: dict[str, int] = field(default_factory=dict)
+    # msg_id → the user message this message belongs to (Tier 3 claims attach
+    # to the root, exactly as the bridge resolves it from reply_to).
+    _root_of: dict[int, int] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Wiring
+    # ------------------------------------------------------------------
+
+    def add_agent(
+        self,
+        name: str,
+        *,
+        username: str = "",
+        reply: ReplyFn | None = None,
+        relevance: RelevanceFn | None = None,
+        react: ReactFn | None = None,
+    ) -> LocalAgent:
+        """Register an agent. Its sender id comes from the join order."""
+        sender_id = 2000 + len(self.agents)
+        self._sender_ids[name] = sender_id
+        router = GroupRouter(
+            agent_name=name,
+            my_id=sender_id,
+            my_username=username or f"{name}agnt",
+            allowed_user_ids={USER_ID},
+        )
+        agent = LocalAgent(
+            name=name,
+            router=router,
+            reply=reply or _default_reply,
+            relevance=relevance or _default_relevance,
+            react=react or _never_react,
+        )
+        # Point the router's model hooks at the callbacks: a local round must be
+        # deterministic and key-free. Topic recognition uses the message's label.
+        router._check_relevance = _as_async(lambda text: agent.relevance(name, text))
+        router._classify_topic = _as_async(lambda text: "")
+        router._should_react_to_peer = _as_async(lambda text: agent.react(name, text))
+        self.agents[name] = agent
+        return agent
+
+    # ------------------------------------------------------------------
+    # Traffic
+    # ------------------------------------------------------------------
+
+    def post(self, agent: str | None, text: str, *, topic_label: str = "", reply_to: int | None = None) -> EventFacts:
+        """Put a message on the bus. `agent=None` means the user."""
+        self._next_msg_id += 1
+        msg_id = self._next_msg_id
+        sender_id = USER_ID if agent is None else self._sender_ids[agent]
+
+        self.store.record_inbound_message(
+            chat_id=self.chat_id,
+            topic_id=self.topic_id,
+            msg_id=msg_id,
+            reply_to_msg_id=reply_to,
+            sender_id=sender_id,
+            sender_type="user" if agent is None else "agent",
+            agent_name=agent,
+            text=text,
+        )
+        self.transcript.append({"from": agent or "user", "text": text, "msg_id": msg_id})
+        self._root_of[msg_id] = msg_id if agent is None else self._root_of.get(reply_to or 0, reply_to or msg_id)
+
+        return EventFacts(
+            text=text,
+            sender_id=sender_id,
+            msg_id=msg_id,
+            is_reply=reply_to is not None,
+            reply_sender_id=self._sender_of(reply_to),
+            topic_label=topic_label,
+        )
+
+    async def run_round(self, facts: EventFacts) -> list[dict]:
+        """Route one message through every agent; return what was actually sent.
+
+        Mirrors the bridge: decide → claim → arbitrate → send, with the claims
+        resolved in eta order instead of after a real sleep.
+        """
+        candidates: list[tuple] = []
+        for agent in self.agents.values():
+            if agent.router.my_id == facts.sender_id:
+                continue
+
+            decision = await agent.router.decide(facts, client=None)
+            root_msg_id = self._root_msg_id(facts, decision.tier)
+
+            if decision.topic_owner:
+                self.store.watch_sla(
+                    chat_id=self.chat_id,
+                    topic_id=self.topic_id,
+                    root_msg_id=root_msg_id,
+                    thread_id=self._thread_id(),
+                    topic=decision.topic,
+                    owner_agent=decision.topic_owner,
+                    request=facts.text,
+                    sla_minutes=decision.owner_sla_minutes,
+                )
+
+            if not decision.should_respond:
+                log.debug("[local] %s skips: %s", agent.name, decision.reason)
+                continue
+
+            self.store.claim_reply(
+                chat_id=self.chat_id,
+                topic_id=self.topic_id,
+                root_msg_id=root_msg_id,
+                trigger_msg_id=facts.msg_id,
+                agent_name=agent.name,
+                tier=decision.tier,
+                eta_ts=decision.delay,  # relative: a round has no wall clock
+                reason=decision.reason,
+            )
+            candidates.append((decision, agent, root_msg_id))
+
+        sent: list[dict] = []
+        # Earliest eta first — the order the real ledger arbitrates by, so the
+        # owner's fast lane wins here for the same reason it wins in production.
+        for decision, agent, root_msg_id in sorted(candidates, key=lambda item: item[0].delay):
+            outcome = self.store.can_send_claim(
+                chat_id=self.chat_id,
+                topic_id=self.topic_id,
+                root_msg_id=root_msg_id,
+                agent_name=agent.name,
+                tier=decision.tier,
+                max_implicit_replies=agent.router.max_implicit_replies,
+            )
+            if not outcome.won:
+                self.store.cancel_claim(
+                    chat_id=self.chat_id,
+                    topic_id=self.topic_id,
+                    trigger_msg_id=facts.msg_id,
+                    agent_name=agent.name,
+                    reason=outcome.reason,
+                )
+                self.store.incr_metric("duplicate_replies_avoided")
+                log.debug("[local] %s stands down: %s", agent.name, outcome.reason)
+                continue
+
+            text = agent.reply(agent.name, facts.text)
+            reply_facts = self.post(agent.name, text, reply_to=facts.msg_id)
+            self.store.mark_sent(
+                chat_id=self.chat_id,
+                topic_id=self.topic_id,
+                trigger_msg_id=facts.msg_id,
+                agent_name=agent.name,
+                reply_msg_id=reply_facts.msg_id,
+            )
+            sent.append(
+                {
+                    "agent": agent.name,
+                    "tier": decision.tier,
+                    "reason": decision.reason,
+                    "text": text,
+                    "msg_id": reply_facts.msg_id,
+                    "reply_facts": reply_facts,
+                }
+            )
+        return sent
+
+    async def user_says(self, text: str, *, topic_label: str = "") -> list[dict]:
+        """Convenience: post as the user, then run the round."""
+        return await self.run_round(self.post(None, text, topic_label=topic_label))
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _thread_id(self) -> str:
+        return f"{self.chat_id}:{self.topic_id}" if self.topic_id else str(self.chat_id)
+
+    def _sender_of(self, msg_id: int | None) -> int | None:
+        if msg_id is None:
+            return None
+        for entry in self.transcript:
+            if entry["msg_id"] == msg_id:
+                return USER_ID if entry["from"] == "user" else self._sender_ids.get(entry["from"])
+        return None
+
+    def _root_msg_id(self, facts: EventFacts, tier: int) -> int:
+        """Tier 3 claims attach to the user message the peer replied to."""
+        if tier == 3:
+            return self._root_of.get(facts.msg_id, facts.msg_id)
+        return facts.msg_id
+
+
+def _as_async(fn):
+    """Wrap a sync callback so it can stand in for the router's async hooks."""
+
+    async def _call(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return _call

--- a/kronos/swarm_report.py
+++ b/kronos/swarm_report.py
@@ -1,0 +1,289 @@
+"""Weekly post-mortem of the swarm (moat 11.4).
+
+Every number here already existed in the ledger; what was missing was one place
+that puts them next to each other. "Impulse answered 40 times" means little on
+its own — next to "cost per reply $0.12" and "two 👎, zero 👍" it becomes a
+decision about whether Impulse should be quieter.
+
+Reads only. Sources, all shared: `reply_claims` (who answered, at which tier),
+`swarm_costs` (spend per agent), `feedback` (reactions), `sla_watch`
+(owned-topic deadlines and escalations), `handoffs`, `council_sessions`,
+`challenges`, `swarm_metrics`.
+
+Deliberately absent: cost per topic. Spend is recorded per agent and per day,
+never attributed to a subject, so a "most expensive topics" table would be an
+invention. Owned topics are reported by activity and missed SLAs instead —
+numbers that exist.
+"""
+
+import time
+
+from kronos.swarm_store import get_swarm
+
+PERIOD_DAYS = {"day": 1, "week": 7, "month": 30}
+DEFAULT_PERIOD = "week"
+
+
+def _period_days(period: str) -> int:
+    if period not in PERIOD_DAYS:
+        raise ValueError(f"unknown period '{period}' (expected one of {', '.join(PERIOD_DAYS)})")
+    return PERIOD_DAYS[period]
+
+
+def build_report(period: str = DEFAULT_PERIOD, *, now: float | None = None) -> dict:
+    """Collect the period's swarm activity into one structure."""
+    days = _period_days(period)
+    now = time.time() if now is None else now
+    since_ts = now - days * 86400
+    since_day = time.strftime("%Y-%m-%d", time.gmtime(since_ts))
+
+    swarm = get_swarm()
+
+    replies = swarm.replies_by_agent(since_ts=since_ts)
+    costs = swarm.costs_by_agent(since_day=since_day)
+    watches = swarm.sla_watches(since_ts=since_ts, limit=1000)
+    handoffs = swarm.handoffs_since(since_ts=since_ts)
+    councils = swarm.councils_since(since_ts=since_ts)
+    challenges = swarm.challenges(since_ts=since_ts, limit=1000)
+
+    agents = _agent_rows(replies, costs, swarm, days)
+
+    return {
+        "period": period,
+        "days": days,
+        "since": time.strftime("%Y-%m-%d %H:%M UTC", time.gmtime(since_ts)),
+        "generated_at": time.strftime("%Y-%m-%d %H:%M UTC", time.gmtime(now)),
+        "agents": agents,
+        "totals": _totals(agents),
+        "tiers": _tier_totals(replies),
+        "collaboration": {
+            "handoffs": len(handoffs),
+            "handoffs_done": sum(1 for h in handoffs if h["state"] == "done"),
+            "handoffs_failed": sum(1 for h in handoffs if h["state"] == "failed"),
+            "councils": len(councils),
+            "reviews": len(challenges),
+            "objections": sum(1 for c in challenges if c["verdict"] == "challenge"),
+            "reviews_unanswered": sum(1 for c in challenges if c["state"] == "timeout"),
+        },
+        "ownership": _ownership(watches),
+        "metrics": swarm.get_metrics(),
+        "feedback": swarm.get_satisfaction_rate(days=days),
+    }
+
+
+def _agent_rows(replies: list[dict], costs: dict[str, dict], swarm, days: int) -> list[dict]:
+    """One row per agent that either answered or spent something."""
+    per_agent: dict[str, dict] = {}
+    for row in replies:
+        agent = per_agent.setdefault(
+            row["agent_name"],
+            {"agent": row["agent_name"], "replies": 0, "tier1": 0, "tier2": 0, "tier3": 0},
+        )
+        count = int(row["replies"])
+        agent["replies"] += count
+        tier_key = f"tier{int(row['tier'])}"
+        if tier_key in agent:
+            agent[tier_key] += count
+
+    for name, spend in costs.items():
+        agent = per_agent.setdefault(name, {"agent": name, "replies": 0, "tier1": 0, "tier2": 0, "tier3": 0})
+        agent["cost_usd"] = round(spend["cost_usd"], 4)
+        agent["requests"] = spend["requests"]
+
+    for name, agent in per_agent.items():
+        agent.setdefault("cost_usd", 0.0)
+        agent.setdefault("requests", 0)
+        # Cost per reply is the number that makes "answered a lot" comparable
+        # between a cheap generalist and an expensive specialist.
+        agent["cost_per_reply"] = round(agent["cost_usd"] / agent["replies"], 4) if agent["replies"] else None
+        satisfaction = swarm.get_satisfaction_rate(agent_name=name, days=days)
+        agent["feedback_positive"] = satisfaction["positive"]
+        agent["feedback_negative"] = satisfaction["negative"]
+
+    return sorted(per_agent.values(), key=lambda row: (-row["replies"], row["agent"]))
+
+
+def _totals(agents: list[dict]) -> dict:
+    replies = sum(row["replies"] for row in agents)
+    cost = sum(row["cost_usd"] for row in agents)
+    return {
+        "agents": len(agents),
+        "replies": replies,
+        "cost_usd": round(cost, 4),
+        "cost_per_reply": round(cost / replies, 4) if replies else None,
+    }
+
+
+def _tier_totals(replies: list[dict]) -> dict:
+    """Tier mix: how much of the swarm's output was asked for vs volunteered."""
+    tiers = {"tier1": 0, "tier2": 0, "tier3": 0}
+    for row in replies:
+        key = f"tier{int(row['tier'])}"
+        if key in tiers:
+            tiers[key] += int(row["replies"])
+    total = sum(tiers.values())
+    tiers["total"] = total
+    tiers["explicit_share"] = round(tiers["tier1"] / total * 100, 1) if total else None
+    return tiers
+
+
+def _ownership(watches: list[dict]) -> dict:
+    """Owned topics by activity, and where the owner went silent."""
+    topics: dict[str, dict] = {}
+    for watch in watches:
+        row = topics.setdefault(
+            watch["topic"],
+            {"topic": watch["topic"], "owner": watch["owner_agent"], "requests": 0, "escalated": 0, "answered": 0},
+        )
+        row["requests"] += 1
+        if watch["state"] == "escalated":
+            row["escalated"] += 1
+        elif watch["state"] == "answered":
+            row["answered"] += 1
+
+    return {
+        "watched": len(watches),
+        "escalated": sum(1 for w in watches if w["state"] == "escalated"),
+        "pending": sum(1 for w in watches if w["state"] == "waiting"),
+        "topics": sorted(topics.values(), key=lambda row: (-row["requests"], row["topic"])),
+    }
+
+
+def render_summary(report: dict) -> str:
+    """Compact digest for chat.
+
+    Telegram has no tables, so this is bullets rather than a squeezed version of
+    the markdown table — the same numbers in a shape the medium can render.
+    """
+    totals = report["totals"]
+    tiers = report["tiers"]
+    ownership = report["ownership"]
+    collab = report["collaboration"]
+    feedback = report["feedback"]
+
+    lines = [
+        f"📊 <b>Отчёт роя — {report['period']}</b>",
+        f"с {report['since']}",
+        "",
+        f"Ответов: {totals['replies']} · расход: ${totals['cost_usd']:.2f}"
+        + (f" (${totals['cost_per_reply']:.3f}/ответ)" if totals["cost_per_reply"] is not None else ""),
+    ]
+
+    if tiers["total"]:
+        lines.append(f"Тиры: T1 {tiers['tier1']} · T2 {tiers['tier2']} · T3 {tiers['tier3']}")
+
+    for row in report["agents"]:
+        per_reply = f" · ${row['cost_per_reply']:.3f}/отв" if row["cost_per_reply"] is not None else ""
+        marks = ""
+        if row["feedback_positive"]:
+            marks += f" 👍{row['feedback_positive']}"
+        if row["feedback_negative"]:
+            marks += f" 👎{row['feedback_negative']}"
+        lines.append(
+            f"• {row['agent']}: {row['replies']} отв (T{row['tier1']}/{row['tier2']}/{row['tier3']}) "
+            f"· ${row['cost_usd']:.2f}{per_reply}{marks}"
+        )
+
+    if ownership["watched"]:
+        lines.append("")
+        lines.append(f"Темы под владением: {ownership['watched']}, эскалаций: {ownership['escalated']}")
+        for row in ownership["topics"][:5]:
+            lines.append(f"• {row['topic']} ({row['owner']}): {row['requests']} обр, эскалаций {row['escalated']}")
+
+    lines.append("")
+    lines.append(
+        f"Передачи: {collab['handoffs']} · консилиумы: {collab['councils']} · "
+        f"ревью: {collab['reviews']} (возражений {collab['objections']})"
+    )
+    if feedback["total"]:
+        lines.append(f"Удовлетворённость: {feedback['satisfaction_rate']:.0f}% из {feedback['total']} реакций")
+
+    return "\n".join(lines)
+
+
+def render_markdown(report: dict) -> str:
+    """Human-readable digest — what goes to Telegram and to the terminal."""
+    totals = report["totals"]
+    tiers = report["tiers"]
+    collab = report["collaboration"]
+    ownership = report["ownership"]
+
+    lines = [
+        f"# Отчёт роя — {report['period']} ({report['since']} → {report['generated_at']})",
+        "",
+        f"Ответов: **{totals['replies']}** · агентов активно: {totals['agents']} · "
+        f"расход: **${totals['cost_usd']:.2f}**"
+        + (f" (${totals['cost_per_reply']:.3f} / ответ)" if totals["cost_per_reply"] is not None else ""),
+    ]
+
+    if tiers["total"]:
+        lines += [
+            "",
+            f"По тирам: прямое обращение {tiers['tier1']} · по релевантности {tiers['tier2']} · "
+            f"реакция на коллегу {tiers['tier3']}"
+            + (f" · доля прямых обращений {tiers['explicit_share']:.0f}%" if tiers["explicit_share"] else ""),
+        ]
+
+    if report["agents"]:
+        lines += [
+            "",
+            "## Кто отвечал",
+            "",
+            "| Агент | Ответов | T1/T2/T3 | Расход | $/ответ | 👍 | 👎 |",
+            "|---|---:|---|---:|---:|---:|---:|",
+        ]
+        for row in report["agents"]:
+            per_reply = f"${row['cost_per_reply']:.3f}" if row["cost_per_reply"] is not None else "—"
+            lines.append(
+                f"| {row['agent']} | {row['replies']} | "
+                f"{row['tier1']}/{row['tier2']}/{row['tier3']} | "
+                f"${row['cost_usd']:.2f} | {per_reply} | "
+                f"{row['feedback_positive']} | {row['feedback_negative']} |"
+            )
+    else:
+        lines += ["", "Ответов за период не было."]
+
+    if ownership["watched"]:
+        lines += [
+            "",
+            "## Владение темами",
+            "",
+            f"Под наблюдением: {ownership['watched']} · эскалаций: {ownership['escalated']} · "
+            f"ещё в ожидании: {ownership['pending']}",
+            "",
+            "| Тема | Владелец | Обращений | Ответил | Эскалаций |",
+            "|---|---|---:|---:|---:|",
+        ]
+        for row in ownership["topics"]:
+            lines.append(
+                f"| {row['topic']} | {row['owner']} | {row['requests']} | {row['answered']} | {row['escalated']} |"
+            )
+
+    lines += [
+        "",
+        "## Сотрудничество",
+        "",
+        f"- Передачи: {collab['handoffs']} (выполнено {collab['handoffs_done']}, "
+        f"провалено {collab['handoffs_failed']})",
+        f"- Консилиумы: {collab['councils']}",
+        f"- Ревью перед отправкой: {collab['reviews']} "
+        f"(возражений {collab['objections']}, без ответа {collab['reviews_unanswered']})",
+    ]
+
+    feedback = report["feedback"]
+    if feedback["total"]:
+        lines += [
+            "",
+            f"Реакции: 👍 {feedback['positive']} · 👎 {feedback['negative']} · "
+            f"удовлетворённость {feedback['satisfaction_rate']:.0f}%",
+        ]
+
+    duplicates = report["metrics"].get("duplicate_replies_avoided", 0)
+    respected = report["metrics"].get("addressing_respected", 0)
+    if duplicates or respected:
+        lines += [
+            "",
+            f"Координация: предотвращено дублей {duplicates} · уважено адресаций {respected}",
+        ]
+
+    return "\n".join(lines)

--- a/kronos/swarm_store.py
+++ b/kronos/swarm_store.py
@@ -326,6 +326,18 @@ def _schema(conn) -> None:
             PRIMARY KEY (day, agent)
         );
 
+        -- Swarm-wide jobs that must fire once, not once per agent (moat 11.4).
+        -- Every process runs the same scheduler, so a weekly digest would be
+        -- delivered six times. The PRIMARY KEY is the arbitration: the first
+        -- INSERT OR IGNORE for a (job, period) wins and the rest are no-ops.
+        CREATE TABLE IF NOT EXISTS job_claims (
+            job TEXT NOT NULL,
+            period_key TEXT NOT NULL,
+            agent_name TEXT NOT NULL,
+            created_at REAL NOT NULL,
+            PRIMARY KEY (job, period_key)
+        );
+
         -- Dissent (moat 11.4): on a topic whose owner declares `dissent:
         -- require`, the draft answer is shown to an agent with a different role
         -- before it is sent. Kept as its own queue rather than a council row,
@@ -1506,6 +1518,79 @@ class SwarmStore:
             "satisfaction_rate": round(rate, 1),
             "days": days,
         }
+
+    # ------------------------------------------------------------------
+    # Once-per-period jobs (moat 11.4)
+    # ------------------------------------------------------------------
+
+    def claim_periodic_job(self, *, job: str, period_key: str, agent_name: str) -> bool:
+        """True for exactly one agent per (job, period_key).
+
+        Six processes run the same scheduler, so a swarm-wide digest needs a
+        single winner. The PRIMARY KEY does the arbitration.
+        """
+        cursor = self._db.write(
+            "INSERT OR IGNORE INTO job_claims (job, period_key, agent_name, created_at) VALUES (?, ?, ?, ?)",
+            (job, period_key, agent_name, time.time()),
+        )
+        return cursor.rowcount > 0
+
+    def periodic_job_owner(self, *, job: str, period_key: str) -> str:
+        row = self._db.read_one(
+            "SELECT agent_name FROM job_claims WHERE job = ? AND period_key = ?",
+            (job, period_key),
+        )
+        return str(row["agent_name"]) if row else ""
+
+    # ------------------------------------------------------------------
+    # Post-mortem aggregates (moat 11.4)
+    # ------------------------------------------------------------------
+
+    def replies_by_agent(self, *, since_ts: float) -> list[dict]:
+        """Sent replies grouped by agent and tier — who answered, how."""
+        rows = self._db.read(
+            """
+            SELECT agent_name, tier, COUNT(*) AS replies
+            FROM reply_claims
+            WHERE state = 'sent' AND created_at >= ?
+            GROUP BY agent_name, tier
+            ORDER BY agent_name, tier
+            """,
+            (since_ts,),
+        )
+        return [dict(row) for row in rows]
+
+    def costs_by_agent(self, *, since_day: str) -> dict[str, dict]:
+        """Spend per agent over a range of days from the shared ledger."""
+        rows = self._db.read(
+            """
+            SELECT agent,
+                   SUM(requests) AS requests,
+                   SUM(cost_usd) AS cost_usd
+            FROM swarm_costs
+            WHERE day >= ?
+            GROUP BY agent
+            """,
+            (since_day,),
+        )
+        return {
+            row["agent"]: {"requests": int(row["requests"] or 0), "cost_usd": float(row["cost_usd"] or 0)}
+            for row in rows
+        }
+
+    def handoffs_since(self, *, since_ts: float, limit: int = 500) -> list[dict]:
+        rows = self._db.read(
+            "SELECT * FROM handoffs WHERE created_at >= ? ORDER BY created_at DESC LIMIT ?",
+            (since_ts, limit),
+        )
+        return [dict(row) for row in rows]
+
+    def councils_since(self, *, since_ts: float, limit: int = 500) -> list[dict]:
+        rows = self._db.read(
+            "SELECT * FROM council_sessions WHERE created_at >= ? ORDER BY created_at DESC LIMIT ?",
+            (since_ts, limit),
+        )
+        return [dict(row) for row in rows]
 
     # ------------------------------------------------------------------
     # Retention (called by a periodic job — not wired in this step)

--- a/kronos/swarm_store.py
+++ b/kronos/swarm_store.py
@@ -326,6 +326,30 @@ def _schema(conn) -> None:
             PRIMARY KEY (day, agent)
         );
 
+        -- Dissent (moat 11.4): on a topic whose owner declares `dissent:
+        -- require`, the draft answer is shown to an agent with a different role
+        -- before it is sent. Kept as its own queue rather than a council row,
+        -- because a council ends in synthesis posted to the chat and this must
+        -- end in a verdict returned to the author — same shape, opposite exit.
+        CREATE TABLE IF NOT EXISTS challenges (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chat_id INTEGER NOT NULL,
+            topic_id INTEGER NOT NULL DEFAULT 0,
+            thread_id TEXT NOT NULL,
+            root_msg_id INTEGER NOT NULL DEFAULT 0,
+            topic TEXT NOT NULL DEFAULT '',
+            author_agent TEXT NOT NULL,
+            reviewer_agent TEXT NOT NULL,
+            claim TEXT NOT NULL,
+            verdict TEXT NOT NULL DEFAULT '',
+            response TEXT NOT NULL DEFAULT '',
+            state TEXT NOT NULL CHECK (state IN ('pending','reviewing','answered','timeout')),
+            created_at REAL NOT NULL,
+            answered_at REAL
+        );
+        CREATE INDEX IF NOT EXISTS idx_challenges_intake
+            ON challenges(reviewer_agent, state, created_at);
+
         -- SLA watch (moat 11.2): a message on an owned topic gets a deadline.
         -- Any agent that recognised the topic registers the row — including a
         -- non-owner, because the case worth covering is precisely the one where
@@ -673,6 +697,103 @@ class SwarmStore:
             (chat_id, topic_id or 0, root_msg_id),
         )
         return int(row["c"]) if row else 0
+
+    # ------------------------------------------------------------------
+    # Dissent (moat 11.4): a draft answer reviewed by another role
+    # ------------------------------------------------------------------
+
+    def request_challenge(
+        self,
+        *,
+        chat_id: int,
+        topic_id: int | None,
+        thread_id: str,
+        root_msg_id: int,
+        topic: str,
+        author_agent: str,
+        reviewer_agent: str,
+        claim: str,
+    ) -> int:
+        """Ask another agent to poke holes in a draft answer. Returns its id."""
+        cursor = self._db.write(
+            """
+            INSERT INTO challenges
+                (chat_id, topic_id, thread_id, root_msg_id, topic, author_agent,
+                 reviewer_agent, claim, state, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?)
+            """,
+            (
+                chat_id,
+                topic_id or 0,
+                thread_id,
+                root_msg_id,
+                topic,
+                author_agent,
+                reviewer_agent,
+                claim,
+                time.time(),
+            ),
+        )
+        return int(cursor.lastrowid)
+
+    def accept_next_challenge(self, reviewer_agent: str) -> dict | None:
+        """Atomically claim the oldest pending review for this agent."""
+
+        def _tx(conn):
+            row = conn.execute(
+                """
+                SELECT * FROM challenges
+                WHERE reviewer_agent = ? AND state = 'pending'
+                ORDER BY created_at ASC
+                LIMIT 1
+                """,
+                (reviewer_agent,),
+            ).fetchone()
+            if row is None:
+                return None
+            conn.execute("UPDATE challenges SET state = 'reviewing' WHERE id = ?", (row["id"],))
+            return dict(row)
+
+        return self._db.write_tx(_tx)
+
+    def answer_challenge(self, challenge_id: int, *, verdict: str, response: str) -> None:
+        if verdict not in ("agree", "challenge"):
+            raise ValueError(f"unknown challenge verdict: {verdict}")
+        self._db.write(
+            """
+            UPDATE challenges
+            SET state = 'answered', verdict = ?, response = ?, answered_at = ?
+            WHERE id = ? AND state IN ('pending', 'reviewing')
+            """,
+            (verdict, response, time.time(), challenge_id),
+        )
+
+    def timeout_challenge(self, challenge_id: int) -> bool:
+        """Give up waiting. True if this call closed it (the reviewer may win).
+
+        The compare-and-set matters: a reviewer that answers in the same instant
+        must not have its verdict overwritten by the author's timeout.
+        """
+
+        def _tx(conn):
+            cur = conn.execute(
+                "UPDATE challenges SET state = 'timeout' WHERE id = ? AND state IN ('pending', 'reviewing')",
+                (challenge_id,),
+            )
+            return cur.rowcount > 0
+
+        return self._db.write_tx(_tx)
+
+    def get_challenge(self, challenge_id: int) -> dict | None:
+        row = self._db.read_one("SELECT * FROM challenges WHERE id = ?", (challenge_id,))
+        return dict(row) if row else None
+
+    def challenges(self, *, since_ts: float = 0.0, limit: int = 200) -> list[dict]:
+        rows = self._db.read(
+            "SELECT * FROM challenges WHERE created_at >= ? ORDER BY created_at DESC LIMIT ?",
+            (since_ts, limit),
+        )
+        return [dict(row) for row in rows]
 
     # ------------------------------------------------------------------
     # SLA watch (moat 11.2): owned topics get a deadline

--- a/kronos/swarm_store.py
+++ b/kronos/swarm_store.py
@@ -325,6 +325,30 @@ def _schema(conn) -> None:
             updated_at REAL NOT NULL,
             PRIMARY KEY (day, agent)
         );
+
+        -- SLA watch (moat 11.2): a message on an owned topic gets a deadline.
+        -- Any agent that recognised the topic registers the row — including a
+        -- non-owner, because the case worth covering is precisely the one where
+        -- the owner's process is down and cannot register anything. UNIQUE makes
+        -- that a race nobody loses, and the escalation job claims each due row
+        -- atomically so six processes create exactly one hand-off.
+        CREATE TABLE IF NOT EXISTS sla_watch (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            chat_id INTEGER NOT NULL,
+            topic_id INTEGER NOT NULL DEFAULT 0,
+            root_msg_id INTEGER NOT NULL,
+            thread_id TEXT NOT NULL,
+            topic TEXT NOT NULL,
+            owner_agent TEXT NOT NULL,
+            request TEXT NOT NULL DEFAULT '',
+            deadline_ts REAL NOT NULL,
+            state TEXT NOT NULL CHECK (state IN ('waiting','escalated','answered','dropped')),
+            created_at REAL NOT NULL,
+            resolved_at REAL,
+            UNIQUE(chat_id, topic_id, root_msg_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_sla_watch_due
+            ON sla_watch(state, deadline_ts);
         """
     )
 
@@ -649,6 +673,88 @@ class SwarmStore:
             (chat_id, topic_id or 0, root_msg_id),
         )
         return int(row["c"]) if row else 0
+
+    # ------------------------------------------------------------------
+    # SLA watch (moat 11.2): owned topics get a deadline
+    # ------------------------------------------------------------------
+
+    def watch_sla(
+        self,
+        *,
+        chat_id: int,
+        topic_id: int | None,
+        root_msg_id: int,
+        thread_id: str,
+        topic: str,
+        owner_agent: str,
+        request: str,
+        sla_minutes: int,
+    ) -> bool:
+        """Register the owner's response deadline. True if this call created it.
+
+        Idempotent per root message: whichever agent recognises the topic first
+        registers the watch, the rest are no-ops.
+        """
+        now = time.time()
+        cursor = self._db.write(
+            """
+            INSERT OR IGNORE INTO sla_watch
+                (chat_id, topic_id, root_msg_id, thread_id, topic, owner_agent,
+                 request, deadline_ts, state, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'waiting', ?)
+            """,
+            (
+                chat_id,
+                topic_id or 0,
+                root_msg_id,
+                thread_id,
+                topic,
+                owner_agent,
+                request[:4000],
+                now + max(sla_minutes, 1) * 60,
+                now,
+            ),
+        )
+        return cursor.rowcount > 0
+
+    def due_sla_watches(self, *, now: float | None = None, limit: int = 20) -> list[dict]:
+        """Watches whose deadline has passed and that are still waiting."""
+        rows = self._db.read(
+            """
+            SELECT * FROM sla_watch
+            WHERE state = 'waiting' AND deadline_ts <= ?
+            ORDER BY deadline_ts ASC
+            LIMIT ?
+            """,
+            (now if now is not None else time.time(), limit),
+        )
+        return [dict(row) for row in rows]
+
+    def resolve_sla_watch(self, watch_id: int, *, state: str) -> bool:
+        """Move a waiting watch to a terminal state. True if this call won.
+
+        The compare-and-set is what makes escalation safe across six processes:
+        each polls the same due rows, and only the one whose UPDATE changed a
+        row goes on to create the hand-off.
+        """
+        if state not in ("escalated", "answered", "dropped"):
+            raise ValueError(f"unknown sla_watch state: {state}")
+
+        def _tx(conn):
+            cur = conn.execute(
+                "UPDATE sla_watch SET state = ?, resolved_at = ? WHERE id = ? AND state = 'waiting'",
+                (state, time.time(), watch_id),
+            )
+            return cur.rowcount > 0
+
+        return self._db.write_tx(_tx)
+
+    def sla_watches(self, *, since_ts: float = 0.0, limit: int = 200) -> list[dict]:
+        rows = self._db.read(
+            "SELECT * FROM sla_watch WHERE created_at >= ? ORDER BY created_at DESC LIMIT ?",
+            (since_ts, limit),
+        )
+        return [dict(row) for row in rows]
 
     # ------------------------------------------------------------------
     # Cross-agent hand-offs (roadmap 5.1)

--- a/tests/test_cli_swarm.py
+++ b/tests/test_cli_swarm.py
@@ -1,0 +1,124 @@
+"""CLI surface for the swarm report and the offline swarm demo (moat 11.4/11.5)."""
+
+import json
+import time
+
+import pytest
+
+from kronos.cli import build_parser, main
+from kronos.config import settings
+
+
+@pytest.fixture
+def swarm_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "swarm_db_path", str(tmp_path / "swarm.db"))
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "agent_name", "kronos")
+    import kronos.db as _db
+    import kronos.swarm_store as swarm_store
+
+    # `main()` reads the ledger through the process-wide singleton, so a stale one
+    # would show the previous test's rows in this test's "empty" report.
+    _db._instances.clear()
+    monkeypatch.setattr(swarm_store, "_singleton", None)
+
+    store = swarm_store.get_swarm()
+    yield store
+    _db._instances.clear()
+
+
+def _reply(store, agent: str, tier: int, msg: int) -> None:
+    store.claim_reply(
+        chat_id=-1,
+        topic_id=0,
+        root_msg_id=msg,
+        trigger_msg_id=msg,
+        agent_name=agent,
+        tier=tier,
+        eta_ts=time.time(),
+    )
+    store.mark_sent(chat_id=-1, topic_id=0, trigger_msg_id=msg, agent_name=agent, reply_msg_id=msg + 1)
+
+
+# --- parser -------------------------------------------------------------------
+
+
+def test_parser_exposes_the_swarm_report():
+    parser = build_parser()
+
+    assert parser.parse_args(["swarm", "report"]).swarm_command == "report"
+    assert parser.parse_args(["swarm", "report"]).period == "week"
+    assert parser.parse_args(["swarm", "report", "--day"]).period == "day"
+    assert parser.parse_args(["swarm", "report", "--period", "month"]).period == "month"
+    assert parser.parse_args(["swarm", "report", "--json"]).as_json is True
+
+
+def test_parser_exposes_the_swarm_demo():
+    assert build_parser().parse_args(["demo", "--swarm"]).swarm is True
+
+
+# --- report -------------------------------------------------------------------
+
+
+def test_report_renders_markdown(swarm_db, capsys):
+    _reply(swarm_db, "kronos", 1, 10)
+
+    code = main(["swarm", "report", "--week"])
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert "Отчёт роя" in out
+    assert "| kronos |" in out
+
+
+def test_report_json_is_machine_readable(swarm_db, capsys):
+    _reply(swarm_db, "nexus", 2, 11)
+
+    code = main(["swarm", "report", "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert code == 0
+    assert payload["period"] == "week"
+    assert payload["agents"][0]["agent"] == "nexus"
+
+
+def test_report_on_an_empty_ledger_still_exits_clean(swarm_db, capsys):
+    assert main(["swarm", "report", "--day"]) == 0
+    assert "Ответов за период не было." in capsys.readouterr().out
+
+
+def test_an_unknown_period_fails_with_a_message(swarm_db, capsys, monkeypatch):
+    """argparse guards the CLI; the runner guards a bad programmatic call."""
+    from kronos.cli import run_swarm_report
+
+    code = run_swarm_report("fortnight", False)
+
+    assert code == 1
+    assert "unknown period" in capsys.readouterr().out
+
+
+# --- demo ---------------------------------------------------------------------
+
+
+def test_the_swarm_demo_runs_offline(capsys, monkeypatch):
+    """No Telegram, no keys, no network — and it must show real coordination."""
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+    code = main(["demo", "--swarm"])
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert "owner of 'planning'" in out
+    assert "escalated to strategist" in out
+    assert "escalations_triggered: 1" in out
+    assert "Отчёт роя" in out
+
+
+def test_the_demo_leaves_the_live_registry_alone(capsys):
+    from kronos.group_router import AGENT_PROFILES
+
+    before = {name: dict(prof) for name, prof in AGENT_PROFILES.items()}
+
+    main(["demo", "--swarm"])
+
+    assert AGENT_PROFILES == before, "the demo swaps the registry and must put it back"

--- a/tests/test_dissent.py
+++ b/tests/test_dissent.py
@@ -1,0 +1,353 @@
+"""Mandatory review before answering (moat phase 11.4).
+
+The properties that matter: an objection reaches the user with the answer, a
+silent reviewer never eats the answer, and a swarm that did not ask for dissent
+pays nothing.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from kronos.config import settings
+from kronos.dissent import (
+    UNREVIEWED_MARK,
+    classify_verdict,
+    format_reviewed_answer,
+    pick_reviewer,
+    review_before_send,
+    run_challenge_intake,
+)
+from kronos.swarm_config import AgentProfile
+
+PROFILES = {
+    "kronos": {
+        "username": "kronosagnt",
+        "aliases": ["kronos"],
+        "role": "strategic advisor",
+        "owns": ["planning"],
+        "escalates_to": "keystone",
+        "dissent": "require",
+    },
+    "keystone": {
+        "username": "keystoneagnt",
+        "aliases": ["keystone"],
+        "role": "quality engineer",
+    },
+    "impulse": {
+        "username": "impulseagnt",
+        "aliases": ["impulse"],
+        "role": "action catalyst",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def registry():
+    from kronos.group_router import AGENT_PROFILES
+
+    original = {name: dict(prof) for name, prof in AGENT_PROFILES.items()}
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update({name: dict(prof) for name, prof in PROFILES.items()})
+    yield
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update(original)
+
+
+@pytest.fixture
+def swarm(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "swarm_db_path", str(tmp_path / "swarm.db"))
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    # Production waits 3s between ledger reads; tests should not.
+    monkeypatch.setattr("kronos.dissent.DISSENT_POLL_SECONDS", 0.01)
+    import kronos.db as _db
+
+    _db._instances.clear()
+    from kronos.swarm_store import SwarmStore
+
+    store = SwarmStore()
+    monkeypatch.setattr("kronos.dissent.get_swarm", lambda: store)
+    yield store
+    _db._instances.clear()
+
+
+async def _review(answer: str = "Делаем A, потом B.", **kwargs) -> str:
+    return await review_before_send(
+        answer=answer,
+        chat_id=-100123,
+        topic_id=7,
+        thread_id="-100123:7",
+        root_msg_id=500,
+        topic="planning",
+        author_agent="kronos",
+        **kwargs,
+    )
+
+
+# --- pure helpers -------------------------------------------------------------
+
+
+def test_the_reviewer_is_the_declared_counterpart():
+    profiles = {
+        "kronos": AgentProfile(username="a", escalates_to="keystone"),
+        "keystone": AgentProfile(username="b"),
+        "impulse": AgentProfile(username="c"),
+    }
+
+    assert pick_reviewer(profiles, "kronos") == "keystone"
+
+
+def test_without_a_counterpart_any_other_agent_reviews():
+    profiles = {"kronos": AgentProfile(username="a"), "impulse": AgentProfile(username="c")}
+
+    assert pick_reviewer(profiles, "kronos") == "impulse"
+
+
+def test_a_solo_agent_has_nobody_to_ask():
+    assert pick_reviewer({"kronos": AgentProfile(username="a")}, "kronos") == ""
+
+
+@pytest.mark.parametrize(
+    "response,expected",
+    [
+        ("Согласен, добавить нечего.", "agree"),
+        ("  согласен  ", "agree"),
+        ("**Согласен** с выводом", "agree"),
+        ("Возражение: сроки нереальны.", "challenge"),
+        ("Не согласен — нет данных.", "challenge"),
+    ],
+)
+def test_verdict_classification(response, expected):
+    assert classify_verdict(response) == expected
+
+
+def test_agreement_leaves_the_answer_alone():
+    """Silence is the signal: no mark means it passed a second pair of eyes."""
+    answer = format_reviewed_answer("Ответ", reviewer="keystone", verdict="agree", response="Согласен")
+
+    assert answer == "Ответ"
+
+
+def test_an_objection_travels_with_the_answer():
+    answer = format_reviewed_answer(
+        "Ответ",
+        reviewer="keystone",
+        verdict="challenge",
+        response="Возражение: нет бюджета.",
+    )
+
+    assert "⚖️ Возражение от keystone" in answer
+    assert "нет бюджета" in answer
+
+
+# --- the gate -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_agent_that_did_not_ask_for_dissent_pays_nothing(swarm):
+    result = await review_before_send(
+        answer="Ответ",
+        chat_id=-100123,
+        topic_id=7,
+        thread_id="-100123:7",
+        root_msg_id=500,
+        topic="blockers",
+        author_agent="impulse",
+    )
+
+    assert result == "Ответ"
+    assert swarm.challenges() == [], "no review was requested, so no row"
+
+
+@pytest.mark.asyncio
+async def test_an_empty_answer_is_not_reviewed(swarm):
+    assert await _review(answer="   ") == "   "
+    assert swarm.challenges() == []
+
+
+@pytest.mark.asyncio
+async def test_an_objection_is_appended_to_the_answer(swarm):
+    async def reviewer_answers():
+        # Give the gate one poll cycle, then answer as the reviewer would.
+        import asyncio
+
+        for _ in range(50):
+            pending = swarm.challenges()
+            if pending:
+                swarm.answer_challenge(pending[0]["id"], verdict="challenge", response="Возражение: нет бюджета.")
+                return
+            await asyncio.sleep(0.01)
+
+    import asyncio
+
+    task = asyncio.create_task(reviewer_answers())
+    result = await _review(timeout=5)
+    await task
+
+    assert "Возражение: нет бюджета." in result
+    assert swarm.get_metrics().get("dissent_reviews_challenge") == 1
+
+
+@pytest.mark.asyncio
+async def test_a_silent_reviewer_does_not_eat_the_answer(swarm):
+    result = await _review(timeout=0.05)
+
+    assert result.startswith("Делаем A, потом B.")
+    assert UNREVIEWED_MARK in result
+    assert swarm.challenges()[0]["state"] == "timeout"
+    assert swarm.get_metrics().get("dissent_timeouts") == 1
+
+
+@pytest.mark.asyncio
+async def test_a_verdict_landing_at_the_deadline_is_not_lost(swarm, monkeypatch):
+    """The timeout is a compare-and-set, so a last-instant review still counts."""
+    challenge_ids = []
+    original = swarm.request_challenge
+
+    def capture(**kwargs):
+        challenge_id = original(**kwargs)
+        challenge_ids.append(challenge_id)
+        return challenge_id
+
+    monkeypatch.setattr(swarm, "request_challenge", capture)
+
+    real_timeout = swarm.timeout_challenge
+
+    def answer_first(challenge_id):
+        swarm.answer_challenge(challenge_id, verdict="challenge", response="Возражение: поздно, но по делу.")
+        return real_timeout(challenge_id)
+
+    monkeypatch.setattr(swarm, "timeout_challenge", answer_first)
+
+    result = await _review(timeout=0.05)
+
+    assert "поздно, но по делу" in result
+    assert UNREVIEWED_MARK not in result
+    assert swarm.get_challenge(challenge_ids[0])["state"] == "answered"
+
+
+@pytest.mark.asyncio
+async def test_a_solo_swarm_sends_without_review(swarm):
+    from kronos.group_router import AGENT_PROFILES
+
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update({"kronos": dict(PROFILES["kronos"])})
+
+    result = await _review()
+
+    assert result == "Делаем A, потом B."
+    assert swarm.challenges() == []
+
+
+# --- the reviewer side --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_reviewer_records_a_verdict(swarm):
+    challenge_id = swarm.request_challenge(
+        chat_id=-100123,
+        topic_id=7,
+        thread_id="-100123:7",
+        root_msg_id=500,
+        topic="planning",
+        author_agent="kronos",
+        reviewer_agent="keystone",
+        claim="Делаем A, потом B.",
+    )
+
+    class Reviewer:
+        def __init__(self):
+            self.calls = []
+
+        async def ainvoke(self, **kwargs):
+            self.calls.append(kwargs)
+            return "Возражение: B невозможно без C."
+
+    reviewer = Reviewer()
+    handled = await run_challenge_intake(reviewer, swarm, reviewer_agent="keystone")
+
+    assert handled == 1
+    row = swarm.get_challenge(challenge_id)
+    assert row["state"] == "answered"
+    assert row["verdict"] == "challenge"
+    assert "B невозможно без C" in row["response"]
+    # A review is not the user's turn: it must not enter the reviewer's history.
+    assert reviewer.calls[0]["source_kind"] == "peer_reaction"
+    assert reviewer.calls[0]["persist_user_turn"] is False
+
+
+@pytest.mark.asyncio
+async def test_a_reviewer_only_sees_its_own_queue(swarm):
+    swarm.request_challenge(
+        chat_id=1,
+        topic_id=0,
+        thread_id="1",
+        root_msg_id=1,
+        topic="planning",
+        author_agent="kronos",
+        reviewer_agent="keystone",
+        claim="x",
+    )
+
+    handled = await run_challenge_intake(AsyncMock(), swarm, reviewer_agent="impulse")
+
+    assert handled == 0
+
+
+@pytest.mark.asyncio
+async def test_a_claimed_challenge_is_not_handed_out_twice(swarm):
+    swarm.request_challenge(
+        chat_id=1,
+        topic_id=0,
+        thread_id="1",
+        root_msg_id=1,
+        topic="planning",
+        author_agent="kronos",
+        reviewer_agent="keystone",
+        claim="x",
+    )
+
+    first = swarm.accept_next_challenge("keystone")
+    second = swarm.accept_next_challenge("keystone")
+
+    assert first is not None
+    assert second is None
+
+
+@pytest.mark.asyncio
+async def test_a_failed_review_leaves_the_row_for_the_ledger(swarm):
+    challenge_id = swarm.request_challenge(
+        chat_id=1,
+        topic_id=0,
+        thread_id="1",
+        root_msg_id=1,
+        topic="planning",
+        author_agent="kronos",
+        reviewer_agent="keystone",
+        claim="x",
+    )
+
+    class Broken:
+        async def ainvoke(self, **kwargs):
+            raise RuntimeError("model down")
+
+    handled = await run_challenge_intake(Broken(), swarm, reviewer_agent="keystone")
+
+    assert handled == 1
+    assert swarm.get_challenge(challenge_id)["state"] == "reviewing"
+
+
+def test_an_unknown_verdict_is_rejected(swarm):
+    challenge_id = swarm.request_challenge(
+        chat_id=1,
+        topic_id=0,
+        thread_id="1",
+        root_msg_id=1,
+        topic="planning",
+        author_agent="kronos",
+        reviewer_agent="keystone",
+        claim="x",
+    )
+
+    with pytest.raises(ValueError):
+        swarm.answer_challenge(challenge_id, verdict="maybe", response="")

--- a/tests/test_swarm_budget.py
+++ b/tests/test_swarm_budget.py
@@ -1,0 +1,271 @@
+"""Per-agent budgets and quiet mode (moat phase 11.3).
+
+A swarm-wide cap says nothing about *who* spent it: the first agent awake can
+burn the shared limit on unprompted opinions and leave the other five mute. A
+personal slice fixes that — and it deliberately does not block, because the
+thing worth protecting is the user's direct question, not the volunteering.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kronos import policy as policy_module
+from kronos.config import settings
+from kronos.group_router import MAX_PEER_REPLIES, GroupRouter
+from kronos.security import cost_guardian as guardian_module
+from kronos.security.cost_guardian import CostGuardian
+
+MY_ID = 1001
+USER_ID = 42
+PEER_ID = 2001
+
+PROFILES = {
+    "kronos": {
+        "username": "kronosagnt",
+        "aliases": ["kronos"],
+        "role": "strategic advisor",
+        "budget_usd_daily": 1.0,
+    },
+    "impulse": {
+        "username": "impulseagnt",
+        "aliases": ["impulse"],
+        "role": "action catalyst",
+        "max_implicit_replies": 1,
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def registry(monkeypatch):
+    from kronos.group_router import AGENT_PROFILES
+
+    original = {name: dict(prof) for name, prof in AGENT_PROFILES.items()}
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update({name: dict(prof) for name, prof in PROFILES.items()})
+    monkeypatch.setattr(policy_module, "_active", policy_module.Policy(budgets={"daily_usd": 10.0}))
+    yield
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update(original)
+
+
+def _spend(monkeypatch, **per_agent: float) -> None:
+    monkeypatch.setattr(guardian_module, "_swarm_per_agent_cost", lambda: dict(per_agent))
+    monkeypatch.setattr(
+        guardian_module,
+        "_swarm_daily_cost",
+        lambda: {"cost_usd": sum(per_agent.values()), "requests": 1},
+    )
+
+
+def _guardian(monkeypatch, agent: str = "kronos") -> CostGuardian:
+    monkeypatch.setattr(settings, "agent_name", agent)
+    return CostGuardian(daily_limit=10.0, session_limit=1.0)
+
+
+def _router(agent_name: str) -> GroupRouter:
+    return GroupRouter(
+        agent_name=agent_name,
+        my_id=MY_ID,
+        my_username=PROFILES[agent_name]["username"],
+        allowed_user_ids={USER_ID},
+    )
+
+
+def _event(text: str, *, sender_id: int = USER_ID, reply_msg=None):
+    event = MagicMock()
+    event.raw_text = text
+    event.sender_id = sender_id
+    event.message = MagicMock()
+    event.message.id = 100
+    event.message.entities = []
+    event.is_reply = reply_msg is not None
+    event.get_reply_message = AsyncMock(return_value=reply_msg)
+    event.topic_label = None
+    return event
+
+
+# --- the personal limit -------------------------------------------------------
+
+
+def test_the_registry_supplies_the_limit(monkeypatch):
+    guard = _guardian(monkeypatch, "kronos")
+
+    assert guard.personal_limit() == 1.0
+
+
+def test_the_policy_overrides_the_registry(monkeypatch):
+    monkeypatch.setattr(
+        policy_module,
+        "_active",
+        policy_module.Policy(budgets={"daily_usd": 10.0, "per_agent_daily_usd": {"kronos": 3.0}}),
+    )
+    guard = _guardian(monkeypatch, "kronos")
+
+    assert guard.personal_limit() == 3.0
+
+
+def test_no_declared_budget_means_no_personal_cap(monkeypatch):
+    guard = _guardian(monkeypatch, "impulse")
+
+    assert guard.personal_limit() == 0.0
+    _spend(monkeypatch, impulse=9.99)
+    assert guard.quiet_reason() == "", "without a personal slice only the swarm cap applies"
+
+
+def test_spend_is_read_per_agent(monkeypatch):
+    guard = _guardian(monkeypatch, "kronos")
+    _spend(monkeypatch, kronos=0.4, impulse=2.0)
+
+    assert guard.personal_spend() == 0.4
+    assert guard.personal_spend("impulse") == 2.0
+
+
+# --- quiet mode ---------------------------------------------------------------
+
+
+def test_under_the_limit_the_agent_stays_talkative(monkeypatch):
+    guard = _guardian(monkeypatch, "kronos")
+    _spend(monkeypatch, kronos=0.5)
+
+    assert guard.quiet_reason() == ""
+
+
+def test_at_the_limit_the_agent_goes_quiet(monkeypatch):
+    guard = _guardian(monkeypatch, "kronos")
+    _spend(monkeypatch, kronos=1.0)
+
+    assert "personal daily budget spent" in guard.quiet_reason()
+
+
+def test_the_hard_gate_stays_swarm_wide(monkeypatch):
+    """Quiet mode must not become a block — Tier 1 has to keep working."""
+    guard = _guardian(monkeypatch, "kronos")
+    _spend(monkeypatch, kronos=1.5)
+
+    allowed, reason = guard.check_budget("session-1")
+
+    assert allowed is True, reason
+
+
+def test_an_unreadable_ledger_does_not_mute_the_agent(monkeypatch):
+    """Fail open: a locked database must not read as "budget exhausted"."""
+    guard = _guardian(monkeypatch, "kronos")
+
+    def broken_swarm():
+        raise RuntimeError("database is locked")
+
+    monkeypatch.setattr("kronos.swarm_store.get_swarm", broken_swarm)
+
+    assert guardian_module._swarm_per_agent_cost() == {}
+    assert guard.quiet_reason() == ""
+
+
+def test_a_broken_guardian_does_not_mute_the_router(monkeypatch):
+    router = _router("kronos")
+
+    def broken_guardian():
+        raise RuntimeError("guardian unavailable")
+
+    monkeypatch.setattr("kronos.security.cost_guardian.get_guardian", broken_guardian)
+
+    assert router._quiet_reason() == ""
+
+
+def test_the_status_reports_the_personal_slice(monkeypatch):
+    guard = _guardian(monkeypatch, "kronos")
+    _spend(monkeypatch, kronos=1.0)
+
+    status = guard.get_status()
+
+    assert status["personal_limit"] == 1.0
+    assert status["personal_cost"] == 1.0
+    assert status["quiet"] is True
+
+
+# --- degradation --------------------------------------------------------------
+
+
+def test_the_personal_share_degrades_before_the_swarm_does(monkeypatch):
+    """80% of a small slice, while the shared budget is still comfortable."""
+    guard = _guardian(monkeypatch, "kronos")
+    _spend(monkeypatch, kronos=0.85)
+
+    assert guard.should_degrade() is True
+
+
+def test_a_comfortable_agent_does_not_degrade(monkeypatch):
+    guard = _guardian(monkeypatch, "kronos")
+    _spend(monkeypatch, kronos=0.5, impulse=1.0)
+
+    assert guard.should_degrade() is False
+
+
+def test_the_swarm_threshold_still_degrades_everyone(monkeypatch):
+    guard = _guardian(monkeypatch, "impulse")  # no personal limit
+    _spend(monkeypatch, kronos=4.0, impulse=4.5)
+
+    assert guard.should_degrade() is True
+
+
+# --- routing under quiet mode -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_quiet_agent_still_answers_a_direct_mention(monkeypatch):
+    router = _router("kronos")
+    monkeypatch.setattr(router, "_quiet_reason", lambda: "personal daily budget spent")
+
+    decision = await router.decide(_event("@kronosagnt что делать?"), MagicMock())
+
+    assert decision.should_respond is True
+    assert decision.tier == 1
+
+
+@pytest.mark.asyncio
+async def test_a_quiet_agent_does_not_volunteer(monkeypatch):
+    router = _router("kronos")
+    monkeypatch.setattr(router, "_quiet_reason", lambda: "personal daily budget spent")
+    relevance = AsyncMock(return_value=10)
+    monkeypatch.setattr(router, "_check_relevance", relevance)
+
+    decision = await router.decide(_event("вопрос без адресата"), MagicMock())
+
+    assert decision.should_respond is False
+    assert "quiet mode" in decision.reason
+    relevance.assert_not_awaited(), "the check must come before the spend it prevents"
+
+
+@pytest.mark.asyncio
+async def test_a_quiet_agent_does_not_react_to_peers(monkeypatch):
+    router = _router("kronos")
+    monkeypatch.setattr(router, "_quiet_reason", lambda: "personal daily budget spent")
+    react = AsyncMock(return_value=True)
+    monkeypatch.setattr(router, "_should_react_to_peer", react)
+    user_msg = MagicMock()
+    user_msg.sender_id = USER_ID
+
+    decision = await router.decide(_event("мнение коллеги", sender_id=PEER_ID, reply_msg=user_msg), MagicMock())
+
+    assert decision.should_respond is False
+    assert "quiet mode" in decision.reason
+    react.assert_not_awaited()
+
+
+# --- per-agent reply tolerance ------------------------------------------------
+
+
+def test_the_reply_cap_defaults_to_the_swarm_value():
+    assert _router("kronos").max_implicit_replies == MAX_PEER_REPLIES
+
+
+def test_the_reply_cap_honours_the_per_agent_override():
+    assert _router("impulse").max_implicit_replies == 1
+
+
+@pytest.mark.asyncio
+async def test_a_yielding_agent_stands_down_one_reply_sooner(monkeypatch):
+    router = _router("impulse")
+    monkeypatch.setattr(router, "_count_peer_replies", AsyncMock(return_value=1))
+
+    assert await router.should_still_respond(_event("x"), MagicMock(), tier=2) is False

--- a/tests/test_swarm_config.py
+++ b/tests/test_swarm_config.py
@@ -1,0 +1,257 @@
+"""The swarm registry as validated config (moat phase 11.1).
+
+Two properties matter more than the schema itself: a file written before this
+module still loads (the swarm is running), and a contradiction that would send
+an escalation nowhere fails loudly instead of being discovered at 3am.
+"""
+
+import pytest
+import yaml
+
+from kronos.swarm_config import (
+    DEFAULT_SLA_MINUTES,
+    AgentProfile,
+    SwarmConfigError,
+    all_profiles,
+    escalation_target,
+    load_profiles,
+    profile_for,
+    profile_from_dict,
+    topic_owner,
+    validate_profiles,
+)
+
+LEGACY = {
+    "kronos": {
+        "username": "kronosagnt",
+        "aliases": ["кронос"],
+        "role": "strategic advisor",
+    },
+    "nexus": {"username": "nexusagnt", "aliases": ["нексус"], "role": "data analyst"},
+}
+
+ORGANISED = {
+    "kronos": {
+        "username": "kronosagnt",
+        "aliases": ["кронос"],
+        "role": "strategic advisor",
+        "owns": ["planning", "Priorities"],
+        "escalates_to": "nexus",
+        "sla_minutes": 5,
+        "budget_usd_daily": 1.5,
+        "dissent": "require",
+        "max_implicit_replies": 1,
+    },
+    "nexus": {
+        "username": "nexusagnt",
+        "aliases": ["нексус"],
+        "role": "data analyst",
+        "owns": ["metrics"],
+        "escalates_to": "kronos",
+    },
+}
+
+
+def _write(tmp_path, payload) -> str:
+    path = tmp_path / "agents.yaml"
+    path.write_text(yaml.safe_dump(payload, allow_unicode=True), encoding="utf-8")
+    return str(path)
+
+
+# --- backward compatibility ---------------------------------------------------
+
+
+def test_a_file_without_the_new_fields_still_loads(tmp_path):
+    profiles = load_profiles(_write(tmp_path, LEGACY))
+
+    assert set(profiles) == {"kronos", "nexus"}
+    kronos = profiles["kronos"]
+    assert kronos.username == "kronosagnt"
+    assert kronos.owns == []
+    assert kronos.escalates_to == ""
+    assert kronos.sla_minutes == DEFAULT_SLA_MINUTES
+    assert kronos.budget_usd_daily == 0.0
+    assert kronos.dissent == "allow"
+    assert kronos.max_implicit_replies is None
+
+
+def test_a_missing_file_is_an_empty_swarm(tmp_path):
+    """The packaged distribution ships without a registry."""
+    assert load_profiles(tmp_path / "absent.yaml") == {}
+
+
+def test_the_router_view_keeps_the_plain_dict_shape(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENTS_CONFIG_PATH", _write(tmp_path, ORGANISED))
+    from kronos.group_router import _load_profiles
+
+    raw = _load_profiles()
+
+    assert raw["kronos"]["username"] == "kronosagnt"
+    assert raw["kronos"]["role"] == "strategic advisor"
+    assert raw["kronos"]["owns"] == ["planning", "priorities"]
+
+
+def test_bare_dicts_from_tests_coerce_with_defaults():
+    """test_group_router injects three-key dicts straight into AGENT_PROFILES."""
+    profile = profile_from_dict("operator", {"username": "opagnt", "aliases": ["op"], "role": "execution"})
+
+    assert profile.sla_minutes == DEFAULT_SLA_MINUTES
+    assert profile.owns == []
+
+
+def test_an_unregistered_agent_gets_defaults():
+    assert profile_for("nobody-here").sla_minutes == DEFAULT_SLA_MINUTES
+
+
+def test_the_live_registry_has_a_typed_view():
+    """Tools read AGENT_PROFILES as dicts; routing needs the typed fields."""
+    from kronos.group_router import AGENT_PROFILES
+
+    original = {name: dict(prof) for name, prof in AGENT_PROFILES.items()}
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update({"kronos": dict(ORGANISED["kronos"]), "nexus": dict(ORGANISED["nexus"])})
+    try:
+        typed = all_profiles()
+        assert typed["kronos"].owns == ["planning", "priorities"]
+        assert profile_for("kronos").dissent == "require"
+    finally:
+        AGENT_PROFILES.clear()
+        AGENT_PROFILES.update(original)
+
+
+# --- normalisation ------------------------------------------------------------
+
+
+def test_values_are_normalised_for_chat_matching(tmp_path):
+    """Topics and names arrive from chat in whatever case the user typed."""
+    profiles = load_profiles(
+        _write(
+            tmp_path,
+            {"kronos": {"username": "@KronosAgnt", "aliases": ["Кронос"], "owns": ["  Planning ", ""]}},
+        )
+    )
+
+    kronos = profiles["kronos"]
+    assert kronos.username == "kronosagnt"
+    assert kronos.aliases == ["кронос"]
+    assert kronos.owns == ["planning"]
+    assert kronos.owns_topic("PLANNING") is True
+    assert kronos.owns_topic("") is False
+
+
+def test_env_still_overrides_the_username(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENT_USERNAME_KRONOS", "kronos_staging")
+
+    profiles = load_profiles(_write(tmp_path, LEGACY))
+
+    assert profiles["kronos"].username == "kronos_staging"
+
+
+def test_username_defaults_to_the_naming_pattern(tmp_path):
+    profiles = load_profiles(_write(tmp_path, {"impulse": {"role": "action catalyst"}}))
+
+    assert profiles["impulse"].username == "impulseagnt"
+    assert profiles["impulse"].aliases == ["impulse"]
+
+
+# --- errors -------------------------------------------------------------------
+
+
+def test_escalating_to_an_unknown_agent_is_an_error(tmp_path):
+    payload = {"kronos": {**LEGACY["kronos"], "escalates_to": "ghost"}}
+
+    with pytest.raises(SwarmConfigError, match="unknown agent 'ghost'"):
+        load_profiles(_write(tmp_path, payload))
+
+
+def test_escalating_to_yourself_is_an_error(tmp_path):
+    payload = {"kronos": {**LEGACY["kronos"], "escalates_to": "kronos"}}
+
+    with pytest.raises(SwarmConfigError, match="escalates to itself"):
+        load_profiles(_write(tmp_path, payload))
+
+
+def test_an_unknown_dissent_mode_names_the_agent(tmp_path):
+    payload = {"kronos": {**LEGACY["kronos"], "dissent": "maybe"}}
+
+    with pytest.raises(SwarmConfigError, match="agent 'kronos'"):
+        load_profiles(_write(tmp_path, payload))
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [("sla_minutes", 0), ("budget_usd_daily", -1), ("max_implicit_replies", -1)],
+)
+def test_nonsense_numbers_are_rejected(tmp_path, field, value):
+    with pytest.raises(SwarmConfigError):
+        load_profiles(_write(tmp_path, {"kronos": {**LEGACY["kronos"], field: value}}))
+
+
+def test_a_broken_file_is_not_silently_an_empty_swarm(tmp_path):
+    path = tmp_path / "agents.yaml"
+    path.write_text("kronos: [this is a list, not a profile]", encoding="utf-8")
+
+    with pytest.raises(SwarmConfigError):
+        load_profiles(str(path))
+
+
+def test_a_top_level_list_is_rejected(tmp_path):
+    path = tmp_path / "agents.yaml"
+    path.write_text("- kronos\n- nexus\n", encoding="utf-8")
+
+    with pytest.raises(SwarmConfigError, match="must map agent names"):
+        load_profiles(str(path))
+
+
+# --- warnings (legal, but worth saying out loud) ------------------------------
+
+
+def test_two_owners_for_one_topic_warns_and_stays_unowned():
+    profiles = {
+        "kronos": AgentProfile(owns=["planning"], username="a"),
+        "nexus": AgentProfile(owns=["planning"], username="b"),
+    }
+
+    warnings = validate_profiles(profiles)
+
+    assert any("planning" in w for w in warnings)
+    assert topic_owner(profiles, "planning") == "", "a contested topic must not grant the owner shortcut"
+
+
+def test_over_committed_budgets_warn(monkeypatch):
+    from kronos import policy as policy_module
+
+    monkeypatch.setattr(policy_module, "_active", policy_module.Policy(budgets={"daily_usd": 2.0}))
+    profiles = {
+        "kronos": AgentProfile(username="a", budget_usd_daily=1.5),
+        "nexus": AgentProfile(username="b", budget_usd_daily=1.5),
+    }
+
+    warnings = validate_profiles(profiles)
+
+    assert any("above the swarm daily cap" in w for w in warnings)
+
+
+def test_budgets_within_the_cap_are_quiet(monkeypatch):
+    from kronos import policy as policy_module
+
+    monkeypatch.setattr(policy_module, "_active", policy_module.Policy(budgets={"daily_usd": 5.0}))
+    profiles = {"kronos": AgentProfile(username="a", budget_usd_daily=1.5)}
+
+    assert validate_profiles(profiles) == []
+
+
+# --- lookups ------------------------------------------------------------------
+
+
+def test_topic_owner_and_escalation_target():
+    profiles = {
+        "kronos": AgentProfile(username="a", owns=["planning"], escalates_to="nexus"),
+        "nexus": AgentProfile(username="b", owns=["metrics"]),
+    }
+
+    assert topic_owner(profiles, "Planning") == "kronos"
+    assert topic_owner(profiles, "pricing") == ""
+    assert escalation_target(profiles, "kronos") == "nexus"
+    assert escalation_target(profiles, "nexus") == ""
+    assert escalation_target(profiles, "ghost") == ""

--- a/tests/test_swarm_config.py
+++ b/tests/test_swarm_config.py
@@ -255,3 +255,30 @@ def test_topic_owner_and_escalation_target():
     assert escalation_target(profiles, "kronos") == "nexus"
     assert escalation_target(profiles, "nexus") == ""
     assert escalation_target(profiles, "ghost") == ""
+
+
+# --- startup ------------------------------------------------------------------
+
+
+def test_startup_refuses_a_contradictory_registry(tmp_path, monkeypatch, caplog):
+    """A traceback from whichever module imported the router first is not a message."""
+    from kronos.app import _load_swarm_registry_or_exit
+
+    monkeypatch.setenv(
+        "AGENTS_CONFIG_PATH",
+        _write(tmp_path, {"kronos": {**LEGACY["kronos"], "escalates_to": "ghost"}}),
+    )
+
+    with pytest.raises(SystemExit) as exit_info:
+        _load_swarm_registry_or_exit()
+
+    assert exit_info.value.code == 1
+    assert "Refusing to start" in caplog.text
+
+
+def test_startup_accepts_a_valid_registry(tmp_path, monkeypatch):
+    from kronos.app import _load_swarm_registry_or_exit
+
+    monkeypatch.setenv("AGENTS_CONFIG_PATH", _write(tmp_path, ORGANISED))
+
+    _load_swarm_registry_or_exit()  # must not raise

--- a/tests/test_swarm_escalation.py
+++ b/tests/test_swarm_escalation.py
@@ -1,0 +1,212 @@
+"""SLA escalation for owned topics (moat phase 11.2).
+
+Ownership only helps if silence has a consequence. These tests pin the two
+properties that make escalation safe with six pollers on one ledger: the watch
+is a single row per message, and exactly one process turns it into a hand-off.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from kronos.config import settings
+from kronos.group_router import GroupRouter
+
+MY_ID = 1001
+USER_ID = 42
+ALLOWED_USERS = {USER_ID}
+
+PROFILES = {
+    "kronos": {
+        "username": "kronosagnt",
+        "aliases": ["kronos"],
+        "role": "strategic advisor",
+        "owns": ["planning"],
+        "escalates_to": "nexus",
+        "sla_minutes": 15,
+    },
+    "nexus": {
+        "username": "nexusagnt",
+        "aliases": ["nexus"],
+        "role": "data analyst",
+        "owns": ["metrics"],
+    },
+    "impulse": {
+        "username": "impulseagnt",
+        "aliases": ["impulse"],
+        "role": "action catalyst",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def registry():
+    """Swap the live registry for a swarm with declared ownership."""
+    from kronos.group_router import AGENT_PROFILES
+
+    original = {name: dict(prof) for name, prof in AGENT_PROFILES.items()}
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update({name: dict(prof) for name, prof in PROFILES.items()})
+    yield
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update(original)
+
+
+@pytest.fixture
+def swarm(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "swarm_db_path", str(tmp_path / "swarm.db"))
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    import kronos.db as _db
+
+    _db._instances.clear()
+    from kronos.swarm_store import SwarmStore
+
+    store = SwarmStore()
+    yield store
+    _db._instances.clear()
+
+
+def _router(agent_name: str) -> GroupRouter:
+    return GroupRouter(
+        agent_name=agent_name,
+        my_id=MY_ID,
+        my_username=PROFILES[agent_name]["username"],
+        allowed_user_ids=ALLOWED_USERS,
+    )
+
+
+def _event(text: str, *, msg_id: int = 100, topic_label: str | None = None):
+    event = MagicMock()
+    event.raw_text = text
+    event.sender_id = USER_ID
+    event.message = MagicMock()
+    event.message.id = msg_id
+    event.message.entities = []
+    event.is_reply = False
+    event.get_reply_message = AsyncMock(return_value=None)
+    # MagicMock invents attributes; the router reads topic_label with getattr.
+    event.topic_label = topic_label
+    return event
+
+
+# --- the watch ledger ---------------------------------------------------------
+
+
+def _watch(swarm, *, root_msg_id: int = 100, sla_minutes: int = 15, owner: str = "kronos") -> bool:
+    return swarm.watch_sla(
+        chat_id=-100123,
+        topic_id=7,
+        root_msg_id=root_msg_id,
+        thread_id="-100123:7",
+        topic="planning",
+        owner_agent=owner,
+        request="распланируй квартал",
+        sla_minutes=sla_minutes,
+    )
+
+
+def test_only_the_first_agent_registers_the_watch(swarm):
+    assert _watch(swarm) is True
+    assert _watch(swarm) is False, "six agents see the same message; the watch is one row"
+    assert len(swarm.sla_watches()) == 1
+
+
+def test_a_watch_is_not_due_before_its_deadline(swarm):
+    _watch(swarm, sla_minutes=15)
+
+    assert swarm.due_sla_watches() == []
+    assert len(swarm.due_sla_watches(now=time.time() + 16 * 60)) == 1
+
+
+def test_resolving_a_watch_is_a_compare_and_set(swarm):
+    _watch(swarm)
+    watch_id = swarm.sla_watches()[0]["id"]
+
+    assert swarm.resolve_sla_watch(watch_id, state="escalated") is True
+    assert swarm.resolve_sla_watch(watch_id, state="escalated") is False
+
+
+def test_an_unknown_state_is_rejected(swarm):
+    _watch(swarm)
+
+    with pytest.raises(ValueError):
+        swarm.resolve_sla_watch(swarm.sla_watches()[0]["id"], state="whatever")
+
+
+# --- escalation ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_escalation_creates_exactly_one_handoff(swarm, monkeypatch):
+    from kronos.cron.escalation import run_sla_escalation
+
+    monkeypatch.setattr(settings, "agent_name", "impulse")
+    _watch(swarm, sla_minutes=1)
+    monkeypatch.setattr(
+        swarm,
+        "due_sla_watches",
+        lambda **kwargs: [dict(row) for row in swarm.sla_watches()],
+    )
+    monkeypatch.setattr("kronos.swarm_store.get_swarm", lambda: swarm)
+    monkeypatch.setattr("kronos.cron.escalation.get_swarm", lambda: swarm)
+
+    await run_sla_escalation()
+    await run_sla_escalation()  # a second poll (or a second process) must not repeat it
+
+    pending = swarm.pending_handoffs("nexus")
+    assert len(pending) == 1
+    assert "planning" in pending[0]["context"]
+    assert swarm.get_metrics().get("escalations_triggered") == 1
+    assert swarm.sla_watches()[0]["state"] == "escalated"
+
+
+@pytest.mark.asyncio
+async def test_an_answered_topic_is_not_escalated(swarm, monkeypatch):
+    from kronos.cron.escalation import run_sla_escalation
+
+    monkeypatch.setattr(settings, "agent_name", "impulse")
+    _watch(swarm, sla_minutes=1)
+    swarm.claim_reply(
+        chat_id=-100123,
+        topic_id=7,
+        root_msg_id=100,
+        trigger_msg_id=100,
+        agent_name="kronos",
+        tier=2,
+        eta_ts=time.time(),
+    )
+    swarm.mark_sent(chat_id=-100123, topic_id=7, trigger_msg_id=100, agent_name="kronos", reply_msg_id=101)
+    monkeypatch.setattr(swarm, "due_sla_watches", lambda **kwargs: [dict(row) for row in swarm.sla_watches()])
+    monkeypatch.setattr("kronos.cron.escalation.get_swarm", lambda: swarm)
+
+    await run_sla_escalation()
+
+    assert swarm.pending_handoffs("nexus") == []
+    assert swarm.sla_watches()[0]["state"] == "answered"
+
+
+@pytest.mark.asyncio
+async def test_an_owner_without_cover_is_dropped_not_retried_forever(swarm, monkeypatch):
+    from kronos.cron.escalation import run_sla_escalation
+
+    monkeypatch.setattr(settings, "agent_name", "kronos")
+    _watch(swarm, sla_minutes=1, owner="nexus")  # nexus declares no escalates_to
+    monkeypatch.setattr(swarm, "due_sla_watches", lambda **kwargs: [dict(row) for row in swarm.sla_watches()])
+    monkeypatch.setattr("kronos.cron.escalation.get_swarm", lambda: swarm)
+
+    await run_sla_escalation()
+
+    assert swarm.sla_watches()[0]["state"] == "dropped"
+    assert swarm.get_metrics().get("escalations_undeliverable") == 1
+
+
+@pytest.mark.asyncio
+async def test_nothing_due_is_a_cheap_no_op(swarm, monkeypatch):
+    from kronos.cron.escalation import run_sla_escalation
+
+    monkeypatch.setattr("kronos.cron.escalation.get_swarm", lambda: swarm)
+
+    await run_sla_escalation()  # must not raise on an empty ledger

--- a/tests/test_swarm_local.py
+++ b/tests/test_swarm_local.py
@@ -201,3 +201,61 @@ async def test_a_peer_chain_does_not_start_new_reactions(bus):
     chain = await bus.run_round(reaction[0]["reply_facts"])
 
     assert [row["tier"] for row in chain] == [1]
+
+
+@pytest.mark.asyncio
+async def test_a_peer_ping_pong_runs_out_of_budget(bus):
+    """Found by this bus: Tier 1 bypasses every cap, so two agents looped forever.
+
+    A peer replying to my message reads as an explicit address, and my answer is
+    a reply to them — so before the exchange bound this ran without end, burning
+    budget and flooding the chat.
+    """
+    from kronos.group_router import MAX_PEER_EXCHANGES
+
+    bus.add_agent("nexus", relevance=_keen, react=lambda agent, text: True)
+    bus.add_agent("kronos", relevance=lambda agent, text: 1, react=lambda agent, text: True)
+
+    facts = (await bus.user_says("что с метриками?"))[0]["reply_facts"]
+    hops = 0
+    for _ in range(20):
+        sent = await bus.run_round(facts)
+        if not sent:
+            break
+        hops += 1
+        facts = sent[0]["reply_facts"]
+
+    assert hops < 20, "the exchange must terminate on its own"
+    # One Tier 3 reaction plus a bounded exchange for each of the two agents.
+    assert hops <= 1 + 2 * MAX_PEER_EXCHANGES
+
+
+@pytest.mark.asyncio
+async def test_an_agent_never_answers_itself(bus):
+    bus.add_agent("nexus", relevance=_keen)
+
+    sent = await bus.user_says("вопрос")
+    echo = await bus.run_round(sent[0]["reply_facts"])
+
+    assert echo == []
+
+
+# --- the ledger is real -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_transcript_and_the_ledger_agree(bus):
+    bus.add_agent("nexus", relevance=_keen)
+
+    await bus.user_says("вопрос про метрики")
+
+    assert [entry["from"] for entry in bus.transcript] == ["user", "nexus"]
+    recorded = bus.store.get_recent_messages(chat_id=bus.chat_id, topic_id=bus.topic_id, limit=10)
+    assert {row["sender_type"] for row in recorded} == {"user", "agent"}
+
+
+@pytest.mark.asyncio
+async def test_the_user_id_is_whitelisted_for_every_agent(bus):
+    agent = bus.add_agent("nexus")
+
+    assert USER_ID in agent.router.allowed_user_ids

--- a/tests/test_swarm_local.py
+++ b/tests/test_swarm_local.py
@@ -1,0 +1,203 @@
+"""The swarm without Telegram (moat phase 11.5).
+
+The value of this bus is that it is not a second implementation: these tests
+assert the production behaviours — one answer per message, owner-first, the
+addressing guard — through the local transport. If the router's rules changed,
+these would break too, which is the point.
+"""
+
+import pytest
+
+from kronos.config import settings
+from kronos.swarm_local import USER_ID, LocalSwarmBus
+
+PROFILES = {
+    "kronos": {
+        "username": "kronosagnt",
+        "aliases": ["kronos"],
+        "role": "strategic advisor",
+        "owns": ["planning"],
+        "escalates_to": "nexus",
+        "sla_minutes": 1,
+    },
+    "nexus": {
+        "username": "nexusagnt",
+        "aliases": ["nexus"],
+        "role": "data analyst",
+        "owns": ["metrics"],
+    },
+    "impulse": {
+        "username": "impulseagnt",
+        "aliases": ["impulse"],
+        "role": "action catalyst",
+        "max_implicit_replies": 1,
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def registry():
+    from kronos.group_router import AGENT_PROFILES
+
+    original = {name: dict(prof) for name, prof in AGENT_PROFILES.items()}
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update({name: dict(prof) for name, prof in PROFILES.items()})
+    yield
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update(original)
+
+
+@pytest.fixture
+def bus(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "swarm_db_path", str(tmp_path / "swarm.db"))
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    import kronos.db as _db
+
+    _db._instances.clear()
+    from kronos.swarm_store import SwarmStore
+
+    bus = LocalSwarmBus(store=SwarmStore())
+    yield bus
+    _db._instances.clear()
+
+
+def _keen(agent: str, text: str) -> int:
+    """Everyone finds everything relevant — maximises the chance of a duplicate."""
+    return 10
+
+
+# --- one answer, not three ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_implicit_reply_cap_binds_across_agents(bus):
+    """Three eager agents, two replies — the swarm cap, not one-per-message."""
+    bus.add_agent("kronos", relevance=_keen)
+    bus.add_agent("nexus", relevance=_keen)
+    bus.add_agent("impulse", relevance=_keen)
+
+    sent = await bus.user_says("что делать с ростом?")
+
+    assert len(sent) == 2
+    assert bus.store.count_sent_replies(chat_id=bus.chat_id, topic_id=bus.topic_id, root_msg_id=1001) == 2
+    assert bus.store.get_metrics().get("duplicate_replies_avoided") == 1
+
+
+@pytest.mark.asyncio
+async def test_an_agent_with_a_tighter_cap_yields(bus):
+    """impulse declares max_implicit_replies: 1, so one peer answer silences it.
+
+    The owner's fast lane makes the order deterministic: kronos claims 1-4s,
+    impulse 5-20s, so impulse always checks the ledger second.
+    """
+    bus.add_agent("kronos", relevance=lambda agent, text: 1)
+    bus.add_agent("impulse", relevance=_keen)
+
+    sent = await bus.user_says("распланируй квартал", topic_label="planning")
+
+    assert [row["agent"] for row in sent] == ["kronos"]
+    assert bus.store.get_metrics().get("duplicate_replies_avoided") == 1
+
+
+@pytest.mark.asyncio
+async def test_an_uninterested_swarm_stays_quiet(bus):
+    bus.add_agent("nexus", relevance=lambda agent, text: 2)
+    bus.add_agent("impulse", relevance=lambda agent, text: 3)
+
+    assert await bus.user_says("привет") == []
+
+
+@pytest.mark.asyncio
+async def test_an_addressed_agent_answers_and_the_others_do_not(bus):
+    bus.add_agent("nexus", relevance=_keen)
+    bus.add_agent("impulse", relevance=_keen)
+
+    sent = await bus.user_says("@impulseagnt разблокируй это")
+
+    assert [row["agent"] for row in sent] == ["impulse"]
+    assert sent[0]["tier"] == 1
+
+
+@pytest.mark.asyncio
+async def test_the_topic_owner_wins_against_a_keener_peer(bus):
+    bus.add_agent("kronos", relevance=lambda agent, text: 1)
+    bus.add_agent("impulse", relevance=_keen)
+
+    sent = await bus.user_says("распланируй квартал", topic_label="planning")
+
+    assert [row["agent"] for row in sent] == ["kronos"]
+    assert "owner of 'planning'" in sent[0]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_an_owned_topic_gets_a_deadline(bus):
+    bus.add_agent("kronos", relevance=_keen)
+
+    await bus.user_says("распланируй квартал", topic_label="planning")
+
+    watch = bus.store.sla_watches()[0]
+    assert (watch["topic"], watch["owner_agent"], watch["state"]) == ("planning", "kronos", "waiting")
+
+
+@pytest.mark.asyncio
+async def test_a_silent_owner_is_escalated_through_the_real_job(bus, monkeypatch):
+    """End-to-end: local round → watch → escalation job → hand-off queue."""
+    from kronos.cron.escalation import run_sla_escalation
+
+    monkeypatch.setattr(settings, "agent_name", "impulse")
+    monkeypatch.setattr("kronos.cron.escalation.get_swarm", lambda: bus.store)
+    bus.add_agent("impulse", relevance=lambda agent, text: 1)  # nobody answers
+    await bus.user_says("распланируй квартал", topic_label="planning")
+
+    watch = bus.store.sla_watches()[0]
+    bus.store._db.write("UPDATE sla_watch SET deadline_ts = 0 WHERE id = ?", (watch["id"],))
+    await run_sla_escalation()
+
+    assert [h["to_agent"] for h in bus.store.pending_handoffs("nexus")] == ["nexus"]
+    assert bus.store.sla_watches()[0]["state"] == "escalated"
+
+
+# --- peer traffic -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_peer_reaction_attaches_to_the_user_root(bus):
+    """Tier 3 spends the root message's reply budget, not a fresh one."""
+    bus.add_agent("nexus", relevance=_keen)
+    bus.add_agent("kronos", relevance=lambda agent, text: 1, react=lambda agent, text: True)
+
+    first = await bus.user_says("что с метриками?")
+    reaction = await bus.run_round(first[0]["reply_facts"])
+
+    assert [row["agent"] for row in first] == ["nexus"]
+    assert [row["agent"] for row in reaction] == ["kronos"]
+    assert reaction[0]["tier"] == 3
+    assert bus.store.count_sent_replies(chat_id=bus.chat_id, topic_id=bus.topic_id, root_msg_id=1001) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_third_voice_on_one_message_is_refused(bus):
+    """The cap covers Tier 2 and Tier 3 together."""
+    bus.add_agent("nexus", relevance=_keen)
+    bus.add_agent("kronos", relevance=_keen, react=lambda agent, text: True)
+
+    first = await bus.user_says("что с метриками?")
+    reaction = await bus.run_round(first[0]["reply_facts"])
+
+    assert len(first) == 2, "both answered the user"
+    assert reaction == [], "the root message's budget is spent"
+
+
+@pytest.mark.asyncio
+async def test_a_peer_chain_does_not_start_new_reactions(bus):
+    """Tier 3 needs a user anchor, or the bots would debate each other forever."""
+    bus.add_agent("nexus", relevance=_keen, react=lambda agent, text: True)
+    bus.add_agent("kronos", relevance=lambda agent, text: 1, react=lambda agent, text: True)
+
+    first = await bus.user_says("что с метриками?")
+    reaction = await bus.run_round(first[0]["reply_facts"])
+    # kronos replied to nexus, so nexus sees a reply-to-me: that is Tier 1, not
+    # a new Tier 3 reaction.
+    chain = await bus.run_round(reaction[0]["reply_facts"])
+
+    assert [row["tier"] for row in chain] == [1]

--- a/tests/test_swarm_ownership.py
+++ b/tests/test_swarm_ownership.py
@@ -1,0 +1,249 @@
+"""Owner-first routing and SLA escalation (moat phase 11.2).
+
+The point of ownership is that the specialist answers its own topic even when a
+generalist scores the message higher — and that the specialist going silent has
+a consequence instead of leaving the user unanswered.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from kronos.group_router import OWNER_DEFERENCE_SECONDS, GroupRouter
+
+MY_ID = 1001
+USER_ID = 42
+ALLOWED_USERS = {USER_ID}
+
+PROFILES = {
+    "kronos": {
+        "username": "kronosagnt",
+        "aliases": ["kronos"],
+        "role": "strategic advisor",
+        "owns": ["planning"],
+        "escalates_to": "nexus",
+        "sla_minutes": 15,
+    },
+    "nexus": {
+        "username": "nexusagnt",
+        "aliases": ["nexus"],
+        "role": "data analyst",
+        "owns": ["metrics"],
+    },
+    "impulse": {
+        "username": "impulseagnt",
+        "aliases": ["impulse"],
+        "role": "action catalyst",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def registry():
+    """Swap the live registry for a swarm with declared ownership."""
+    from kronos.group_router import AGENT_PROFILES
+
+    original = {name: dict(prof) for name, prof in AGENT_PROFILES.items()}
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update({name: dict(prof) for name, prof in PROFILES.items()})
+    yield
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update(original)
+
+
+def _router(agent_name: str) -> GroupRouter:
+    return GroupRouter(
+        agent_name=agent_name,
+        my_id=MY_ID,
+        my_username=PROFILES[agent_name]["username"],
+        allowed_user_ids=ALLOWED_USERS,
+    )
+
+
+def _event(text: str, *, msg_id: int = 100, topic_label: str | None = None):
+    event = MagicMock()
+    event.raw_text = text
+    event.sender_id = USER_ID
+    event.message = MagicMock()
+    event.message.id = msg_id
+    event.message.entities = []
+    event.is_reply = False
+    event.get_reply_message = AsyncMock(return_value=None)
+    # MagicMock invents attributes; the router reads topic_label with getattr.
+    event.topic_label = topic_label
+    return event
+
+
+# --- topic recognition --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_labelled_event_needs_no_llm():
+    """The local bus and eval scenarios name the subject directly."""
+    router = _router("kronos")
+
+    with patch.object(router, "_classify_topic", new=AsyncMock(return_value="")) as classify:
+        topic = await router._topic_key(_event("что дальше?", topic_label="Planning"), "что дальше?")
+
+    assert topic == "planning"
+    classify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_an_undeclared_label_falls_back_to_classification():
+    router = _router("kronos")
+
+    with patch.object(router, "_classify_topic", new=AsyncMock(return_value="metrics")):
+        assert await router._topic_key(_event("сколько DAU?", topic_label="general"), "сколько DAU?") == "metrics"
+
+
+@pytest.mark.asyncio
+async def test_classification_is_cached_per_message():
+    router = _router("kronos")
+    reply = MagicMock()
+    reply.content = "planning"
+    model = MagicMock()
+    model.ainvoke = AsyncMock(return_value=reply)
+
+    with patch("kronos.llm.get_model", return_value=model):
+        first = await router._classify_topic("надо распланировать квартал")
+        second = await router._classify_topic("надо распланировать квартал")
+
+    assert first == second == "planning"
+    assert model.ainvoke.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_an_invented_label_is_ignored():
+    """The lite model answers freely; only a declared topic counts."""
+    router = _router("kronos")
+    reply = MagicMock()
+    reply.content = "product-strategy"
+    model = MagicMock()
+    model.ainvoke = AsyncMock(return_value=reply)
+
+    with patch("kronos.llm.get_model", return_value=model):
+        assert await router._classify_topic("что делаем с продуктом?") == ""
+
+
+@pytest.mark.asyncio
+async def test_classification_failure_falls_back_to_no_topic():
+    """A glitch in a lite call must not silence the swarm."""
+    router = _router("kronos")
+    model = MagicMock()
+    model.ainvoke = AsyncMock(side_effect=RuntimeError("provider down"))
+
+    with patch("kronos.llm.get_model", return_value=model):
+        assert await router._classify_topic("текст") == ""
+
+
+@pytest.mark.asyncio
+async def test_a_registry_without_ownership_costs_nothing():
+    from kronos.group_router import AGENT_PROFILES
+
+    AGENT_PROFILES.clear()
+    AGENT_PROFILES.update({"impulse": dict(PROFILES["impulse"])})
+    router = _router("impulse")
+
+    with patch.object(router, "_classify_topic", new=AsyncMock(return_value="planning")) as classify:
+        assert await router._topic_key(_event("текст"), "текст") == ""
+
+    classify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_contested_topic_has_no_owner():
+    from kronos.group_router import AGENT_PROFILES
+
+    AGENT_PROFILES["nexus"] = {**PROFILES["nexus"], "owns": ["planning"]}
+    router = _router("impulse")
+
+    assert router._topic_owners.get("planning", "") == ""
+
+
+# --- owner-first routing ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_owner_answers_without_a_relevance_check():
+    router = _router("kronos")
+
+    with patch.object(router, "_check_relevance", new=AsyncMock(return_value=1)) as relevance:
+        decision = await router.decide(_event("распланируй квартал", topic_label="planning"), MagicMock())
+
+    assert decision.should_respond is True
+    assert decision.tier == 2
+    assert decision.topic_owner == "kronos"
+    assert "owner of 'planning'" in decision.reason
+    relevance.assert_not_awaited(), "the owner must not need permission from a relevance score"
+
+
+@pytest.mark.asyncio
+async def test_the_owner_outranks_a_more_relevant_non_owner():
+    """Arbitration orders by eta, so the owner's lane has to be the faster one."""
+    owner = _router("kronos")
+    other = _router("impulse")
+    event = _event("распланируй квартал", topic_label="planning")
+
+    with patch.object(owner, "_check_relevance", new=AsyncMock(return_value=3)):
+        owner_decision = await owner.decide(event, MagicMock())
+    with patch.object(other, "_check_relevance", new=AsyncMock(return_value=10)):
+        other_decision = await other.decide(event, MagicMock())
+
+    assert owner_decision.should_respond and other_decision.should_respond
+    assert owner_decision.delay < other_decision.delay
+
+
+@pytest.mark.asyncio
+async def test_a_non_owner_defers_but_still_covers_a_dead_owner():
+    other = _router("impulse")
+
+    with patch.object(other, "_check_relevance", new=AsyncMock(return_value=9)):
+        decision = await other.decide(_event("распланируй квартал", topic_label="planning"), MagicMock())
+
+    assert decision.delay == OWNER_DEFERENCE_SECONDS
+    assert "deferring to owner kronos" in decision.reason
+
+    from kronos.swarm_store import CLAIM_EXPIRY_SECONDS
+
+    assert decision.delay < CLAIM_EXPIRY_SECONDS, "a deferral past claim expiry could never win arbitration"
+
+
+@pytest.mark.asyncio
+async def test_an_unowned_topic_routes_exactly_as_before():
+    router = _router("impulse")
+
+    with patch.object(router, "_classify_topic", new=AsyncMock(return_value="")):
+        with patch.object(router, "_check_relevance", new=AsyncMock(return_value=9)):
+            decision = await router.decide(_event("что-то нейтральное"), MagicMock())
+
+    assert decision.should_respond is True
+    assert decision.topic_owner == ""
+    assert 5 <= decision.delay <= 20
+
+
+@pytest.mark.asyncio
+async def test_an_addressed_message_skips_classification():
+    """@mention is unambiguous; paying for a lite call would be waste."""
+    router = _router("kronos")
+    event = _event("@kronosagnt распланируй квартал")
+
+    with patch.object(router, "_classify_topic", new=AsyncMock(return_value="planning")) as classify:
+        decision = await router.decide(event, MagicMock())
+
+    assert decision.tier == 1
+    classify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_skip_still_reports_the_topic_for_the_watch():
+    """The SLA watch must be registered even by an agent with nothing to say."""
+    other = _router("impulse")
+
+    with patch.object(other, "_check_relevance", new=AsyncMock(return_value=2)):
+        decision = await other.decide(_event("распланируй квартал", topic_label="planning"), MagicMock())
+
+    assert decision.should_respond is False
+    assert (decision.topic, decision.topic_owner, decision.owner_sla_minutes) == ("planning", "kronos", 15)

--- a/tests/test_swarm_report.py
+++ b/tests/test_swarm_report.py
@@ -1,0 +1,281 @@
+"""Weekly swarm post-mortem (moat phase 11.4).
+
+The report is read-only aggregation, so the risk is not corruption — it is
+plausible-looking wrong numbers. These tests pin the arithmetic against a
+synthetic week, and pin that an empty ledger renders instead of raising.
+"""
+
+import time
+
+import pytest
+
+from kronos.config import settings
+from kronos.swarm_report import PERIOD_DAYS, build_report, render_markdown, render_summary
+
+
+@pytest.fixture
+def swarm(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "swarm_db_path", str(tmp_path / "swarm.db"))
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "agent_name", "kronos")
+    import kronos.db as _db
+
+    _db._instances.clear()
+    from kronos.swarm_store import SwarmStore
+
+    store = SwarmStore()
+    monkeypatch.setattr("kronos.swarm_report.get_swarm", lambda: store)
+    yield store
+    _db._instances.clear()
+
+
+def _reply(store, agent: str, tier: int, *, root: int, msg: int) -> None:
+    store.claim_reply(
+        chat_id=-100123,
+        topic_id=7,
+        root_msg_id=root,
+        trigger_msg_id=msg,
+        agent_name=agent,
+        tier=tier,
+        eta_ts=time.time(),
+    )
+    store.mark_sent(chat_id=-100123, topic_id=7, trigger_msg_id=msg, agent_name=agent, reply_msg_id=msg + 1000)
+
+
+def _cost(store, agent: str, cost: float, requests: int = 10) -> None:
+    store._db.write(
+        """
+        INSERT INTO swarm_costs (day, agent, requests, input_tokens, output_tokens, cost_usd, updated_at)
+        VALUES (?, ?, ?, 0, 0, ?, ?)
+        """,
+        (time.strftime("%Y-%m-%d"), agent, requests, cost, time.time()),
+    )
+
+
+@pytest.fixture
+def week(swarm):
+    """A synthetic week with known numbers."""
+    _reply(swarm, "kronos", 1, root=10, msg=10)
+    _reply(swarm, "kronos", 2, root=11, msg=11)
+    _reply(swarm, "nexus", 2, root=12, msg=12)
+    _reply(swarm, "impulse", 3, root=12, msg=13)
+    _cost(swarm, "kronos", 0.40)
+    _cost(swarm, "nexus", 0.20)
+    _cost(swarm, "impulse", 0.10)
+    swarm.watch_sla(
+        chat_id=-100123,
+        topic_id=7,
+        root_msg_id=11,
+        thread_id="-100123:7",
+        topic="planning",
+        owner_agent="kronos",
+        request="план",
+        sla_minutes=15,
+    )
+    swarm.watch_sla(
+        chat_id=-100123,
+        topic_id=7,
+        root_msg_id=14,
+        thread_id="-100123:7",
+        topic="metrics",
+        owner_agent="nexus",
+        request="почему упал DAU",
+        sla_minutes=20,
+    )
+    planning = next(w for w in swarm.sla_watches() if w["topic"] == "planning")
+    metrics = next(w for w in swarm.sla_watches() if w["topic"] == "metrics")
+    swarm.resolve_sla_watch(planning["id"], state="answered")
+    swarm.resolve_sla_watch(metrics["id"], state="escalated")
+    handoff = swarm.create_handoff(
+        chat_id=-100123,
+        topic_id=7,
+        thread_id="-100123:7",
+        from_agent="impulse",
+        to_agent="keystone",
+        context="про архитектуру",
+    )
+    swarm.complete_handoff(handoff, success=True)
+    challenge = swarm.request_challenge(
+        chat_id=-100123,
+        topic_id=7,
+        thread_id="-100123:7",
+        root_msg_id=11,
+        topic="planning",
+        author_agent="kronos",
+        reviewer_agent="keystone",
+        claim="Делаем A",
+    )
+    swarm.answer_challenge(challenge, verdict="challenge", response="Возражение: нет ресурсов")
+    swarm.add_feedback(agent_name="kronos", chat_id=-100123, msg_id=1010, emoji="👍")
+    swarm.add_feedback(agent_name="impulse", chat_id=-100123, msg_id=1013, emoji="👎")
+    swarm.incr_metric("duplicate_replies_avoided", 3)
+    return swarm
+
+
+# --- arithmetic ---------------------------------------------------------------
+
+
+def test_replies_are_counted_per_agent_and_tier(week):
+    report = build_report("week")
+
+    by_agent = {row["agent"]: row for row in report["agents"]}
+    assert by_agent["kronos"]["replies"] == 2
+    assert (by_agent["kronos"]["tier1"], by_agent["kronos"]["tier2"]) == (1, 1)
+    assert by_agent["impulse"]["tier3"] == 1
+    assert report["tiers"] == {
+        "tier1": 1,
+        "tier2": 2,
+        "tier3": 1,
+        "total": 4,
+        "explicit_share": 25.0,
+    }
+
+
+def test_cost_per_reply_makes_agents_comparable(week):
+    report = build_report("week")
+
+    by_agent = {row["agent"]: row for row in report["agents"]}
+    assert by_agent["kronos"]["cost_per_reply"] == 0.2  # $0.40 over two replies
+    assert by_agent["impulse"]["cost_per_reply"] == 0.1
+    assert report["totals"]["cost_usd"] == 0.7
+    assert report["totals"]["cost_per_reply"] == 0.175
+
+
+def test_agents_are_ordered_by_output(week):
+    report = build_report("week")
+
+    assert [row["agent"] for row in report["agents"]] == ["kronos", "impulse", "nexus"]
+
+
+def test_an_agent_that_only_spent_still_appears(swarm):
+    """Spending without answering is exactly what a report should surface."""
+    _cost(swarm, "lacuna", 0.33)
+
+    report = build_report("week")
+
+    lacuna = report["agents"][0]
+    assert lacuna["agent"] == "lacuna"
+    assert lacuna["replies"] == 0
+    assert lacuna["cost_per_reply"] is None, "dividing by zero replies would invent a number"
+
+
+def test_ownership_reports_silence_per_topic(week):
+    report = build_report("week")
+
+    ownership = report["ownership"]
+    assert (ownership["watched"], ownership["escalated"], ownership["pending"]) == (2, 1, 0)
+    topics = {row["topic"]: row for row in ownership["topics"]}
+    assert topics["metrics"]["escalated"] == 1
+    assert topics["planning"]["answered"] == 1
+
+
+def test_collaboration_counts_reviews_and_objections(week):
+    report = build_report("week")
+
+    collab = report["collaboration"]
+    assert (collab["handoffs"], collab["handoffs_done"]) == (1, 1)
+    assert (collab["reviews"], collab["objections"], collab["reviews_unanswered"]) == (1, 1, 0)
+
+
+def test_feedback_is_attributed_per_agent(week):
+    report = build_report("week")
+
+    by_agent = {row["agent"]: row for row in report["agents"]}
+    assert by_agent["kronos"]["feedback_positive"] == 1
+    assert by_agent["impulse"]["feedback_negative"] == 1
+    assert report["feedback"]["satisfaction_rate"] == 50.0
+
+
+def test_metrics_are_passed_through(week):
+    assert build_report("week")["metrics"]["duplicate_replies_avoided"] == 3
+
+
+def test_a_shorter_window_excludes_older_rows(week, monkeypatch):
+    """A day report must not inherit the week's replies."""
+    report = build_report("day", now=time.time() + 3 * 86400)
+
+    assert report["totals"]["replies"] == 0
+
+
+@pytest.mark.parametrize("period", sorted(PERIOD_DAYS))
+def test_every_period_builds(week, period):
+    assert build_report(period)["period"] == period
+
+
+def test_an_unknown_period_is_rejected(week):
+    with pytest.raises(ValueError, match="unknown period"):
+        build_report("fortnight")
+
+
+# --- rendering ----------------------------------------------------------------
+
+
+def test_markdown_carries_the_numbers(week):
+    text = render_markdown(build_report("week"))
+
+    assert "Отчёт роя" in text
+    assert "| kronos | 2 |" in text
+    assert "planning" in text and "metrics" in text
+    assert "Ревью перед отправкой: 1" in text
+
+
+def test_the_chat_summary_avoids_tables(week):
+    """Telegram cannot render a markdown table, so the digest must not use one."""
+    text = render_summary(build_report("week"))
+
+    assert "|---" not in text
+    assert "kronos" in text and "👍1" in text
+
+
+def test_an_empty_ledger_renders_instead_of_raising(swarm):
+    report = build_report("week")
+
+    assert report["totals"]["replies"] == 0
+    assert "Ответов за период не было." in render_markdown(report)
+    assert render_summary(report)
+
+
+# --- one delivery, not six ----------------------------------------------------
+
+
+def test_only_one_agent_claims_the_week(swarm):
+    assert swarm.claim_periodic_job(job="swarm-weekly-report", period_key="2026-W30", agent_name="kronos") is True
+    assert swarm.claim_periodic_job(job="swarm-weekly-report", period_key="2026-W30", agent_name="nexus") is False
+    assert swarm.periodic_job_owner(job="swarm-weekly-report", period_key="2026-W30") == "kronos"
+
+
+def test_the_next_week_is_a_fresh_claim(swarm):
+    swarm.claim_periodic_job(job="swarm-weekly-report", period_key="2026-W30", agent_name="kronos")
+
+    assert swarm.claim_periodic_job(job="swarm-weekly-report", period_key="2026-W31", agent_name="nexus") is True
+
+
+@pytest.mark.asyncio
+async def test_the_weekly_job_sends_once_across_agents(week, monkeypatch):
+    from kronos.cron import swarm_weekly
+
+    monkeypatch.setattr("kronos.cron.swarm_weekly.get_swarm", lambda: week)
+    sent: list[str] = []
+    monkeypatch.setattr(swarm_weekly, "send_bot_api", lambda text, **kwargs: sent.append(text) or True)
+    monkeypatch.setattr(swarm_weekly, "send_ntfy", lambda *args, **kwargs: True)
+
+    await swarm_weekly.run_swarm_weekly_report()
+    monkeypatch.setattr(settings, "agent_name", "nexus")
+    await swarm_weekly.run_swarm_weekly_report()
+
+    assert len(sent) == 1
+    assert "Отчёт роя" in sent[0]
+
+
+@pytest.mark.asyncio
+async def test_a_quiet_week_is_not_pushed(swarm, monkeypatch):
+    from kronos.cron import swarm_weekly
+
+    monkeypatch.setattr("kronos.cron.swarm_weekly.get_swarm", lambda: swarm)
+    sent: list[str] = []
+    monkeypatch.setattr(swarm_weekly, "send_bot_api", lambda text, **kwargs: sent.append(text) or True)
+    monkeypatch.setattr(swarm_weekly, "send_ntfy", lambda *args, **kwargs: True)
+
+    await swarm_weekly.run_swarm_weekly_report()
+
+    assert sent == [], "an empty week is not worth a notification"


### PR DESCRIPTION
Phase 11 of the moat roadmap. Six agents stop being "bots that don't collide" and become an organisation: a subject has an owner, silence has an escalation, an agent has a budget, a contested answer has a critic — and all of it can be shown without six Telegram accounts.

Every field is optional. A registry written before this PR loads unchanged and routes exactly as it did, which is what makes it safe to deploy to a running swarm.

## What landed

| Commit | What |
|---|---|
| `dda9969` | Validated `agents.yaml` schema: `owns`, `escalates_to`, `sla_minutes`, `budget_usd_daily`, `dissent`, `max_implicit_replies` |
| `28e0d7d` | Subject recognition + owner-first routing (owner skips the relevance threshold and takes the fast lane; non-owners defer) |
| `32275a1` | `sla-escalation` job: a missed deadline becomes a hand-off to the owner's cover |
| `8caaa42` | Per-agent daily budget with quiet mode |
| `69e0366` | Dissent: `dissent: require` sends a draft to another role before it is sent |
| `6ad9785` | `kaos swarm report [--day\|--week] [--json]` + Sunday push |
| `b0f4a69` | `EventFacts` adapter — the one place that knows Telethon's shape |
| `ab23555` | `kaos demo --swarm`: the swarm on an in-process bus, no Telegram, no keys |
| `73d62e3` | **Fix:** peer-to-peer replies could loop without end |
| `3b1dd64` | Docs, `kaos doctor` registry check, startup validation |

## The bug the local bus found

On its first run, two agents answered each other for as long as I let them. Twelve hops, no sign of stopping.

A peer replying to my message sets `reply_to_me` → `explicit_to_me` → Tier 1, and Tier 1 deliberately bypasses every loop guard: no cooldown, no implicit-reply cap, no arbitration. My answer is itself a reply to theirs, so they answer at Tier 1 too. The daily budget cap doesn't stop it either — "limit reached" is also a message.

The bypass is right for the reason it exists: the *user's* explicit address must always be honoured. A peer's address does not earn that. Peer-sourced Tier 1 is now bounded per window. This is a pre-existing bug reachable in production after any Tier 3 reaction, not something this phase introduced.

## Decisions worth reviewing

- **A non-owner defers 90s, not the owner's full SLA.** A claim older than `CLAIM_EXPIRY_SECONDS` (120) is expired and can never win arbitration, so a literal 15-minute sleep would mean "never answer" while still costing a task and an LLM call. Inside the window a live owner always wins; past it, an owner whose process is down no longer leaves the user waiting for the escalation job.
- **The SLA watch is registered by whichever agent recognised the subject — including a non-owner, including on a skip.** The case worth covering is exactly the one where the owner's process is down and can register nothing.
- **Quiet mode instead of a hard stop.** Out of its own budget, an agent still answers when addressed and stops volunteering. A block would mean the user's direct question goes unanswered because the agent spent its allowance on opinions nobody asked for.
- **The reviewer rides the council intake pass**, not a fourth poller. A review is a one-participant council with the opposite exit: a council ends in synthesis posted to the chat, a review ends in a verdict handed back to the author.
- **No `challenge_answer` tool**, though the plan called for one. Tier 3 peer-reaction already lets an agent answer a peer it disagrees with; a tool would add an interface without adding a capability. The real gap was the pre-send gate, which is what shipped.
- **No cost-per-topic column in the report.** Spend is recorded per agent and per day, never attributed to a subject, so that table would be an invention. Owned topics are reported by activity and missed SLAs instead.

## Verification

- `KAOS_ENV_FILE=/dev/null pytest -m "not integration" -q` → 1214 passed (94 new tests)
- `pytest -m eval -q` → 8 passed
- `kaos demo --swarm` driven end to end: cap arbitration, ownership shortcut, Tier 3 reaction, non-owner-registered watch, escalation through the hand-off queue, then the weekly report
- `kaos swarm report --week` against a seeded ledger, and `kaos doctor` against both a valid and a deliberately broken registry

## Deploying this

Nothing changes until `agents.yaml` declares the new fields. The registry in this PR *does* declare them for the six-agent swarm (ownership per role, mutual escalation, 15–30 min SLAs, no `dissent: require`, no per-agent budgets), so the first deploy turns owner-first routing and SLA escalation on. Strip those fields to keep today's behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)