### PR TITLE
Skill registry with provenance, auto-eval on install, and measured self-improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to Kronos Agent OS are documented here.
 
 ### Added
 
+- **Skill registry with provenance and auto-eval** — a skill can now declare
+  `version`, `requires_kaos`, `checksum` and an SSH `signature` (verified through
+  `ssh-keygen -Y verify`, no new dependency), and `registry.yaml` lists named
+  sources with a trust level. `kaos skills search / info / install / verify /
+  approve / stats` work against them; install replays the skill's own scenario
+  offline and only a signature from a configured key plus a check that did not
+  fail installs a skill active — everything else lands as a reviewable draft with
+  the reason attached. A skill with no scenario is marked unverified, not refused.
+  Usage counting is local, and the anonymous aggregate is assembled only with
+  `registry.telemetry: share`. Docs: [Registry](docs/REGISTRY.md).
+- **Measured self-improvement** — every weekly persona proposal now carries a
+  measurement (`persona_proposals.eval_json`): the patch is applied to a copy of
+  the workspace, the prompt is reassembled and the offline suite runs against both.
+  A proposal that breaks prompt assembly, regresses a scenario, or repeats guidance
+  already in the file is auto-rejected with a reason and no notification; the rest
+  reach the owner with the delta. The report states plainly that scripted scenarios
+  cannot score answer quality (`measured_quality: false`) instead of implying a
+  number. `/persona show <id>`, `/persona list --rejected`.
+
 - **Swarm 3.0 — the org chart is config** — `agents.yaml` gained `owns`,
   `escalates_to`, `sla_minutes`, `budget_usd_daily`, `dissent` and
   `max_implicit_replies`, validated at startup (a broken `escalates_to` raises;

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ kaos eval diff --base origin/main # what did my change move?
 kaos policy report    # effective governance posture and value sources
 kaos audit verify     # has the audit trail been edited?
 kaos swarm report --week # who answered, how well, at what cost
+kaos skills search memo  # search configured skill sources
+kaos skills install <name> # install with signature + scenario checks
+kaos skills verify       # re-check checksums, signatures, versions
+kaos skills stats        # which skills are actually used
 kaos demo --swarm     # swarm coordination locally: no Telegram, no keys
 kaos connect telegram # guided Telegram setup check
 kaos templates list  # list bundled agent templates
@@ -291,6 +295,24 @@ The demo needs no Telegram accounts and no provider keys: it runs three agents o
 an in-process bus over a temporary ledger, through the production router.
 
 This is useful for multi-persona group chats and expert panels, but the default KAOS runtime also works as a single durable agent. See [Sub-Agents & Swarm](docs/SWARM.md).
+
+## Skills From Elsewhere
+
+A skill is a markdown procedure the agent follows, so installing one accepts
+instructions. `registry.yaml` lists sources and how much each must prove:
+
+```bash
+cp registry.example.yaml registry.yaml
+kaos skills search memo
+kaos skills install decision-memo   # verifies, replays the skill's own scenario
+kaos skills verify                  # anything tampered with since?
+```
+
+A skill installs **active** only when its source requires signing, a key in
+`registry.trusted_keys` signed those exact bytes, and the skill's own offline
+scenario did not fail. Anything else lands as a draft with the reason attached —
+a failure never deletes anything. Publishing (checksum, signing, shipping a
+check) is documented in [Registry](docs/REGISTRY.md).
 
 ## Governance
 

--- a/dashboard-ui/src/pages/SkillsPage.tsx
+++ b/dashboard-ui/src/pages/SkillsPage.tsx
@@ -4,7 +4,27 @@ import { SectionHeader } from '../components/Charts';
 import CodeMirror from '@uiw/react-codemirror';
 import { markdown } from '@codemirror/lang-markdown';
 
-interface Skill { name: string; enabled: boolean; size: number; preview: string; }
+interface Skill {
+  name: string; enabled: boolean; size: number; preview: string;
+  version?: string; status?: string; verified?: boolean; signed?: boolean;
+  eval_status?: string; calls?: number;
+}
+
+// Provenance in one glance: what vouches for this skill, and is it ever used.
+// "unverified" is not a failure — a locally authored skill has no checksum —
+// so it reads as absence of proof, not as something broken.
+function proofLabel(s: Skill): { text: string; color: string; title: string } {
+  if (s.signed) return { text: 'signed', color: '#4ade80', title: 'a configured key signed this exact content' };
+  if (s.verified) return { text: 'checksum', color: '#38bdf8', title: 'declares a checksum that matches its content' };
+  return { text: 'unverified', color: '#555', title: 'declares no checksum — normal for a local skill' };
+}
+
+function evalLabel(status?: string): { text: string; color: string } | null {
+  if (status === 'passed') return { text: 'check ok', color: '#4ade80' };
+  if (status === 'failed') return { text: 'check failed', color: '#ef4444' };
+  if (status === 'error') return { text: 'check broken', color: '#f97316' };
+  return null;
+}
 
 export default function SkillsPage() {
   const [skills, setSkills] = useState<Skill[]>([]);
@@ -140,9 +160,28 @@ export default function SkillsPage() {
                   border: `1px solid ${selected === s.name ? '#2563eb33' : 'transparent'}`,
                   opacity: s.enabled ? 1 : 0.5,
                 }} onClick={() => loadSkill(s.name)}>
-                  <span style={{ flex: 1, color: selected === s.name ? '#fff' : '#999', fontSize: '0.82rem', fontWeight: selected === s.name ? 500 : 400 }}>
-                    {s.name}
-                  </span>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: 'flex', alignItems: 'baseline', gap: '0.35rem' }}>
+                      <span style={{ color: selected === s.name ? '#fff' : '#999', fontSize: '0.82rem', fontWeight: selected === s.name ? 500 : 400, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {s.name}
+                      </span>
+                      {s.version && <span style={{ fontSize: '0.62rem', color: '#555', fontFamily: 'monospace', flexShrink: 0 }}>v{s.version}</span>}
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '0.35rem', marginTop: '0.15rem', flexWrap: 'wrap' }}>
+                      <span title={proofLabel(s).title} style={{ fontSize: '0.6rem', color: proofLabel(s).color }}>
+                        {proofLabel(s).text}
+                      </span>
+                      {evalLabel(s.eval_status) && (
+                        <span style={{ fontSize: '0.6rem', color: evalLabel(s.eval_status)!.color }}>
+                          · {evalLabel(s.eval_status)!.text}
+                        </span>
+                      )}
+                      {s.status === 'draft' && <span style={{ fontSize: '0.6rem', color: '#f97316' }}>· draft</span>}
+                      <span title="times this skill was actually loaded" style={{ fontSize: '0.6rem', color: (s.calls ?? 0) > 0 ? '#888' : '#444' }}>
+                        · {(s.calls ?? 0) > 0 ? `${s.calls} loads` : 'never loaded'}
+                      </span>
+                    </div>
+                  </div>
                   <div style={{ display: 'flex', gap: '0.2rem', flexShrink: 0 }}>
                     <button onClick={(e) => { e.stopPropagation(); toggleSkill(s.name); }} style={{
                       padding: '0.12rem 0.4rem', borderRadius: 4, border: 'none', cursor: 'pointer', fontSize: '0.6rem', fontWeight: 600,

--- a/dashboard/api/skills.py
+++ b/dashboard/api/skills.py
@@ -28,13 +28,35 @@ class SkillContent(BaseModel):
     content: str
 
 
+def _provenance() -> dict[str, dict]:
+    """Version, proof and usage per skill, keyed by directory name.
+
+    Read through the store and the usage counter so the control room shows the
+    same facts as `kaos skills verify` and `kaos skills stats`. Best-effort: a
+    disabled or half-written skill must still list.
+    """
+    try:
+        from kronos.skills.store import SkillStore
+        from kronos.skills.usage import local_report
+
+        # Built from the same workspace the listing reads, not from the process-wide
+        # singleton: otherwise the two halves of a row could describe different
+        # agents' skills.
+        store = SkillStore(str(_skills_root().parent.parent))
+        return {row["skill"]: row for row in local_report(store)}
+    except Exception as e:  # pragma: no cover - defensive
+        log.debug("Could not read skill provenance: %s", e)
+        return {}
+
+
 @router.get("/")
 async def list_skills():
-    """List all skills with enabled status."""
+    """List all skills with enabled status, provenance and usage."""
     skills_dir = _skills_root()
     if not skills_dir.is_dir():
         return {"skills": []}
 
+    provenance = _provenance()
     skills = []
     for skill_dir in sorted(skills_dir.iterdir()):
         if not skill_dir.is_dir():
@@ -42,27 +64,30 @@ async def list_skills():
 
         skill_file = skill_dir / "SKILL.md"
         disabled_file = skill_dir / "SKILL.md.disabled"
-
         if skill_file.exists():
-            content = skill_file.read_text(encoding="utf-8")
-            skills.append(
-                {
-                    "name": skill_dir.name,
-                    "enabled": True,
-                    "size": len(content),
-                    "preview": content[:150],
-                }
-            )
+            content, enabled = skill_file.read_text(encoding="utf-8"), True
         elif disabled_file.exists():
-            content = disabled_file.read_text(encoding="utf-8")
-            skills.append(
-                {
-                    "name": skill_dir.name,
-                    "enabled": False,
-                    "size": len(content),
-                    "preview": content[:150],
-                }
-            )
+            content, enabled = disabled_file.read_text(encoding="utf-8"), False
+        else:
+            continue
+
+        row = provenance.get(skill_dir.name, {})
+        skills.append(
+            {
+                "name": skill_dir.name,
+                "enabled": enabled,
+                "size": len(content),
+                "preview": content[:150],
+                "version": row.get("version", ""),
+                "status": row.get("status", ""),
+                # "verified" means a checksum exists and this is what it covers;
+                # "signed" means a configured key vouched for it.
+                "verified": bool(row.get("verified", False)),
+                "signed": bool(row.get("signed", False)),
+                "eval_status": row.get("eval_status", "none"),
+                "calls": int(row.get("calls", 0) or 0),
+            }
+        )
 
     return {"skills": skills}
 

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -165,6 +165,32 @@ Two practical notes:
 Each agent writes to its own `data/<agent>/logs/`, so the six swarm processes
 maintain six independent chains and never contend.
 
+## What The Agent Installs: skills from elsewhere
+
+Two policy sections govern the registry (full detail in [Registry](REGISTRY.md)):
+
+```yaml
+registry:
+  trusted_keys: ["ssh-ed25519 AAAA… publisher@example.com"]
+  trust_default: checksum        # applies to a source that declares none
+  require_eval_on_install: true  # a failing scenario keeps the skill a draft
+  telemetry: "off"               # off | local | share
+
+evolution:
+  max_regression_pct: 0          # any regressed scenario auto-rejects a proposal
+  auto_reject: true
+```
+
+The one path where a skill activates without a human reading it is a signature from
+a key listed here, over the exact bytes, on a skill whose own offline check passed.
+Everything else installs as a draft — which is the same posture as the rest of this
+document: proof, or a pause.
+
+Note the YAML trap `telemetry` deliberately absorbs: a bare `off` parses as the
+boolean `false` in YAML 1.1, and it is honoured as "off" rather than failing
+startup. `telemetry: on` is refused, because guessing which mode was meant would be
+worse than an error.
+
 ## Checklist For A Public Or Shared Install
 
 1. `kaos policy report` — confirm every capability you did not intend is `false`.
@@ -173,5 +199,10 @@ maintain six independent chains and never contend.
 4. `ALLOWED_USERS` set; `ALLOW_ALL_USERS=false`.
 5. `WEBHOOK_SECRET` non-empty (an empty secret returns 401 for everything, which
    also breaks your own cron delivery).
+6. `kaos skills verify` — anything `FAIL` is a skill whose content no longer
+   matches what was signed or hashed. `UNVERIFIED` is normal for locally authored
+   skills.
+7. `registry.telemetry` stays `off` unless you decided otherwise; nothing is sent
+   automatically in any mode.
 6. `kaos audit verify` in a scheduled job, so a broken chain is noticed.
 7. `pytest -m eval` before deploying — see [Agent CI](EVALS.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Start here if you want to understand or contribute to Kronos Agent OS.
 | [MCP & Tools](MCP.md) | Static MCP, tool gateway, dynamic tool gates |
 | [Automations](AUTOMATIONS.md) | Scheduler, jobs, notifications, audit trail |
 | [Sub-Agents & Swarm](SWARM.md) | Optional multi-agent coordination |
+| [Skill Registry](REGISTRY.md) | Publishing, signing, installing and measuring skills |
 | [Dashboard](DASHBOARD.md) | Local control room and API map |
 | [Deployment](DEPLOYMENT.md) | Local, Docker, systemd, and server ops setup |
 | [Security](SECURITY.md) | Threat model and safe defaults |

--- a/docs/REGISTRY.md
+++ b/docs/REGISTRY.md
@@ -1,0 +1,227 @@
+# Skill Registry
+
+A skill is a markdown procedure the agent will follow. Installing one runs no
+code, but it does accept instructions — so the question "where did this come from,
+has it changed, and does it work" has to be answerable offline.
+
+This is a file-based registry. Sources are places you list in `registry.yaml`;
+nobody runs a service, and no source becomes trusted by being reachable.
+
+## Using it
+
+```bash
+cp registry.example.yaml registry.yaml
+kaos skills search memo          # search configured sources (cached locally)
+kaos skills info decision-memo   # what a source claims about a skill
+kaos skills install decision-memo
+kaos skills verify               # re-check everything installed
+kaos skills stats                # which skills are actually used
+```
+
+`search` serves a cached index for six hours; `--refresh` refetches. A source that
+is down is reported per source — one dead host does not make the others useless.
+
+## What install decides
+
+| Outcome | When |
+|---|---|
+| **active** | the source's `trust` is `signed`, the signature verifies against a key in `registry.trusted_keys`, the checksum matches, the version fits, and the skill's own scenario did not fail |
+| **draft** | anything else — with the reason attached |
+| **refused** | the name is taken by an installed skill or an existing tool, or the fetch failed |
+
+A draft is not a rejection: it is the pre-existing behaviour for external skills,
+and it is what you read before running `kaos skills approve <name>`. A failure never
+deletes anything; the worst case is a draft you can read.
+
+The one path that activates without a human reading the file is a signature from a
+key **you** configured, over the exact bytes, on a skill whose own check passed.
+That is stronger evidence than skimming markdown — which is the only reason it is
+allowed to substitute for it.
+
+## Publishing a skill
+
+### 1. Frontmatter
+
+```yaml
+---
+name: decision-memo
+description: Write a one-page decision memo
+version: 1.2.0
+requires_kaos: ">=0.2,<0.4"
+author: you@example.com
+tools: [read_file]
+checksum: "sha256:…"     # see below
+signature: "…"           # optional, see below
+---
+```
+
+Everything except `name` and `description` is optional; a skill written before this
+existed installs exactly as it always did, and reports as `unverified`.
+
+### 2. Checksum
+
+```bash
+python -c "from kronos.skills.integrity import compute_checksum; \
+           print(compute_checksum('path/to/decision-memo'))"
+```
+
+Paste the result into `checksum:`. The hash covers an **allowlist** of semantic
+fields — `name`, `description`, `version`, `requires_kaos`, `author`, `tools`,
+`tier` — plus the body and every file under `references/`.
+
+Two consequences worth knowing:
+
+* Local bookkeeping is *not* hashed (`status`, `imported_from`, `imported_at`,
+  `tags`, `eval_status`, and the `checksum`/`signature` fields themselves). This is
+  what makes the checksum survive import, which rewrites frontmatter, and what lets
+  KAOS record a local eval verdict without invalidating your checksum.
+* A silently added `tools:` entry *is* hashed. Requirements a skill imposes are part
+  of what you signed.
+
+### 3. Signature (optional, required by `trust: signed` sources)
+
+Sign the checksum string with an SSH key — the same mechanism as signed git
+commits, so there is no bespoke tooling and KAOS needs no crypto dependency:
+
+```bash
+printf '%s' "sha256:…" > checksum.txt
+ssh-keygen -Y sign -f ~/.ssh/id_ed25519 -n kaos-skill checksum.txt
+```
+
+Paste the body of `checksum.txt.sig` into `signature:` (the full PEM block also
+works). The installing side must have your **public** key in `policy.yaml`:
+
+```yaml
+registry:
+  trusted_keys:
+    - "ssh-ed25519 AAAAC3... you@example.com"
+```
+
+A signature over a checksum that no longer matches is refused, not reported as
+valid: the signature vouches for the checksum, so a broken checksum voids it.
+
+### 4. A check the installer can run (recommended)
+
+Ship a scenario next to `SKILL.md`:
+
+```
+decision-memo/
+├── SKILL.md
+├── references/…
+└── evals/scenario.yaml
+```
+
+The format is the Phase 8 scenario — self-contained, with the model's turns
+scripted inside it, so the installer replays it with no provider key and no
+network. See [Evals](EVALS.md) for the fields.
+
+By convention the scenario is a sibling of `SKILL.md`; an index entry may point
+elsewhere with `scenario_url`. Note the difference in how a bad response is
+treated: garbage from the *conventional* path means "no scenario here" (many hosts
+answer 200 with an HTML page for a missing file), while garbage from a URL you
+declared is kept and reported as your broken check.
+
+**What that check proves and does not.** It replays your own recorded turn against
+your own expectations. It catches a skill that contradicts itself — a forbidden
+tool called, a budget blown, a claim missing — and a skill broken in transit. It
+cannot tell anyone the skill is a good idea. So a passing scenario permits
+activation and never demands it, and a skill without one installs as `unverified`
+rather than being refused: most skills have none, and refusing them would leave the
+registry empty and the marking meaningless.
+
+### 5. The index
+
+Each source publishes `index.json` at its root (`github:user/repo` reads the
+repository root; `github:user/repo/subdir` reads that subdirectory):
+
+```json
+{
+  "version": 1,
+  "skills": [
+    {
+      "name": "decision-memo",
+      "description": "Write a one-page decision memo",
+      "version": "1.2.0",
+      "url": "github:you/skills/decision-memo",
+      "author": "you@example.com",
+      "requires_kaos": ">=0.2",
+      "checksum": "sha256:…",
+      "signed": true
+    }
+  ]
+}
+```
+
+An entry advertising a different checksum than the skill declares keeps the skill a
+draft — two sources of truth disagreeing is worth stopping on.
+
+## Trust levels
+
+| `trust` | Required to activate | Use for |
+|---|---|---|
+| `signed` | signature from a configured key | an official source |
+| `checksum` | nothing activates automatically; a matching checksum is still verified and reported | community sources |
+| `none` | nothing activates automatically, nothing is required | a local or experimental source |
+
+`registry.trust_default` in `policy.yaml` applies to a source that declares none.
+
+## Usage stats and telemetry
+
+```bash
+kaos skills stats            # local: version, proof, check verdict, real loads
+kaos skills stats --share    # anonymous aggregate, only with telemetry: share
+```
+
+`calls` counts real loads of a skill, not catalog listings. **Outcomes are not
+tracked**: nothing in the runtime links a turn's result back to the skills that turn
+loaded, so an ok-rate here would be invented. The signal for "does this skill work"
+is its scenario verdict, shown alongside.
+
+Telemetry is `off` by default and stays off unless an operator writes it in the
+policy:
+
+```yaml
+registry:
+  telemetry: off     # off | local | share
+```
+
+* `off` — no counters are read for sharing purposes at all.
+* `local` — counters are yours; still nothing to share.
+* `share` — `--share` assembles `{skill, version, calls_bucket, eval_status,
+  verified}`. No content, no exact counts, no timestamps, no agent or user
+  identity. Volume is bucketed (`unused`, `1-9`, `10-99`, `100+`) because an exact
+  count is a workflow fingerprint.
+
+Nothing is sent automatically in any mode — `--share` prints the payload, and where
+it goes is your decision. A test asserts that no aggregate is assembled while the
+mode is anything other than `share`.
+
+## Self-improvement, measured
+
+The same "prove it" rule applies to the agent's own persona proposals. A weekly
+proposal is now measured before the owner is asked (see
+[Runtime](RUNTIME.md) and `kronos/evolution_eval.py`): the patch is applied to a
+copy of the workspace, the prompt is reassembled, and the offline suite runs against
+both.
+
+What it can prove is bounded, and the report says so — `measured_quality: false`.
+Scripted scenarios cannot score an answer's quality, because the model's turns come
+from the scenario file. What they do catch is a persona that breaks prompt assembly,
+one that makes a scenario start failing, and one that repeats guidance already in
+the file. Those are auto-rejected with a reason and no notification; everything else
+reaches the owner with the delta attached.
+
+```bash
+/persona list              # pending proposals with their verdicts
+/persona show <id>         # the full measurement
+/persona list --rejected   # what the measurement refused, and why
+```
+
+Thresholds live in the `evolution` policy section (`max_regression_pct`,
+`auto_reject`). A missing suite means unmeasured, never auto-rejected.
+
+## Rollback
+
+Delete `registry.yaml` and `kaos skills install` answers "no sources configured".
+Nothing in this document changes the pre-existing `import_skill` path, and no skill
+already installed is affected.

--- a/kronos/bridge_commands.py
+++ b/kronos/bridge_commands.py
@@ -7,6 +7,8 @@ Handlers that need the live client (``/observer``, the ``/osint`` runner) stay
 in ``bridge.py``.
 """
 
+import json
+
 from kronos.config import settings
 from kronos.security.cost_guardian import get_guardian
 from kronos.swarm_store import get_swarm
@@ -49,6 +51,23 @@ def _handle_runtime_info_query(text: str) -> str | None:
     )
 
 
+def _proposal_measurement(proposal: dict) -> dict:
+    """Stored measurement for a proposal, or {} when it predates measuring."""
+    raw = proposal.get("eval_json") or ""
+    if not raw:
+        return {}
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _proposal_verdict(proposal: dict) -> str:
+    measurement = _proposal_measurement(proposal)
+    return str(measurement.get("decision_reason") or measurement.get("verdict") or "")
+
+
 async def _handle_persona_command(text: str) -> str | None:
     """Handle /persona [list | approve <id> | reject <id>]. Returns reply or None."""
     if not text.startswith("/persona"):
@@ -61,14 +80,50 @@ async def _handle_persona_command(text: str) -> str | None:
     agent = settings.agent_name
 
     if action == "list":
+        # Auto-rejected proposals are listed on request: a measurement that hides
+        # what it rejected is indistinguishable from one that never ran.
+        if "--rejected" in parts:
+            rejected = evolution.list_proposals(agent, state="rejected", limit=10)
+            if not rejected:
+                return "🧬 Отклонённых предложений нет."
+            lines = ["🧬 Отклонённые предложения:"]
+            for proposal in rejected:
+                reason = _proposal_verdict(proposal)
+                lines.append(f"#{proposal['id']} → {proposal['target']}: {proposal['rationale'][:60]}")
+                if reason:
+                    lines.append(f"    причина: {reason}")
+            return "\n".join(lines)
+
         pending = evolution.list_pending(agent)
         if not pending:
             return "🧬 Нет предложений эволюции персоны."
         lines = ["🧬 Предложения эволюции персоны:"]
         for proposal in pending:
             lines.append(f"#{proposal['id']} → {proposal['target']}: {proposal['rationale'][:80]}")
-        lines.append("\n/persona approve <id> · /persona reject <id>")
+            reason = _proposal_verdict(proposal)
+            if reason:
+                lines.append(f"    замер: {reason}")
+        lines.append("\n/persona show <id> · /persona approve <id> · /persona reject <id>")
         return "\n".join(lines)
+
+    if action == "show" and len(parts) > 2 and parts[2].isdigit():
+        proposal = evolution.get_proposal(int(parts[2]), agent)
+        if proposal is None:
+            return f"Предложение #{parts[2]} не найдено."
+        from kronos.evolution_eval import render_report
+
+        measurement = _proposal_measurement(proposal)
+        body = [
+            f"🧬 Предложение #{proposal['id']} → {proposal['target'].upper()} ({proposal['state']})",
+            f"Почему: {proposal['rationale']}",
+            "",
+            proposal["proposal"],
+        ]
+        if measurement:
+            body += ["", "Замер:", render_report(measurement)]
+        else:
+            body += ["", "Замера нет (предложение старше механизма измерения)."]
+        return "\n".join(body)
 
     if action in ("approve", "reject") and len(parts) > 2 and parts[2].isdigit():
         pid = int(parts[2])
@@ -81,7 +136,7 @@ async def _handle_persona_command(text: str) -> str | None:
         get_swarm().incr_metric("persona_proposals_approved")
         return f"✅ Применил предложение #{pid} к {decided['target'].upper()}\n{path}"
 
-    return "Использование: /persona [list | approve <id> | reject <id>]"
+    return "Использование: /persona [list [--rejected] | show <id> | approve <id> | reject <id>]"
 
 
 async def _handle_stats_command(text: str) -> str | None:

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -786,6 +786,39 @@ def _skills_workspace_root(agent: str = "") -> Path:
     return _repo_root() / "workspaces" / _agent_slug(settings.agent_name)
 
 
+def _integrity_trusted_keys() -> list[str]:
+    from kronos.skills.integrity import trusted_keys
+
+    return trusted_keys()
+
+
+def _print_verify_reports(reports: list[dict], *, keys: list[str]) -> None:
+    """One line per skill, plus the detail only when it is not the happy path."""
+    for row in reports:
+        if row["unverified"]:
+            status = "UNVERIFIED"
+        elif row["trusted"]:
+            status = "SIGNED" if row["signature_ok"] else "OK"
+        else:
+            status = "FAIL"
+        print(f"[{status}] {row['skill']} v{row['version']}")
+        if not row["checksum_ok"]:
+            print(f"         {row['checksum_detail']}")
+        if not row["compatible"]:
+            print(f"         {row['compatibility_detail']}")
+        if row["signature_detail"] != "no signature declared":
+            print(f"         {row['signature_detail']}")
+
+    unverified = sum(1 for row in reports if row["unverified"])
+    if unverified:
+        print(
+            f"\n{unverified} skill(s) declare no checksum — locally authored skills normally do not. "
+            "Add `checksum:` to SKILL.md to make tampering detectable."
+        )
+    if not keys and any(row["signature_detail"].startswith("no trusted keys") for row in reports):
+        print("No registry.trusted_keys in policy.yaml, so signatures cannot be checked.")
+
+
 def run_skills(
     command: str,
     pack: str = "",
@@ -820,6 +853,32 @@ def run_skills(
         result = import_skill(source, store)
         print(result)
         return 0 if "imported successfully" in result else 1
+
+    if command == "verify":
+        from kronos.skills.integrity import verify_skill
+        from kronos.skills.store import SkillStore
+
+        store = SkillStore(str(_skills_workspace_root(agent)))
+        targets = [store.get(skill)] if skill else store.list_skills()
+        if skill and targets[0] is None:
+            print(f"Skill '{skill}' not found.")
+            return 1
+        if not targets:
+            print("No skills installed.")
+            return 0
+
+        keys = _integrity_trusted_keys()
+        reports = [verify_skill(target, keys=keys) for target in targets]
+        if output == "json":
+            print(json.dumps(reports, indent=2))
+        else:
+            _print_verify_reports(reports, keys=keys)
+        # A skill with no checksum is unverified, not broken — only a *failed*
+        # check is an error, otherwise every pre-12.1 skill would fail the exit code.
+        broken = [row for row in reports if row["checksum_ok"] is False and row["unverified"] is False]
+        broken += [row for row in reports if not row["compatible"]]
+        broken += [row for row in reports if row["signature_detail"].startswith("signature does not match")]
+        return 1 if broken else 0
 
     if command == "export":
         from kronos.skills.hub import export_skill
@@ -1542,6 +1601,10 @@ def build_parser() -> argparse.ArgumentParser:
     skill_import = skills_sub.add_parser("import", help="import an external SKILL.md as a draft")
     skill_import.add_argument("source", help="URL to SKILL.md or github:user/repo/skill-name")
     skill_import.add_argument("--agent", default="", help="target AGENT_NAME/workspace; defaults to current settings")
+    skill_verify = skills_sub.add_parser("verify", help="check skill checksums, signatures and version requirements")
+    skill_verify.add_argument("skill", nargs="?", default="", help="one skill; omit to verify all")
+    skill_verify.add_argument("--agent", default="", help="target AGENT_NAME/workspace; defaults to current settings")
+    skill_verify.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
     skill_export = skills_sub.add_parser("export", help="export a local skill as SKILL.md")
     skill_export.add_argument("skill")
     skill_export.add_argument("--agent", default="", help="source AGENT_NAME/workspace; defaults to current settings")
@@ -1756,6 +1819,13 @@ def main(argv: list[str] | None = None) -> int:
             )
         if args.skills_command == "import":
             return run_skills("import", source=args.source, agent=args.agent)
+        if args.skills_command == "verify":
+            return run_skills(
+                "verify",
+                skill=args.skill,
+                agent=args.agent,
+                output="json" if args.as_json else "",
+            )
         if args.skills_command == "export":
             return run_skills("export", skill=args.skill, agent=args.agent, output=args.output)
         parser.parse_args(["skills", "--help"])

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -918,6 +918,45 @@ def run_skills(
     if command in ("search", "info", "install"):
         return _run_skills_registry(command, query=source or skill, agent=agent, source_name=pack, refresh=force)
 
+    if command == "stats":
+        from kronos.skills.store import SkillStore
+        from kronos.skills.usage import local_report, shareable_aggregate, telemetry_mode
+
+        store = SkillStore(str(_skills_workspace_root(agent)))
+        rows = local_report(store)
+        if not rows:
+            print("No skills installed.")
+            return 0
+
+        if output == "share":
+            payload = shareable_aggregate(store)
+            if not payload:
+                print(
+                    f"Telemetry is '{telemetry_mode()}'. Nothing was assembled and nothing was sent.\n"
+                    "Set registry.telemetry: share in policy.yaml to allow an anonymous aggregate."
+                )
+                return 1
+            print(json.dumps(payload, indent=2))
+            return 0
+
+        print(f"Skills in {store.skills_roots[-1]}\n")
+        print(f"{'skill':<28} {'ver':<8} {'calls':>6}  {'state':<8} {'proof':<12} check")
+        for row in rows:
+            proof = "signed" if row["signed"] else ("checksum" if row["verified"] else "unverified")
+            print(
+                f"{row['skill'][:28]:<28} {row['version'][:8]:<8} {row['calls']:>6}  "
+                f"{row['status']:<8} {proof:<12} {row['eval_status']}"
+            )
+        unused = [row["skill"] for row in rows if not row["calls"]]
+        if unused:
+            print(f"\nNever loaded: {', '.join(unused[:8])}")
+        print(
+            "\nCalls are real loads of the skill. Outcomes are not tracked: nothing in the\n"
+            "runtime links a turn's result to the skills it loaded, so an ok-rate here would\n"
+            "be invented. The check column is the skill's own scenario verdict."
+        )
+        return 0
+
     if command == "approve":
         from kronos.skills.store import SkillStore
 
@@ -1693,6 +1732,13 @@ def build_parser() -> argparse.ArgumentParser:
     skill_registry_install.add_argument("--source", default="", help="pin to one configured source")
     skill_registry_install.add_argument("--agent", default="", help="target AGENT_NAME/workspace")
     skill_registry_install.add_argument("--refresh", action="store_true", help="refetch source indexes first")
+    skill_stats = skills_sub.add_parser("stats", help="which skills are actually used")
+    skill_stats.add_argument("--agent", default="", help="target AGENT_NAME/workspace")
+    skill_stats.add_argument(
+        "--share",
+        action="store_true",
+        help="print the anonymous aggregate (requires registry.telemetry: share)",
+    )
     skill_approve = skills_sub.add_parser("approve", help="activate a draft skill after reviewing it")
     skill_approve.add_argument("skill")
     skill_approve.add_argument("--agent", default="", help="target AGENT_NAME/workspace")
@@ -1926,6 +1972,8 @@ def main(argv: list[str] | None = None) -> int:
                 agent=args.agent,
                 force=args.refresh,
             )
+        if args.skills_command == "stats":
+            return run_skills("stats", agent=args.agent, output="share" if args.share else "")
         if args.skills_command == "approve":
             return run_skills("approve", skill=args.skill, agent=args.agent)
         if args.skills_command == "verify":

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -601,6 +601,32 @@ def run_doctor() -> int:
     except SwarmConfigError as e:
         fail("Swarm registry", str(e).splitlines()[0])
 
+    from kronos.skills.registry import RegistryError as _RegistryError
+    from kronos.skills.registry import load_sources as _load_sources
+
+    try:
+        _sources = _load_sources()
+        if not _sources:
+            ok("Skill sources", "none configured (copy registry.example.yaml to add one)")
+        else:
+            ok(
+                "Skill sources",
+                ", ".join(f"{source.name} ({source.trust})" for source in _sources),
+            )
+            _signed = [source for source in _sources if source.trust == "signed"]
+            if _signed:
+                from kronos.skills.integrity import trusted_keys as _keys
+
+                if not _keys():
+                    warn(
+                        "Skill signatures",
+                        f"{len(_signed)} source(s) require signing but registry.trusted_keys is empty",
+                    )
+                else:
+                    ok("Skill signatures", f"{len(_keys())} trusted key(s)")
+    except _RegistryError as e:
+        fail("Skill sources", str(e).splitlines()[0])
+
     from kronos.portability import BUNDLE_SCHEMA_VERSION
     from kronos.portability.importers import available as _importers
 

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -819,6 +819,67 @@ def _print_verify_reports(reports: list[dict], *, keys: list[str]) -> None:
         print("No registry.trusted_keys in policy.yaml, so signatures cannot be checked.")
 
 
+def _run_skills_registry(command: str, *, query: str, agent: str, source_name: str, refresh: bool) -> int:
+    """`kaos skills search|info|install` — the registry side of the skills verb."""
+    from kronos.skills.registry import RegistryError, find_entry, install, load_index, load_sources, search
+
+    try:
+        sources = load_sources()
+    except RegistryError as e:
+        print(f"[FAIL] {e}")
+        return 1
+
+    if not sources:
+        print("No skill sources configured. Copy registry.example.yaml to registry.yaml to add one.")
+        return 1
+
+    entries, problems = load_index(sources, refresh=refresh)
+    for problem in problems:
+        print(f"[WARN] {problem}")
+    if not entries:
+        print("No skills found in any configured source.")
+        return 1
+
+    if command == "search":
+        matches = search(query, entries)
+        if not matches:
+            print(f"Nothing matches '{query}'.")
+            return 0
+        for entry in matches:
+            marks = " (signed)" if entry.signed else ""
+            print(f"- {entry.name} v{entry.version or '?'} [{entry.source}{marks}]: {entry.description}")
+        print("\nInstall one with: kaos skills install <name>")
+        return 0
+
+    if command == "info":
+        entry = find_entry(query, entries, source=source_name)
+        if entry is None:
+            print(f"'{query}' is not in the index.")
+            return 1
+        print(f"{entry.name} v{entry.version or 'unknown'}")
+        print(f"  source:      {entry.source} (trust: {entry.trust})")
+        print(f"  description: {entry.description or 'none'}")
+        print(f"  author:      {entry.author or 'unknown'}")
+        print(f"  url:         {entry.url or 'missing'}")
+        print(f"  requires:    KAOS {entry.requires_kaos or 'any'}")
+        print(f"  checksum:    {entry.checksum or 'not advertised'}")
+        print(f"  signed:      {'yes' if entry.signed else 'no'}")
+        return 0
+
+    from kronos.skills.store import SkillStore
+
+    workspace_root = _skills_workspace_root(agent)
+    store = SkillStore(str(workspace_root))
+    result = install(query, store=store, source=source_name, entries=entries)
+    print(result.render())
+    if result.installed and result.status == "draft":
+        skill = store.get(result.skill)
+        if skill is not None:
+            print(f"Read it at {skill.path}")
+        print(f"Activate it once you trust it: kaos skills approve {result.skill}")
+    return 0 if result.installed else 1
+
+
 def run_skills(
     command: str,
     pack: str = "",
@@ -853,6 +914,24 @@ def run_skills(
         result = import_skill(source, store)
         print(result)
         return 0 if "imported successfully" in result else 1
+
+    if command in ("search", "info", "install"):
+        return _run_skills_registry(command, query=source or skill, agent=agent, source_name=pack, refresh=force)
+
+    if command == "approve":
+        from kronos.skills.store import SkillStore
+
+        store = SkillStore(str(_skills_workspace_root(agent)))
+        target = store.get(skill)
+        if target is None:
+            print(f"Skill '{skill}' not found.")
+            return 1
+        if target.status == "active":
+            print(f"Skill '{skill}' is already active.")
+            return 0
+        store.update_status(skill, "active")
+        print(f"Skill '{skill}' is now active.")
+        return 0
 
     if command == "verify":
         from kronos.skills.integrity import verify_skill
@@ -1601,6 +1680,22 @@ def build_parser() -> argparse.ArgumentParser:
     skill_import = skills_sub.add_parser("import", help="import an external SKILL.md as a draft")
     skill_import.add_argument("source", help="URL to SKILL.md or github:user/repo/skill-name")
     skill_import.add_argument("--agent", default="", help="target AGENT_NAME/workspace; defaults to current settings")
+    skill_search = skills_sub.add_parser("search", help="search configured skill sources")
+    skill_search.add_argument("query", nargs="?", default="", help="substring to match; omit to list everything")
+    skill_search.add_argument(
+        "--refresh", action="store_true", help="refetch source indexes instead of using the cache"
+    )
+    skill_info = skills_sub.add_parser("info", help="show what a source advertises about a skill")
+    skill_info.add_argument("skill")
+    skill_info.add_argument("--source", default="", help="pin to one configured source")
+    skill_registry_install = skills_sub.add_parser("install", help="install a skill from a configured source")
+    skill_registry_install.add_argument("skill")
+    skill_registry_install.add_argument("--source", default="", help="pin to one configured source")
+    skill_registry_install.add_argument("--agent", default="", help="target AGENT_NAME/workspace")
+    skill_registry_install.add_argument("--refresh", action="store_true", help="refetch source indexes first")
+    skill_approve = skills_sub.add_parser("approve", help="activate a draft skill after reviewing it")
+    skill_approve.add_argument("skill")
+    skill_approve.add_argument("--agent", default="", help="target AGENT_NAME/workspace")
     skill_verify = skills_sub.add_parser("verify", help="check skill checksums, signatures and version requirements")
     skill_verify.add_argument("skill", nargs="?", default="", help="one skill; omit to verify all")
     skill_verify.add_argument("--agent", default="", help="target AGENT_NAME/workspace; defaults to current settings")
@@ -1819,6 +1914,20 @@ def main(argv: list[str] | None = None) -> int:
             )
         if args.skills_command == "import":
             return run_skills("import", source=args.source, agent=args.agent)
+        if args.skills_command == "search":
+            return run_skills("search", source=args.query, force=args.refresh)
+        if args.skills_command == "info":
+            return run_skills("info", skill=args.skill, pack=args.source)
+        if args.skills_command == "install":
+            return run_skills(
+                "install",
+                skill=args.skill,
+                pack=args.source,
+                agent=args.agent,
+                force=args.refresh,
+            )
+        if args.skills_command == "approve":
+            return run_skills("approve", skill=args.skill, agent=args.agent)
         if args.skills_command == "verify":
             return run_skills(
                 "verify",

--- a/kronos/cron/persona_evolve.py
+++ b/kronos/cron/persona_evolve.py
@@ -3,8 +3,17 @@
 Reads the week's satisfaction + negative feedback, asks the LLM for ONE concrete
 edit to SOUL or IDENTITY, stores it as a pending proposal, and notifies the user
 in Telegram to approve/reject via /persona. Nothing is applied without approval.
+
+Since moat 12.4 every proposal is measured before the owner sees it (see
+`kronos.evolution_eval`): the patched persona is applied to a copy of the
+workspace, the offline scenario suite is run against both, and a proposal that
+breaks prompt assembly, regresses a scenario, or merely repeats what the file
+already says is auto-rejected without a notification. What that measurement can
+and cannot prove is documented in that module — it cannot score answer quality,
+and the report says so rather than implying otherwise.
 """
 
+import json
 import logging
 
 from langchain_core.messages import HumanMessage
@@ -91,13 +100,47 @@ PROPOSAL: <конкретный текст, готовый к вставке в 
         return
 
     target, rationale, proposal = parsed
-    pid = evolution.create_proposal(agent_name=agent, target=target, rationale=rationale, proposal=proposal)
+
+    # Measure before anyone is asked (moat 12.4). A proposal that breaks prompt
+    # assembly, regresses a scenario or merely repeats what the file already says
+    # is decided here; the owner's attention is for judgement calls.
+    from kronos.evolution_eval import measure_proposal, render_report, verdict
+    from kronos.policy import get_policy
+
+    candidate = {"target": target, "rationale": rationale, "proposal": proposal}
+    try:
+        measurement = await measure_proposal(candidate)
+    except Exception as e:
+        log.warning("Persona proposal could not be measured: %s", e)
+        measurement = {"measured_quality": False, "notes": [f"measurement failed: {e}"], "regressions": []}
+
+    evolution_policy = get_policy().evolution
+    acceptable, reason = verdict(measurement, max_regression_pct=evolution_policy.max_regression_pct)
+    measurement["verdict"] = reason
+
+    pid = evolution.create_proposal(
+        agent_name=agent,
+        target=target,
+        rationale=rationale,
+        proposal=proposal,
+        eval_json=json.dumps(measurement, ensure_ascii=False),
+    )
     swarm.incr_metric("persona_proposals_created")
+
+    if not acceptable and evolution_policy.auto_reject:
+        evolution.decide_proposal(pid, agent, approved=False)
+        evolution.record_decision_reason(pid, reason)
+        swarm.incr_metric("persona_proposals_auto_rejected")
+        # No push: a proposal the measurement refuted is noise, not news. It stays
+        # visible in `/persona list --rejected` with its reason.
+        log.info("Persona proposal #%s auto-rejected: %s", pid, reason)
+        return
 
     send_bot_api(
         f"🧬 Предложение эволюции персоны #{pid} → {target.upper()}\n\n"
         f"Почему: {rationale}\n\n"
         f"Изменение:\n{proposal}\n\n"
+        f"Замер:\n{render_report(measurement)}\n\n"
         f"Применить: /persona approve {pid} · Отклонить: /persona reject {pid}",
         topic_id=TOPIC_GENERAL,
     )

--- a/kronos/evolution.py
+++ b/kronos/evolution.py
@@ -32,6 +32,12 @@ def _init_schema(conn) -> None:
         """
     )
 
+    # Measurement of the proposal (moat 12.4). Added by migration so an existing
+    # database keeps its pending proposals.
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(persona_proposals)").fetchall()}
+    if "eval_json" not in columns:
+        conn.execute("ALTER TABLE persona_proposals ADD COLUMN eval_json TEXT")
+
 
 def _db():
     db = get_db("persona_proposals")
@@ -39,15 +45,54 @@ def _db():
     return db
 
 
-def create_proposal(*, agent_name: str, target: str, rationale: str, proposal: str) -> int:
+def create_proposal(
+    *,
+    agent_name: str,
+    target: str,
+    rationale: str,
+    proposal: str,
+    eval_json: str = "",
+) -> int:
     """Insert a pending proposal and return its id."""
     cursor = _db().write(
         "INSERT INTO persona_proposals "
-        "(agent_name, target, rationale, proposal, state, created_at) "
-        "VALUES (?, ?, ?, ?, 'pending', ?)",
-        (agent_name, target, rationale, proposal, time.time()),
+        "(agent_name, target, rationale, proposal, state, created_at, eval_json) "
+        "VALUES (?, ?, ?, ?, 'pending', ?, ?)",
+        (agent_name, target, rationale, proposal, time.time(), eval_json),
     )
     return int(cursor.lastrowid)
+
+
+def list_proposals(agent_name: str, *, state: str = "", limit: int = 20) -> list[dict]:
+    """Recent proposals, optionally filtered by state (including rejected ones).
+
+    Auto-rejected proposals are listed here on purpose: a measurement that hides
+    what it rejected is indistinguishable from one that never ran.
+    """
+    if state:
+        rows = _db().read(
+            "SELECT * FROM persona_proposals WHERE agent_name=? AND state=? ORDER BY created_at DESC LIMIT ?",
+            (agent_name, state, limit),
+        )
+    else:
+        rows = _db().read(
+            "SELECT * FROM persona_proposals WHERE agent_name=? ORDER BY created_at DESC LIMIT ?",
+            (agent_name, limit),
+        )
+    return [dict(row) for row in rows]
+
+
+def record_decision_reason(proposal_id: int, reason: str) -> None:
+    """Attach why a proposal was decided, inside the stored measurement."""
+    import json as _json
+
+    row = _db().read_one("SELECT eval_json FROM persona_proposals WHERE id=?", (proposal_id,))
+    try:
+        payload = _json.loads(row["eval_json"]) if row and row["eval_json"] else {}
+    except (TypeError, ValueError):
+        payload = {}
+    payload["decision_reason"] = reason
+    _db().write("UPDATE persona_proposals SET eval_json=? WHERE id=?", (_json.dumps(payload), proposal_id))
 
 
 def list_pending(agent_name: str) -> list[dict]:

--- a/kronos/evolution_eval.py
+++ b/kronos/evolution_eval.py
@@ -1,0 +1,257 @@
+"""Measure a persona proposal before a human is asked about it (moat 12.4).
+
+Self-improvement used to arrive as an assertion: "this edit will improve the
+reaction". Nothing checked it, so every proposal cost the owner a read.
+
+What can honestly be measured here is narrower than the roadmap assumed, and the
+difference matters enough to state plainly:
+
+* Golden scenarios replay a **scripted** model (Phase 8): the model's turns come
+  from the scenario file, so they do not change when the system prompt changes. A
+  persona edit therefore cannot move a scripted scenario's *answer*. Claiming a
+  quality delta from this suite would be a lie dressed as a number.
+* What the suite genuinely proves is that the patched persona still runs: the
+  prompt assembles, the engine's invariants (tool gating, approvals, budgets) hold,
+  and no scenario starts failing. A persona long enough to blow a turn budget, or
+  malformed enough to break prompt assembly, is caught here.
+* The rest of the signal is structural and cheap: does the prompt still build, how
+  much longer does it get, and is the proposal already present in the file (LLMs
+  re-propose the same guidance for weeks).
+
+So a proposal carries a measurement that can *refute* it and cannot flatter it.
+`measured_quality: false` is part of the report, not a footnote.
+
+The patched persona is applied to a copy of the workspace, never to the live one —
+persona files are not in git, so the worktree trick from Phase 8.5 does not apply
+here.
+"""
+
+import logging
+import shutil
+import tempfile
+from pathlib import Path
+
+log = logging.getLogger("kronos.evolution_eval")
+
+# A persona section this much larger than the file it joins is suspicious on its
+# own: prompts are the most expensive real estate in the system.
+PROMPT_GROWTH_WARN_PCT = 25.0
+
+# Near-duplicate detection: proportion of the proposal's lines already present.
+DUPLICATE_LINE_THRESHOLD = 0.6
+
+
+def _target_file(workspace, target: str) -> Path:
+    return {"soul": workspace.soul, "identity": workspace.identity}[target]
+
+
+def patched_workspace(proposal: dict, *, into: Path) -> Path:
+    """Copy the live workspace and apply the proposal to the copy."""
+    from kronos.workspace import Workspace, ws
+
+    source = ws.root
+    destination = into / source.name
+    shutil.copytree(source, destination, dirs_exist_ok=True)
+
+    patched = Workspace(destination)
+    target_file = _target_file(patched, proposal["target"])
+    target_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(target_file, "a", encoding="utf-8") as handle:
+        handle.write(f"\n\n## Evolution (proposed)\n_{proposal.get('rationale', '')}_\n\n{proposal['proposal']}\n")
+    return destination
+
+
+def prompt_delta(proposal: dict, patched_root: Path) -> dict:
+    """Does the patched persona still assemble, and how much bigger is it?"""
+    import kronos.workspace as workspace_module
+    from kronos.persona import build_system_prompt
+    from kronos.workspace import Workspace
+
+    original = workspace_module.ws
+    try:
+        before = build_system_prompt()
+    except Exception as e:
+        return {"built": False, "error": f"the current persona does not build: {e}"}
+
+    workspace_module.ws = Workspace(patched_root)
+    try:
+        after = build_system_prompt()
+    except Exception as e:
+        return {"built": False, "error": f"patched persona does not build: {e}"}
+    finally:
+        workspace_module.ws = original
+
+    growth = ((len(after) - len(before)) / len(before) * 100) if before else 0.0
+    return {
+        "built": True,
+        "chars_before": len(before),
+        "chars_after": len(after),
+        "growth_pct": round(growth, 2),
+    }
+
+
+def duplicate_ratio(proposal: dict) -> float:
+    """How much of the proposal is already in the target file.
+
+    Persona generation runs weekly off the same feedback, so re-proposing existing
+    guidance is the common failure, not a rare one.
+    """
+    from kronos.workspace import ws
+
+    target_file = _target_file(ws, proposal["target"])
+    if not target_file.is_file():
+        return 0.0
+    existing = {line.strip().lower() for line in target_file.read_text(encoding="utf-8").splitlines() if line.strip()}
+    lines = [line.strip().lower() for line in str(proposal["proposal"]).splitlines() if line.strip()]
+    if not lines:
+        return 0.0
+    return round(sum(1 for line in lines if line in existing) / len(lines), 2)
+
+
+async def measure_proposal(proposal: dict, *, suite_dir: Path | None = None) -> dict:
+    """Everything measurable about one proposal, as a report the DB can hold."""
+    from kronos.cli import DEFAULT_EVAL_SUITE
+    from kronos.evals.diff import diff_reports
+    from kronos.evals.runner import run_suite
+
+    report: dict = {
+        "measured_quality": False,
+        "why_not": (
+            "golden scenarios replay a scripted model, so a persona edit cannot change "
+            "their answers; this measures that the patched persona still runs"
+        ),
+        "duplicate_ratio": 0.0,
+        "prompt": {},
+        "suite": {},
+        "entries": [],
+        "regressions": [],
+        "notes": [],
+    }
+
+    try:
+        report["duplicate_ratio"] = duplicate_ratio(proposal)
+    except Exception as e:  # pragma: no cover - defensive
+        report["notes"].append(f"duplicate check failed: {e}")
+
+    suite = Path(suite_dir) if suite_dir else Path(__file__).resolve().parent.parent / DEFAULT_EVAL_SUITE
+    if not suite.is_dir():
+        report["notes"].append(f"no scenario suite at {suite}; proposal is unmeasured")
+        return report
+
+    with tempfile.TemporaryDirectory(prefix="kaos-persona-eval-") as tmp:
+        try:
+            patched_root = patched_workspace(proposal, into=Path(tmp))
+        except Exception as e:
+            report["notes"].append(f"could not build a patched workspace: {e}")
+            return report
+
+        report["prompt"] = prompt_delta(proposal, patched_root)
+        if not report["prompt"].get("built", False):
+            report["regressions"].append(
+                {
+                    "scenario": "system-prompt",
+                    "kind": "prompt_broken",
+                    "detail": report["prompt"].get("error", "prompt did not build"),
+                }
+            )
+            return report
+
+        growth = report["prompt"].get("growth_pct", 0.0)
+        if growth > PROMPT_GROWTH_WARN_PCT:
+            report["notes"].append(f"the prompt grows {growth:.1f}% — every turn pays for that")
+
+        base = await run_suite(suite)
+        head = await _run_suite_with_workspace(suite, patched_root)
+
+    diff = diff_reports(base.to_dict(), head.to_dict(), base_ref="current", head_ref="proposed")
+    report["suite"] = {
+        "base_failed": diff.base_failed,
+        "head_failed": diff.head_failed,
+        "scenarios": len(base.results),
+    }
+    report["entries"] = [entry.to_dict() for entry in diff.entries]
+    report["regressions"] = [entry.to_dict() for entry in diff.regressions]
+    if diff.empty:
+        report["notes"].append("no behaviour change in the offline suite")
+    return report
+
+
+async def _run_suite_with_workspace(suite: Path, patched_root: Path):
+    """Run the suite with the patched workspace swapped in, then swap back."""
+    import kronos.workspace as workspace_module
+    from kronos.evals.runner import run_suite
+    from kronos.workspace import Workspace
+
+    original = workspace_module.ws
+    workspace_module.ws = Workspace(patched_root)
+    try:
+        return await run_suite(suite)
+    finally:
+        workspace_module.ws = original
+
+
+def regression_pct(report: dict) -> float:
+    """Share of scenarios that started failing, as a percentage."""
+    total = int(report.get("suite", {}).get("scenarios", 0) or 0)
+    regressions = len(report.get("regressions", []) or [])
+    if not total:
+        return 100.0 if regressions else 0.0
+    return round(regressions / total * 100, 2)
+
+
+def verdict(report: dict, *, max_regression_pct: float) -> tuple[bool, str]:
+    """Should a human be asked about this proposal at all?
+
+    Auto-rejection is for proposals that are measurably worse or plainly
+    redundant. Everything else reaches the owner — the point is to spend their
+    attention on judgement calls, not to hide changes from them.
+    """
+    broken = [entry for entry in report.get("regressions", []) if entry.get("kind") == "prompt_broken"]
+    if broken:
+        return False, broken[0].get("detail", "the patched persona does not build")
+
+    pct = regression_pct(report)
+    if pct > max_regression_pct:
+        names = ", ".join(entry.get("scenario", "?") for entry in report.get("regressions", [])[:3])
+        return False, f"{pct:.0f}% of scenarios regressed ({names})"
+
+    if report.get("duplicate_ratio", 0.0) >= DUPLICATE_LINE_THRESHOLD:
+        return False, f"{report['duplicate_ratio'] * 100:.0f}% of the proposal is already in the file"
+
+    return True, "no measurable regression"
+
+
+def render_report(report: dict) -> str:
+    """Short human summary — what goes into Telegram and `/persona show`."""
+    lines: list[str] = []
+
+    prompt = report.get("prompt") or {}
+    if prompt.get("built"):
+        lines.append(f"Промпт: +{prompt.get('growth_pct', 0):.1f}% ({prompt.get('chars_after', 0)} симв.)")
+    elif prompt:
+        lines.append(f"Промпт НЕ собирается: {prompt.get('error', 'unknown')}")
+
+    suite = report.get("suite") or {}
+    if suite:
+        lines.append(
+            f"Сценарии: {suite.get('scenarios', 0)}, падений {suite.get('base_failed', 0)} → {suite.get('head_failed', 0)}"
+        )
+
+    entries = report.get("entries") or []
+    if entries:
+        for entry in entries[:5]:
+            lines.append(f"• {entry.get('scenario')}: {entry.get('kind')} — {entry.get('detail')}")
+    elif suite:
+        lines.append("• поведение офлайн-сьюта не изменилось")
+
+    duplicate = report.get("duplicate_ratio", 0.0)
+    if duplicate:
+        lines.append(f"Дублирует уже написанное: {duplicate * 100:.0f}%")
+
+    for note in report.get("notes") or []:
+        lines.append(f"— {note}")
+
+    if not report.get("measured_quality", False):
+        lines.append("— качество ответа офлайн не измеряется (модель в сценариях скриптована)")
+
+    return "\n".join(lines)

--- a/kronos/policy.py
+++ b/kronos/policy.py
@@ -153,7 +153,6 @@ class RegistryPolicy(BaseModel):
     trust_default: str = "checksum"
     require_eval_on_install: bool = True
     telemetry: str = "off"
-    max_regression_pct: float = 0.0
 
     @field_validator("trust_default")
     @classmethod
@@ -169,11 +168,22 @@ class RegistryPolicy(BaseModel):
             raise ValueError(f"registry.telemetry must be one of {TELEMETRY_MODES}, got {value!r}")
         return value
 
+
+class EvolutionPolicy(BaseModel):
+    """How much a self-improvement proposal must prove (moat 12.4).
+
+    `max_regression_pct` is 0 by default: a proposal that makes any scenario fail
+    is auto-rejected rather than shown to the owner.
+    """
+
+    max_regression_pct: float = 0.0
+    auto_reject: bool = True
+
     @field_validator("max_regression_pct")
     @classmethod
     def _sane_regression(cls, value: float) -> float:
         if not 0 <= value <= 100:
-            raise ValueError("registry.max_regression_pct must be a percentage between 0 and 100")
+            raise ValueError("evolution.max_regression_pct must be a percentage between 0 and 100")
         return value
 
 
@@ -190,6 +200,7 @@ class Policy(BaseModel):
     durable: DurablePolicy = Field(default_factory=DurablePolicy)
     pii: PiiPolicy = Field(default_factory=PiiPolicy)
     registry: RegistryPolicy = Field(default_factory=RegistryPolicy)
+    evolution: EvolutionPolicy = Field(default_factory=EvolutionPolicy)
 
     # Where this policy came from; "" means "no file, code defaults".
     source_path: str = ""

--- a/kronos/policy.py
+++ b/kronos/policy.py
@@ -161,12 +161,20 @@ class RegistryPolicy(BaseModel):
             raise ValueError(f"registry.trust_default must be one of {TRUST_LEVELS}, got {value!r}")
         return value
 
-    @field_validator("telemetry")
+    @field_validator("telemetry", mode="before")
     @classmethod
-    def _known_telemetry_mode(cls, value: str) -> str:
-        if value not in TELEMETRY_MODES:
+    def _known_telemetry_mode(cls, value: object) -> str:
+        # YAML 1.1 parses a bare `off` as False, and `telemetry: off` is exactly how
+        # an operator will write "no telemetry". Honour that instead of failing
+        # startup over a quoting rule nobody should have to know.
+        if value is False:
+            return "off"
+        if value is True:
+            raise ValueError(f"registry.telemetry must be one of {TELEMETRY_MODES}, not a boolean true")
+        text = str(value or "").strip().lower()
+        if text not in TELEMETRY_MODES:
             raise ValueError(f"registry.telemetry must be one of {TELEMETRY_MODES}, got {value!r}")
-        return value
+        return text
 
 
 class EvolutionPolicy(BaseModel):

--- a/kronos/policy.py
+++ b/kronos/policy.py
@@ -38,6 +38,8 @@ SOURCE_DEFAULT = "default"
 
 INJECTION_ACTIONS = ("log", "strip", "block")
 EGRESS_MODES = ("allowlist", "open")
+TRUST_LEVELS = ("signed", "checksum", "none")
+TELEMETRY_MODES = ("off", "local", "share")
 
 
 class PolicyError(Exception):
@@ -139,6 +141,42 @@ class PiiPolicy(BaseModel):
     mask_in_cassettes: bool = True
 
 
+class RegistryPolicy(BaseModel):
+    """Where skills may come from and how much they must prove (moat 12).
+
+    `trust_default` applies to a source that declares none. `telemetry` is off by
+    default and stays off unless an operator writes it here — usage data about
+    which skills work is the user's, not ours.
+    """
+
+    trusted_keys: list[str] = Field(default_factory=list)
+    trust_default: str = "checksum"
+    require_eval_on_install: bool = True
+    telemetry: str = "off"
+    max_regression_pct: float = 0.0
+
+    @field_validator("trust_default")
+    @classmethod
+    def _known_trust_level(cls, value: str) -> str:
+        if value not in TRUST_LEVELS:
+            raise ValueError(f"registry.trust_default must be one of {TRUST_LEVELS}, got {value!r}")
+        return value
+
+    @field_validator("telemetry")
+    @classmethod
+    def _known_telemetry_mode(cls, value: str) -> str:
+        if value not in TELEMETRY_MODES:
+            raise ValueError(f"registry.telemetry must be one of {TELEMETRY_MODES}, got {value!r}")
+        return value
+
+    @field_validator("max_regression_pct")
+    @classmethod
+    def _sane_regression(cls, value: float) -> float:
+        if not 0 <= value <= 100:
+            raise ValueError("registry.max_regression_pct must be a percentage between 0 and 100")
+        return value
+
+
 class Policy(BaseModel):
     """The whole declared posture of one deployment."""
 
@@ -151,6 +189,7 @@ class Policy(BaseModel):
     retention: RetentionPolicy = Field(default_factory=RetentionPolicy)
     durable: DurablePolicy = Field(default_factory=DurablePolicy)
     pii: PiiPolicy = Field(default_factory=PiiPolicy)
+    registry: RegistryPolicy = Field(default_factory=RegistryPolicy)
 
     # Where this policy came from; "" means "no file, code defaults".
     source_path: str = ""

--- a/kronos/skills/autoeval.py
+++ b/kronos/skills/autoeval.py
@@ -1,0 +1,202 @@
+"""Run a skill's own scenario before trusting it (moat 12.3).
+
+A signature proves who wrote a skill, not that it works. Since Phase 8 a scenario
+is a single self-contained YAML — the model's turns are scripted inside it — so a
+publisher can ship one next to `SKILL.md` and an installer can replay it offline,
+with no provider key and no network.
+
+What that check is and is not: it replays the publisher's own recorded turn and
+asserts the publisher's own expectations. It catches a skill that contradicts
+itself (forbidden tool called, budget blown, claim missing) and a skill broken in
+transit. It cannot tell you the skill is a good idea. That is why a passing
+scenario permits activation but never demands it, and why a skill without one is
+marked `unverified` rather than refused — most skills will have none for a while,
+and refusing them would leave the registry empty and the marking meaningless.
+
+The eval verdict is written into the skill's frontmatter. That is safe by
+construction: the checksum covers an allowlist of semantic fields, and these are
+not in it, so recording a local verdict cannot invalidate a published checksum.
+"""
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from kronos.skills.store import SkillStore
+
+log = logging.getLogger("kronos.skills.autoeval")
+
+# Where a skill keeps its scenario, relative to the skill directory.
+SCENARIO_RELPATH = "evals/scenario.yaml"
+
+EVAL_PASSED = "passed"
+EVAL_FAILED = "failed"
+EVAL_MISSING = "none"
+EVAL_ERROR = "error"
+
+
+@dataclass
+class EvalOutcome:
+    """What the scenario said, in a form the installer can act on."""
+
+    status: str = EVAL_MISSING
+    detail: str = ""
+
+    @property
+    def passed(self) -> bool:
+        return self.status == EVAL_PASSED
+
+    @property
+    def ran(self) -> bool:
+        return self.status in (EVAL_PASSED, EVAL_FAILED)
+
+
+def scenario_url(skill_url: str, explicit: str = "") -> str:
+    """Where the scenario lives for a skill fetched from `skill_url`.
+
+    Convention over configuration: a sibling `evals/scenario.yaml` next to
+    SKILL.md, so publishing a check needs no extra index field. An explicit URL in
+    the index wins when the layout differs.
+    """
+    if explicit:
+        return explicit
+    if not skill_url:
+        return ""
+    if skill_url.startswith("github:"):
+        base = skill_url.removesuffix("/SKILL.md").rstrip("/")
+        return f"{base}/{SCENARIO_RELPATH}"
+    if skill_url.endswith("/SKILL.md"):
+        return skill_url[: -len("SKILL.md")] + SCENARIO_RELPATH
+    return ""
+
+
+def fetch_scenario(url: str, skill_dir: Path, *, declared: bool = False) -> Path | None:
+    """Fetch a scenario next to an installed skill. None when there is none.
+
+    Goes through the same egress-checked fetcher as the skill itself; a 404 is the
+    normal case, not an error.
+
+    `declared` decides what a *non-scenario* response means. Plenty of hosts answer
+    200 with an HTML error page for a missing file, and the conventional path is a
+    guess — so garbage from a guessed URL means "no scenario here". Garbage from a
+    URL the publisher put in the index is their broken check, and is kept so the
+    eval reports it.
+    """
+    if not url:
+        return None
+
+    from kronos.skills.hub import _fetch_url, _resolve_source
+
+    resolved = _resolve_source(url) if url.startswith("github:") else url
+    if not resolved:
+        return None
+    try:
+        payload = _fetch_url(resolved)
+    except Exception as e:
+        log.info("No scenario fetched from %s: %s", resolved, e)
+        return None
+
+    if not declared and not _looks_like_scenario(payload):
+        log.info("Response from %s is not a scenario; treating the skill as having none", resolved)
+        return None
+
+    target = skill_dir / SCENARIO_RELPATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(payload, encoding="utf-8")
+    return target
+
+
+def _looks_like_scenario(payload: str) -> bool:
+    """Cheap shape check: valid YAML mapping carrying a script."""
+    import yaml
+
+    try:
+        parsed = yaml.safe_load(payload)
+    except yaml.YAMLError:
+        return False
+    return isinstance(parsed, dict) and bool(parsed.get("script"))
+
+
+async def run_skill_eval(skill_dir: Path) -> EvalOutcome:
+    """Replay the skill's scenario. Hermetic: no keys, no network, no cassettes."""
+    scenario_path = Path(skill_dir) / SCENARIO_RELPATH
+    if not scenario_path.is_file():
+        return EvalOutcome(EVAL_MISSING, "skill ships no scenario")
+
+    from kronos.evals.runner import run_scenario
+    from kronos.evals.scenario import Scenario, ScenarioError
+
+    try:
+        scenario = Scenario.load(scenario_path)
+    except ScenarioError as e:
+        return EvalOutcome(EVAL_ERROR, f"scenario is unusable: {e}")
+
+    try:
+        result = await run_scenario(scenario)
+    except Exception as e:  # pragma: no cover - defensive
+        return EvalOutcome(EVAL_ERROR, f"scenario could not be replayed: {e}")
+
+    from kronos.evals.runner import STATUS_ERROR, STATUS_PASS
+
+    if result.status == STATUS_PASS:
+        return EvalOutcome(EVAL_PASSED, f"scenario '{scenario.name}' passed")
+
+    failures = [check.detail or check.name for check in result.failures] or [result.error or "unknown failure"]
+    detail = f"scenario '{scenario.name}' failed: {'; '.join(failures[:3])}"
+    # A scenario that could not run at all is a broken check, not a verdict on the
+    # skill — the installer treats the two the same way but the report should not.
+    return EvalOutcome(EVAL_ERROR if result.status == STATUS_ERROR else EVAL_FAILED, detail)
+
+
+def record_outcome(store: SkillStore, name: str, outcome: EvalOutcome) -> None:
+    """Persist the verdict on the skill, so `verify` and the UI can show it."""
+    store.set_meta(
+        name,
+        {
+            "eval_status": outcome.status,
+            "eval_detail": outcome.detail,
+        },
+    )
+
+
+def name_conflicts(name: str, store: SkillStore, tool_names: list[str] | None = None) -> str:
+    """Why this name cannot be installed, or "" when it is free.
+
+    A skill that shadows a tool name is worse than a duplicate: `load_skill` and
+    the tool router would disagree about what the model just asked for.
+    """
+    if store.get(name) is not None:
+        return f"a skill named '{name}' is already installed"
+    for tool_name in tool_names or known_tool_names():
+        if tool_name == name:
+            return f"'{name}' is the name of an existing tool"
+    return ""
+
+
+def known_tool_names() -> list[str]:
+    """Tool names available without building an agent.
+
+    Best-effort on purpose: the full tool set depends on configured MCP servers
+    and capability gates, so this covers the built-ins a skill could shadow and
+    stays quiet when a module is unavailable.
+    """
+    names: list[str] = []
+    for module_name, attribute in (
+        ("kronos.tools.reminders", None),
+        ("kronos.tools.handoff", None),
+        ("kronos.tools.council", None),
+        ("kronos.tools.memory_ask", None),
+        ("kronos.tools.skills_tools", None),
+    ):
+        try:
+            module = __import__(module_name, fromlist=["*"])
+        except Exception as e:  # pragma: no cover - optional extras
+            log.debug("Could not inspect %s for tool names: %s", module_name, e)
+            continue
+        for value in vars(module).values():
+            tool_name = getattr(value, "name", None)
+            if isinstance(tool_name, str) and tool_name and callable(getattr(value, "invoke", None)):
+                names.append(tool_name)
+        if attribute:  # pragma: no cover - reserved for future explicit lists
+            names.extend(getattr(module, attribute, []))
+    return sorted(set(names))

--- a/kronos/skills/integrity.py
+++ b/kronos/skills/integrity.py
@@ -1,0 +1,297 @@
+"""Provenance for skills: checksum, signature, version compatibility.
+
+A skill is a procedure the agent will follow. Importing one is not running code,
+but it is accepting instructions — so "where did this come from and has it
+changed since" has to be answerable without trusting the transport.
+
+Three independent questions, deliberately kept apart:
+
+* **checksum** — is this the same content the publisher hashed? Cheap, offline,
+  catches tampering in transit and accidental edits. Useless against an attacker
+  who controls the file, since they can rewrite the checksum too.
+* **signature** — did a key we trust vouch for this checksum? That is the part a
+  file-level attacker cannot forge. Verified through `ssh-keygen -Y verify`, so
+  no new dependency and the same keys people already use for signed commits.
+* **compatibility** — does this skill claim to need a KAOS this old/new?
+
+What the checksum covers is an explicit allowlist of fields, not "the file". The
+import path rewrites frontmatter on the way in (status becomes draft, provenance
+fields are added), so hashing the raw file would make every imported skill fail
+its own checksum. Semantic fields are hashed; local bookkeeping is not.
+"""
+
+import hashlib
+import logging
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from kronos.skills.store import Skill, _parse_frontmatter, _parse_list_field
+
+log = logging.getLogger("kronos.skills.integrity")
+
+HASH_PREFIX = "sha256:"
+
+# Signing namespace for `ssh-keygen -Y sign -n kaos-skill`.
+SIGNATURE_NAMESPACE = "kaos-skill"
+
+# Fields the checksum covers. An allowlist rather than an exclusion list: a new
+# local bookkeeping field must not silently invalidate published checksums, and a
+# new *semantic* field has to be added here on purpose (and documented).
+COVERED_FIELDS = ("name", "description", "version", "requires_kaos", "author", "tools", "tier")
+
+# Fields parsed as lists, canonicalised so "[a, b]" and "[a,b]" hash the same.
+LIST_FIELDS = {"tools"}
+
+
+def canonical_form(meta: dict[str, str], body: str, references: dict[str, Path]) -> bytes:
+    """The exact bytes a checksum is taken over.
+
+    Stable across import (which rewrites frontmatter), across reference ordering,
+    and across trailing-whitespace churn.
+    """
+    lines: list[str] = []
+    for field in COVERED_FIELDS:
+        raw = str(meta.get(field, "") or "").strip()
+        if not raw:
+            continue
+        value = ",".join(_parse_list_field(raw)) if field in LIST_FIELDS else raw
+        lines.append(f"{field}: {value}")
+
+    parts = ["\n".join(lines), "---", body.strip()]
+    for ref_name in sorted(references):
+        ref_path = references[ref_name]
+        text = ref_path.read_text(encoding="utf-8").strip() if ref_path.is_file() else ""
+        parts.append(f"references/{ref_name}")
+        parts.append(text)
+
+    return "\n".join(parts).encode("utf-8")
+
+
+def compute_checksum(skill_dir: Path) -> str:
+    """Checksum of a skill directory on disk (a publisher's or a local one)."""
+    skill_file = skill_dir / "SKILL.md"
+    if not skill_file.is_file():
+        raise FileNotFoundError(f"no SKILL.md in {skill_dir}")
+
+    meta, body = _parse_frontmatter(skill_file.read_text(encoding="utf-8"))
+    references: dict[str, Path] = {}
+    refs_dir = skill_dir / "references"
+    if refs_dir.is_dir():
+        references = {path.stem: path for path in sorted(refs_dir.iterdir()) if path.is_file() and path.suffix == ".md"}
+
+    return HASH_PREFIX + hashlib.sha256(canonical_form(meta, body, references)).hexdigest()
+
+
+def skill_checksum(skill: Skill) -> str:
+    """Checksum of an already-loaded skill, from its own files."""
+    return compute_checksum(skill.path.parent)
+
+
+def verify_checksum(skill: Skill) -> tuple[bool, str]:
+    """Compare the declared checksum with the computed one.
+
+    A skill with no declared checksum is not a failure — most local skills have
+    none. It is reported as unverified, which is a different thing from broken.
+    """
+    declared = (skill.checksum or "").strip()
+    if not declared:
+        return False, "no checksum declared"
+
+    try:
+        actual = skill_checksum(skill)
+    except OSError as e:
+        return False, f"cannot read skill files: {e}"
+
+    if not declared.startswith(HASH_PREFIX):
+        declared = HASH_PREFIX + declared
+    if declared != actual:
+        return False, f"checksum mismatch: declared {declared[:19]}…, computed {actual[:19]}…"
+    return True, "checksum matches"
+
+
+def verify_signature(skill: Skill, *, trusted_keys: list[str]) -> tuple[bool, str]:
+    """Verify a detached SSH signature over the skill's checksum.
+
+    Uses `ssh-keygen -Y verify`, the same mechanism as signed git commits, so
+    publishing needs no bespoke tooling and KAOS needs no crypto dependency. The
+    signed payload is the checksum string, which is short and stable.
+
+    A publisher signs with:
+        ssh-keygen -Y sign -f ~/.ssh/id_ed25519 -n kaos-skill checksum.txt
+    """
+    signature = (skill.signature or "").strip()
+    if not signature:
+        return False, "no signature declared"
+    if not trusted_keys:
+        return False, "no trusted keys configured (registry.trusted_keys in policy.yaml)"
+    if shutil.which("ssh-keygen") is None:
+        return False, "ssh-keygen not available, cannot verify signatures"
+
+    checksum_ok, checksum_detail = verify_checksum(skill)
+    if not checksum_ok:
+        # Signing covers the checksum, so a wrong checksum makes the signature
+        # meaningless even when it verifies against a trusted key.
+        return False, f"signature not checked: {checksum_detail}"
+
+    payload = skill_checksum(skill).encode("utf-8")
+    with tempfile.TemporaryDirectory(prefix="kaos-sig-") as tmp:
+        tmp_dir = Path(tmp)
+        allowed = tmp_dir / "allowed_signers"
+        allowed.write_text("\n".join(_allowed_signer_line(key) for key in trusted_keys) + "\n", encoding="utf-8")
+        sig_file = tmp_dir / "skill.sig"
+        sig_file.write_text(_pem_signature(signature), encoding="utf-8")
+
+        for identity in _identities(trusted_keys):
+            result = subprocess.run(  # noqa: S603 - fixed argv, no shell
+                [
+                    "ssh-keygen",
+                    "-Y",
+                    "verify",
+                    "-f",
+                    str(allowed),
+                    "-I",
+                    identity,
+                    "-n",
+                    SIGNATURE_NAMESPACE,
+                    "-s",
+                    str(sig_file),
+                ],
+                input=payload,
+                capture_output=True,
+                timeout=15,
+                check=False,
+            )
+            if result.returncode == 0:
+                return True, f"signed by {identity}"
+
+    return False, "signature does not match any trusted key"
+
+
+def _allowed_signer_line(key: str) -> str:
+    """One `allowed_signers` entry: `<identity> <keytype> <base64>`."""
+    parts = key.strip().split()
+    if len(parts) >= 3 and not parts[0].startswith(("ssh-", "sk-", "ecdsa-")):
+        return key.strip()  # already `identity keytype base64`
+    identity = parts[-1] if len(parts) >= 3 else "kaos-publisher"
+    return f"{identity} {' '.join(parts[:2])}"
+
+
+def _identities(trusted_keys: list[str]) -> list[str]:
+    return [_allowed_signer_line(key).split()[0] for key in trusted_keys if key.strip()]
+
+
+def _pem_signature(signature: str) -> str:
+    """Accept both a full PEM blob and a bare base64 body."""
+    if "BEGIN SSH SIGNATURE" in signature:
+        return signature if signature.endswith("\n") else signature + "\n"
+    body = "\n".join(signature[i : i + 70] for i in range(0, len(signature), 70))
+    return f"-----BEGIN SSH SIGNATURE-----\n{body}\n-----END SSH SIGNATURE-----\n"
+
+
+def check_compatibility(skill: Skill, kaos_version: str = "") -> tuple[bool, str]:
+    """Evaluate `requires_kaos` against the running version.
+
+    Supports the comma-separated comparator form (`">=0.2,<0.4"`). An unparsable
+    constraint is reported as a failure rather than ignored: a skill that declares
+    a requirement nobody can read should not be trusted to be compatible.
+    """
+    # The frontmatter parser keeps YAML quotes, and `requires_kaos: ">=0.2,<0.4"`
+    # is normally written quoted — without stripping them the constraint would be
+    # unparsable and every quoted requirement would fail closed.
+    requirement = (skill.requires_kaos or "").strip().strip("'\"").strip()
+    if not requirement:
+        return True, "no version requirement"
+
+    if not kaos_version:
+        from kronos import __version__
+
+        kaos_version = __version__
+
+    # A source checkout without install metadata reports "0.0.0+unknown". Failing
+    # closed there would mark every skill with a requirement as incompatible, and
+    # the unknown is on our side, not the skill's — so say so and allow it.
+    if kaos_version.startswith("0.0.0") or "unknown" in kaos_version:
+        return (
+            True,
+            f"cannot determine the running KAOS version ({kaos_version}); requirement '{requirement}' unchecked",
+        )
+
+    current = _parse_version(kaos_version)
+    for clause in [part.strip() for part in requirement.split(",") if part.strip()]:
+        match = re.match(r"^(>=|<=|==|!=|>|<)?\s*(\d+(?:\.\d+)*)", clause)
+        if not match:
+            return False, f"cannot parse version requirement '{clause}'"
+        operator, wanted_text = match.group(1) or "==", match.group(2)
+        wanted = _parse_version(wanted_text)
+        if not _compare(current, operator, wanted):
+            return False, f"needs KAOS {requirement}, running {kaos_version}"
+    return True, f"compatible with KAOS {kaos_version}"
+
+
+def _parse_version(text: str) -> tuple[int, ...]:
+    """Numeric prefix of a version, so "0.3.0rc1" compares as (0, 3, 0)."""
+    parts: list[int] = []
+    for chunk in text.strip().lstrip("vV").split("."):
+        digits = re.match(r"^\d+", chunk)
+        if not digits:
+            break
+        parts.append(int(digits.group()))
+    return tuple(parts) or (0,)
+
+
+def _pad(left: tuple[int, ...], right: tuple[int, ...]) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    width = max(len(left), len(right))
+    return left + (0,) * (width - len(left)), right + (0,) * (width - len(right))
+
+
+def _compare(current: tuple[int, ...], operator: str, wanted: tuple[int, ...]) -> bool:
+    left, right = _pad(current, wanted)
+    return {
+        ">=": left >= right,
+        "<=": left <= right,
+        ">": left > right,
+        "<": left < right,
+        "==": left == right,
+        "!=": left != right,
+    }[operator]
+
+
+def trusted_keys() -> list[str]:
+    """Publisher keys from the policy (empty means "verify nothing")."""
+    try:
+        from kronos.policy import get_policy
+
+        return list(get_policy().registry.trusted_keys)
+    except Exception as e:  # pragma: no cover - policy is optional
+        log.debug("Could not read registry.trusted_keys: %s", e)
+        return []
+
+
+def verify_skill(skill: Skill, *, keys: list[str] | None = None) -> dict:
+    """Everything known about one skill's provenance, in one structure."""
+    keys = trusted_keys() if keys is None else keys
+
+    checksum_ok, checksum_detail = verify_checksum(skill)
+    compatible, compatibility_detail = check_compatibility(skill)
+    signature_ok, signature_detail = (False, "no signature declared")
+    if skill.signature:
+        signature_ok, signature_detail = verify_signature(skill, trusted_keys=keys)
+
+    return {
+        "skill": skill.name,
+        "version": skill.version,
+        "checksum_ok": checksum_ok,
+        "checksum_detail": checksum_detail,
+        "signature_ok": signature_ok,
+        "signature_detail": signature_detail,
+        "compatible": compatible,
+        "compatibility_detail": compatibility_detail,
+        # "Trusted" is the conjunction a caller should gate on: a declared
+        # checksum that matches, a compatible version, and — when a signature is
+        # present — a signature that verifies.
+        "trusted": checksum_ok and compatible and (signature_ok or not skill.signature),
+        "unverified": not skill.checksum,
+    }

--- a/kronos/skills/registry.py
+++ b/kronos/skills/registry.py
@@ -77,6 +77,8 @@ class RegistryEntry:
     signed: bool = False
     source: str = ""
     trust: str = "checksum"
+    # Optional override; by default the scenario is a sibling of SKILL.md.
+    scenario_url: str = ""
 
     def matches(self, query: str) -> bool:
         needle = query.strip().lower()
@@ -211,6 +213,7 @@ def parse_index(source: RegistrySource, payload: str) -> list[RegistryEntry]:
                 requires_kaos=str(item.get("requires_kaos", "")).strip(),
                 checksum=str(item.get("checksum", "")).strip(),
                 signed=bool(item.get("signed", False)),
+                scenario_url=str(item.get("scenario_url", "")).strip(),
                 source=source.name,
                 trust=source.trust,
             )
@@ -309,11 +312,13 @@ def install(
     source: str = "",
     entries: list[RegistryEntry] | None = None,
     allow_activate: bool = True,
+    run_eval: bool = True,
 ) -> InstallResult:
     """Install one advertised skill, then decide what its proof allows.
 
-    The skill lands as a draft first (the existing import path), and is promoted
-    only when the source demands a signature and that signature verifies.
+    The skill lands as a draft first (the existing import path), then its own
+    scenario is replayed offline, and only proof on both counts — a signature from
+    a trusted key and a scenario that passes — promotes it to active.
     """
     if entries is None:
         entries, problems = load_index()
@@ -328,13 +333,51 @@ def install(
     if not entry.url:
         return InstallResult(skill=name, installed=False, reason=f"'{name}' has no url in the index")
 
+    from kronos.skills.autoeval import name_conflicts
+
+    conflict = name_conflicts(name, store)
+    if conflict:
+        return InstallResult(skill=name, installed=False, reason=conflict)
+
     from kronos.skills.hub import import_skill
 
     message = import_skill(entry.url, store)
     if "imported successfully" not in message:
         return InstallResult(skill=name, installed=False, reason=message)
 
-    return finish_install(entry, store=store, allow_activate=allow_activate)
+    outcome = evaluate_installed(entry, store=store) if run_eval else None
+    return finish_install(entry, store=store, allow_activate=allow_activate, outcome=outcome)
+
+
+def evaluate_installed(entry: RegistryEntry, *, store: SkillStore):
+    """Fetch and replay the skill's own scenario. Returns an EvalOutcome."""
+    import asyncio
+
+    from kronos.skills.autoeval import EVAL_ERROR, EvalOutcome, fetch_scenario, record_outcome, run_skill_eval
+    from kronos.skills.autoeval import scenario_url as derive_scenario_url
+
+    skill = store.get(entry.name)
+    if skill is None:  # pragma: no cover - import reported success
+        return EvalOutcome(EVAL_ERROR, "skill vanished after import")
+
+    skill_dir = skill.path.parent
+    fetch_scenario(
+        derive_scenario_url(entry.url, entry.scenario_url),
+        skill_dir,
+        declared=bool(entry.scenario_url),
+    )
+    try:
+        outcome = asyncio.run(run_skill_eval(skill_dir))
+    except RuntimeError:
+        # Already inside a loop (an agent tool calling install): run it in a
+        # thread with its own loop rather than refusing to check.
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            outcome = pool.submit(lambda: asyncio.run(run_skill_eval(skill_dir))).result()
+
+    record_outcome(store, entry.name, outcome)
+    return outcome
 
 
 def finish_install(
@@ -342,9 +385,10 @@ def finish_install(
     *,
     store: SkillStore,
     allow_activate: bool = True,
-    eval_detail: str = "",
+    outcome=None,
 ) -> InstallResult:
     """Verify a freshly imported skill and set its status accordingly."""
+    from kronos.skills.autoeval import EVAL_ERROR, EVAL_FAILED, EVAL_MISSING
     from kronos.skills.integrity import trusted_keys, verify_skill
 
     skill = store.get(entry.name)
@@ -372,17 +416,41 @@ def finish_install(
     elif entry.trust == "signed" and not report["signature_ok"]:
         reasons.append(f"source requires a signature: {report['signature_detail']}")
 
-    # Proof strong enough to skip a human read: the source demands signing and a
-    # key we configured signed these exact bytes.
+    # A failing scenario is the skill contradicting its own publisher, which is
+    # reason enough to leave it a draft. A *missing* one is not a failure — most
+    # skills have none yet, and refusing them would leave the registry empty and
+    # the "unverified" marking meaningless — it only means nothing vouches for
+    # behaviour, which is what the marking says.
+    eval_status = getattr(outcome, "status", EVAL_MISSING) if outcome is not None else ""
+    report["eval_status"] = eval_status or EVAL_MISSING
+    report["eval_detail"] = getattr(outcome, "detail", "") if outcome is not None else ""
+    eval_refuted = eval_status in (EVAL_FAILED, EVAL_ERROR)
+    if eval_refuted:
+        reasons.append(report["eval_detail"])
+
+    from kronos.policy import get_policy
+
+    try:
+        require_eval = get_policy().registry.require_eval_on_install
+    except Exception:  # pragma: no cover - policy is optional
+        require_eval = True
+
+    # Proof strong enough to skip a human read: the source demands signing, a key
+    # we configured signed these exact bytes, and nothing the skill itself claims
+    # to check came back red.
     proven = report["signature_ok"] and report["checksum_ok"] and report["compatible"] and entry.trust == "signed"
+    if require_eval and eval_refuted:
+        proven = False
     status = "active" if (proven and allow_activate and not reasons) else "draft"
     if status == "active":
         store.update_status(entry.name, "active")
 
     reason = "; ".join(reasons)
     if not reason:
-        reason = report["signature_detail"] if proven else "installed for review (no signature to vouch for it)"
-    if eval_detail:
-        reason = f"{reason}; {eval_detail}"
+        reason = report["signature_detail"] if report["signature_ok"] else "installed for review"
+        if eval_status == EVAL_MISSING:
+            reason = f"{reason}; unverified: skill ships no scenario"
+        elif report["eval_detail"]:
+            reason = f"{reason}; {report['eval_detail']}"
 
     return InstallResult(skill=entry.name, installed=True, status=status, reason=reason, report=report)

--- a/kronos/skills/registry.py
+++ b/kronos/skills/registry.py
@@ -1,0 +1,388 @@
+"""Skill registry: named sources, a cached index, and install with proof.
+
+This is a file, not a service. `registry.yaml` lists where skills may come from
+and how much each source must prove; the index is JSON fetched from those sources
+and cached locally so `search` works offline afterwards. Nobody has to run
+infrastructure for this to be useful, and no source is trusted by being reachable.
+
+Install reuses the existing import path (`skills.hub.import_skill`) rather than a
+second downloader, so the egress allowlist, the name-collision guard and the
+draft-by-default rule all still apply. What this adds on top is the verification
+step and the decision that follows from it:
+
+* a `signed` source whose signature verifies against a configured key installs
+  **active** — a key you configured vouching for the exact bytes is stronger
+  evidence than a human skimming markdown;
+* everything else installs as a **draft** with the reason attached, which is the
+  pre-existing behaviour for external skills.
+
+A failure never deletes anything. The worst case is a draft you can read.
+"""
+
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import yaml
+
+from kronos.skills.store import SkillStore
+
+log = logging.getLogger("kronos.skills.registry")
+
+DEFAULT_REGISTRY_FILE = "registry.yaml"
+ENV_REGISTRY_FILE = "KAOS_REGISTRY_FILE"
+REGISTRY_SCHEMA_VERSION = 1
+
+# Convention for a github source: the index lives at the repository root.
+INDEX_FILENAME = "index.json"
+
+# How long a cached index is served without refetching.
+CACHE_TTL_SECONDS = 6 * 3600
+
+TRUST_LEVELS = ("signed", "checksum", "none")
+
+
+class RegistryError(Exception):
+    """Raised when registry.yaml or a source index cannot be used."""
+
+
+@dataclass(frozen=True)
+class RegistrySource:
+    name: str
+    url: str
+    trust: str = "checksum"
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise RegistryError("a registry source needs a name")
+        if not self.url:
+            raise RegistryError(f"source '{self.name}' has no url")
+        if self.trust not in TRUST_LEVELS:
+            raise RegistryError(f"source '{self.name}' has unknown trust '{self.trust}' (expected {TRUST_LEVELS})")
+
+
+@dataclass
+class RegistryEntry:
+    """One skill as advertised by a source. Claims, not facts, until verified."""
+
+    name: str
+    description: str = ""
+    version: str = ""
+    url: str = ""
+    author: str = ""
+    requires_kaos: str = ""
+    checksum: str = ""
+    signed: bool = False
+    source: str = ""
+    trust: str = "checksum"
+
+    def matches(self, query: str) -> bool:
+        needle = query.strip().lower()
+        if not needle:
+            return True
+        return needle in self.name.lower() or needle in self.description.lower()
+
+
+@dataclass
+class InstallResult:
+    """What happened, in enough detail to explain a refusal."""
+
+    skill: str
+    installed: bool
+    status: str = "failed"  # active | draft | failed
+    reason: str = ""
+    report: dict = field(default_factory=dict)
+
+    def render(self) -> str:
+        if not self.installed:
+            return f"[FAIL] {self.skill}: {self.reason}"
+        headline = f"[{'ACTIVE' if self.status == 'active' else 'DRAFT'}] {self.skill} installed"
+        return f"{headline}: {self.reason}" if self.reason else headline
+
+
+# ----------------------------------------------------------------------------
+# registry.yaml
+# ----------------------------------------------------------------------------
+
+
+def registry_file_path(path: str | Path | None = None) -> Path:
+    import os
+
+    if path is not None:
+        return Path(path)
+    from_env = os.environ.get(ENV_REGISTRY_FILE)
+    if from_env:
+        return Path(from_env)
+    return (Path(__file__).resolve().parents[2] / DEFAULT_REGISTRY_FILE).resolve()
+
+
+def load_sources(path: str | Path | None = None) -> list[RegistrySource]:
+    """Read the configured sources. No file means no sources, not an error."""
+    registry_path = registry_file_path(path)
+    if not registry_path.exists():
+        return []
+
+    try:
+        raw = yaml.safe_load(registry_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as e:
+        raise RegistryError(f"{registry_path} is not valid YAML: {e}") from e
+    if not isinstance(raw, dict):
+        raise RegistryError(f"{registry_path} must be a mapping with a 'sources' list")
+
+    version = int(raw.get("version", REGISTRY_SCHEMA_VERSION) or REGISTRY_SCHEMA_VERSION)
+    if version > REGISTRY_SCHEMA_VERSION:
+        raise RegistryError(f"registry schema v{version} is newer than this KAOS supports (v{REGISTRY_SCHEMA_VERSION})")
+
+    entries = raw.get("sources") or []
+    if not isinstance(entries, list):
+        raise RegistryError(f"{registry_path}: 'sources' must be a list")
+
+    from kronos.policy import get_policy
+
+    try:
+        default_trust = get_policy().registry.trust_default
+    except Exception:  # pragma: no cover - policy is optional
+        default_trust = "checksum"
+
+    sources: list[RegistrySource] = []
+    seen: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise RegistryError(f"{registry_path}: each source must be a mapping, got {type(entry).__name__}")
+        source = RegistrySource(
+            name=str(entry.get("name", "")).strip(),
+            url=str(entry.get("url", "")).strip(),
+            trust=str(entry.get("trust", default_trust)).strip(),
+        )
+        if source.name in seen:
+            raise RegistryError(f"{registry_path}: duplicate source name '{source.name}'")
+        seen.add(source.name)
+        sources.append(source)
+    return sources
+
+
+# ----------------------------------------------------------------------------
+# index
+# ----------------------------------------------------------------------------
+
+
+def index_url(source: RegistrySource) -> str:
+    """Where a source's index lives."""
+    if source.url.startswith("github:"):
+        from kronos.skills.hub import GITHUB_RAW_URL
+
+        parts = source.url.removeprefix("github:").strip("/").split("/")
+        if len(parts) < 2:
+            raise RegistryError(f"source '{source.name}': expected github:user/repo, got '{source.url}'")
+        user, repo = parts[0], parts[1]
+        prefix = "/".join(parts[2:])
+        path = f"{prefix}/{INDEX_FILENAME}" if prefix else INDEX_FILENAME
+        return GITHUB_RAW_URL.format(user=user, repo=repo, path=path)
+    if source.url.startswith(("http://", "https://")):
+        return source.url
+    raise RegistryError(f"source '{source.name}': url must be github:user/repo or an http(s) URL")
+
+
+def parse_index(source: RegistrySource, payload: str) -> list[RegistryEntry]:
+    """Turn a source's index JSON into entries."""
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError as e:
+        raise RegistryError(f"source '{source.name}' returned invalid JSON: {e}") from e
+
+    skills = data.get("skills") if isinstance(data, dict) else data
+    if not isinstance(skills, list):
+        raise RegistryError(f"source '{source.name}': index must contain a 'skills' list")
+
+    entries: list[RegistryEntry] = []
+    for item in skills:
+        if not isinstance(item, dict) or not str(item.get("name", "")).strip():
+            log.warning("Source '%s' advertises an entry without a name; skipping it", source.name)
+            continue
+        entries.append(
+            RegistryEntry(
+                name=str(item["name"]).strip(),
+                description=str(item.get("description", "")).strip(),
+                version=str(item.get("version", "")).strip(),
+                url=str(item.get("url") or item.get("source") or "").strip(),
+                author=str(item.get("author", "")).strip(),
+                requires_kaos=str(item.get("requires_kaos", "")).strip(),
+                checksum=str(item.get("checksum", "")).strip(),
+                signed=bool(item.get("signed", False)),
+                source=source.name,
+                trust=source.trust,
+            )
+        )
+    return entries
+
+
+def _cache_path() -> Path:
+    from kronos.config import settings
+
+    return Path(settings.db_dir) / "registry-cache.json"
+
+
+def _read_cache() -> dict:
+    path = _cache_path()
+    if not path.is_file():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        log.debug("Registry cache unreadable (%s); refetching", e)
+        return {}
+
+
+def _write_cache(entries: list[RegistryEntry], *, now: float) -> None:
+    path = _cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"fetched_at": now, "skills": [asdict(entry) for entry in entries]}, indent=2),
+            encoding="utf-8",
+        )
+    except OSError as e:  # pragma: no cover - cache is best-effort
+        log.debug("Could not write the registry cache: %s", e)
+
+
+def load_index(
+    sources: list[RegistrySource] | None = None,
+    *,
+    refresh: bool = False,
+    now: float | None = None,
+) -> tuple[list[RegistryEntry], list[str]]:
+    """Entries from every source, plus one message per source that failed.
+
+    A source being down is reported, never raised: one unreachable host must not
+    make `search` useless for the others.
+    """
+    sources = load_sources() if sources is None else sources
+    now = time.time() if now is None else now
+
+    if not refresh:
+        cached = _read_cache()
+        fetched_at = float(cached.get("fetched_at", 0) or 0)
+        if cached.get("skills") and now - fetched_at < CACHE_TTL_SECONDS:
+            return [RegistryEntry(**row) for row in cached["skills"]], []
+
+    from kronos.skills.hub import _fetch_url
+
+    entries: list[RegistryEntry] = []
+    problems: list[str] = []
+    for source in sources:
+        try:
+            payload = _fetch_url(index_url(source))
+            entries.extend(parse_index(source, payload))
+        except RegistryError as e:
+            problems.append(str(e))
+        except Exception as e:
+            problems.append(f"source '{source.name}' is unreachable: {e}")
+
+    if entries:
+        _write_cache(entries, now=now)
+    return entries, problems
+
+
+def search(query: str, entries: list[RegistryEntry] | None = None) -> list[RegistryEntry]:
+    if entries is None:
+        entries, _ = load_index()
+    return sorted((entry for entry in entries if entry.matches(query)), key=lambda entry: (entry.source, entry.name))
+
+
+def find_entry(name: str, entries: list[RegistryEntry], *, source: str = "") -> RegistryEntry | None:
+    """Exact match by name, optionally pinned to one source."""
+    candidates = [entry for entry in entries if entry.name == name and (not source or entry.source == source)]
+    return candidates[0] if candidates else None
+
+
+# ----------------------------------------------------------------------------
+# install
+# ----------------------------------------------------------------------------
+
+
+def install(
+    name: str,
+    *,
+    store: SkillStore,
+    source: str = "",
+    entries: list[RegistryEntry] | None = None,
+    allow_activate: bool = True,
+) -> InstallResult:
+    """Install one advertised skill, then decide what its proof allows.
+
+    The skill lands as a draft first (the existing import path), and is promoted
+    only when the source demands a signature and that signature verifies.
+    """
+    if entries is None:
+        entries, problems = load_index()
+        if not entries:
+            detail = problems[0] if problems else "no sources configured in registry.yaml"
+            return InstallResult(skill=name, installed=False, reason=detail)
+
+    entry = find_entry(name, entries, source=source)
+    if entry is None:
+        where = f" in source '{source}'" if source else ""
+        return InstallResult(skill=name, installed=False, reason=f"'{name}' is not in the index{where}")
+    if not entry.url:
+        return InstallResult(skill=name, installed=False, reason=f"'{name}' has no url in the index")
+
+    from kronos.skills.hub import import_skill
+
+    message = import_skill(entry.url, store)
+    if "imported successfully" not in message:
+        return InstallResult(skill=name, installed=False, reason=message)
+
+    return finish_install(entry, store=store, allow_activate=allow_activate)
+
+
+def finish_install(
+    entry: RegistryEntry,
+    *,
+    store: SkillStore,
+    allow_activate: bool = True,
+    eval_detail: str = "",
+) -> InstallResult:
+    """Verify a freshly imported skill and set its status accordingly."""
+    from kronos.skills.integrity import trusted_keys, verify_skill
+
+    skill = store.get(entry.name)
+    if skill is None:  # pragma: no cover - import reported success
+        return InstallResult(skill=entry.name, installed=False, reason="skill vanished after import")
+
+    report = verify_skill(skill, keys=trusted_keys())
+    report["source"] = entry.source
+    report["trust"] = entry.trust
+
+    reasons: list[str] = []
+    if entry.checksum and skill.checksum and entry.checksum.strip() != skill.checksum.strip():
+        reasons.append("the index advertises a different checksum than the skill declares")
+    if not report["compatible"]:
+        reasons.append(report["compatibility_detail"])
+
+    # Checksum first, then signature — a failed checksum already explains a failed
+    # signature (the signature covers it), and saying it twice reads like two
+    # separate problems.
+    checksum_matters = entry.trust in ("signed", "checksum")
+    if checksum_matters and report["unverified"]:
+        reasons.append("skill declares no checksum, so nothing can be verified")
+    elif checksum_matters and not report["checksum_ok"]:
+        reasons.append(report["checksum_detail"])
+    elif entry.trust == "signed" and not report["signature_ok"]:
+        reasons.append(f"source requires a signature: {report['signature_detail']}")
+
+    # Proof strong enough to skip a human read: the source demands signing and a
+    # key we configured signed these exact bytes.
+    proven = report["signature_ok"] and report["checksum_ok"] and report["compatible"] and entry.trust == "signed"
+    status = "active" if (proven and allow_activate and not reasons) else "draft"
+    if status == "active":
+        store.update_status(entry.name, "active")
+
+    reason = "; ".join(reasons)
+    if not reason:
+        reason = report["signature_detail"] if proven else "installed for review (no signature to vouch for it)"
+    if eval_detail:
+        reason = f"{reason}; {eval_detail}"
+
+    return InstallResult(skill=entry.name, installed=True, status=status, reason=reason, report=report)

--- a/kronos/skills/store.py
+++ b/kronos/skills/store.py
@@ -266,6 +266,9 @@ class SkillStore:
             source_url=meta.get("source_url", ""),
             imported_at=meta.get("imported_at", ""),
             review_required=str(meta.get("review_required", "")).lower() == "true",
+            requires_kaos=meta.get("requires_kaos", ""),
+            checksum=meta.get("checksum", ""),
+            signature=meta.get("signature", ""),
         )
         log.info("Skill added: %s (status=%s)", name, meta.get("status", "active"))
         self._generate_manifest_file()

--- a/kronos/skills/store.py
+++ b/kronos/skills/store.py
@@ -41,6 +41,9 @@ class Skill:
     requires_kaos: str = ""
     checksum: str = ""
     signature: str = ""
+    # Verdict of the skill's own scenario, when it ships one (moat 12.3).
+    eval_status: str = ""
+    eval_detail: str = ""
 
 
 def _parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
@@ -171,6 +174,8 @@ class SkillStore:
             requires_kaos = meta.get("requires_kaos", "")
             checksum = meta.get("checksum", "")
             signature = meta.get("signature", "")
+            eval_status = meta.get("eval_status", "")
+            eval_detail = meta.get("eval_detail", "")
 
             if not description:
                 # Fallback: extract first paragraph as description
@@ -204,6 +209,8 @@ class SkillStore:
                 requires_kaos=requires_kaos,
                 checksum=checksum,
                 signature=signature,
+                eval_status=eval_status,
+                eval_detail=eval_detail,
             )
 
     @property
@@ -269,6 +276,8 @@ class SkillStore:
             requires_kaos=meta.get("requires_kaos", ""),
             checksum=meta.get("checksum", ""),
             signature=meta.get("signature", ""),
+            eval_status=meta.get("eval_status", ""),
+            eval_detail=meta.get("eval_detail", ""),
         )
         log.info("Skill added: %s (status=%s)", name, meta.get("status", "active"))
         self._generate_manifest_file()
@@ -276,13 +285,21 @@ class SkillStore:
 
     def update_status(self, name: str, status: str) -> bool:
         """Update a skill status in frontmatter and refresh the manifest."""
+        return self.set_meta(name, {"status": status})
+
+    def set_meta(self, name: str, updates: dict[str, object]) -> bool:
+        """Merge frontmatter fields for one skill and refresh the manifest.
+
+        Used for local bookkeeping (status, eval verdicts). Deliberately does not
+        touch the body or the reference files, so a recorded verdict cannot change
+        what the skill's checksum covers.
+        """
         skill = self._skills.get(name)
         if not skill:
             return False
 
-        raw = skill.path.read_text(encoding="utf-8")
-        meta, body = _parse_frontmatter(raw)
-        meta["status"] = status
+        meta, body = _parse_frontmatter(skill.path.read_text(encoding="utf-8"))
+        meta.update({key: _format_frontmatter_value(value) for key, value in updates.items()})
 
         fm_lines = ["---"]
         for key, value in meta.items():
@@ -290,7 +307,12 @@ class SkillStore:
         fm_lines.extend(["---", "", body])
         skill.path.write_text("\n".join(fm_lines), encoding="utf-8")
 
-        skill.status = status
+        if "status" in updates:
+            skill.status = str(updates["status"])
+        if "eval_status" in updates:
+            skill.eval_status = str(updates["eval_status"])
+        if "eval_detail" in updates:
+            skill.eval_detail = str(updates["eval_detail"])
         self._generate_manifest_file()
         return True
 
@@ -338,6 +360,11 @@ class SkillStore:
                 row["imported_at"] = skill.imported_at
             if skill.review_required:
                 row["review_required"] = True
+            if skill.requires_kaos:
+                row["requires_kaos"] = skill.requires_kaos
+            row["verified"] = bool(skill.checksum)
+            row["signed"] = bool(skill.signature)
+            row["eval_status"] = skill.eval_status or "none"
             skills_list.append(row)
         return {
             "version": "1.0.0",

--- a/kronos/skills/store.py
+++ b/kronos/skills/store.py
@@ -36,6 +36,11 @@ class Skill:
     source_url: str = ""
     imported_at: str = ""
     review_required: bool = False
+    # Provenance (moat 12.1). Absent on every skill written before it existed,
+    # which is why "no checksum" means unverified rather than broken.
+    requires_kaos: str = ""
+    checksum: str = ""
+    signature: str = ""
 
 
 def _parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
@@ -163,6 +168,9 @@ class SkillStore:
             source_url = meta.get("source_url", "")
             imported_at = meta.get("imported_at", "")
             review_required = meta.get("review_required", "").lower() == "true"
+            requires_kaos = meta.get("requires_kaos", "")
+            checksum = meta.get("checksum", "")
+            signature = meta.get("signature", "")
 
             if not description:
                 # Fallback: extract first paragraph as description
@@ -193,6 +201,9 @@ class SkillStore:
                 source_url=source_url,
                 imported_at=imported_at,
                 review_required=review_required,
+                requires_kaos=requires_kaos,
+                checksum=checksum,
+                signature=signature,
             )
 
     @property

--- a/kronos/skills/tools.py
+++ b/kronos/skills/tools.py
@@ -42,6 +42,12 @@ def load_skill(skill_name: str) -> str:
 
     log.info("Loaded skill: %s (%d chars)", skill_name, len(skill.content))
 
+    # Count the load, not the catalog listing: being offered to the model is not
+    # being used (moat 12.5).
+    from kronos.skills.usage import record_call
+
+    record_call(skill.name)
+
     result = skill.content
     if skill.status == "draft":
         result = (

--- a/kronos/skills/usage.py
+++ b/kronos/skills/usage.py
@@ -1,0 +1,136 @@
+"""Which skills actually get used (moat 12.5).
+
+Twenty installed skills and no idea which three carry the work is the state this
+answers. The counter is local, per agent, and increments where a skill is really
+loaded — nothing is inferred from a catalog listing, because being *offered* to the
+model is not being used.
+
+Deliberately narrow: `calls` and `last_used_at`, nothing about outcomes. Nothing in
+the runtime links a turn's result back to the skills that turn loaded, so an
+`ok_rate` column would be a number with no derivation behind it. The signal that
+does exist for "does this skill work" is its scenario verdict from 12.3, and
+`kaos skills stats` shows that next to the usage instead of inventing a rate.
+
+Sharing is off by default and stays off unless `registry.telemetry: share` is
+written in the policy. The exported aggregate carries no skill content, no ids and
+no counts — only bucketed call volume — and a test asserts that nothing is
+assembled at all in any other mode.
+"""
+
+import logging
+import time
+
+from kronos.db import get_db
+
+log = logging.getLogger("kronos.skills.usage")
+
+CALL_BUCKETS = ((0, "unused"), (1, "1-9"), (10, "10-99"), (100, "100+"))
+
+
+def _init_schema(conn) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS skill_usage (
+            skill        TEXT PRIMARY KEY,
+            calls        INTEGER NOT NULL DEFAULT 0,
+            last_used_at REAL
+        );
+        """
+    )
+
+
+def _db():
+    db = get_db("skill_usage")
+    db.init_schema(_init_schema)
+    return db
+
+
+def record_call(skill: str) -> None:
+    """Count one real load. Never raises — telemetry must not break a turn."""
+    if not skill:
+        return
+    try:
+        _db().write(
+            """
+            INSERT INTO skill_usage (skill, calls, last_used_at) VALUES (?, 1, ?)
+            ON CONFLICT(skill) DO UPDATE SET calls = calls + 1, last_used_at = excluded.last_used_at
+            """,
+            (skill, time.time()),
+        )
+    except Exception as e:  # pragma: no cover - defensive
+        log.debug("Could not record usage for skill '%s': %s", skill, e)
+
+
+def usage() -> dict[str, dict]:
+    """Per-skill counters, keyed by skill name."""
+    try:
+        rows = _db().read("SELECT skill, calls, last_used_at FROM skill_usage")
+    except Exception as e:  # pragma: no cover - defensive
+        log.debug("Could not read skill usage: %s", e)
+        return {}
+    return {row["skill"]: {"calls": int(row["calls"]), "last_used_at": row["last_used_at"]} for row in rows}
+
+
+def call_bucket(calls: int) -> str:
+    """Coarse volume label — the only usage figure that may ever be shared."""
+    label = CALL_BUCKETS[0][1]
+    for threshold, name in CALL_BUCKETS:
+        if calls >= threshold:
+            label = name
+    return label
+
+
+def local_report(store=None) -> list[dict]:
+    """Usage joined with what is known about each skill's provenance."""
+    from kronos.skills.store import SkillStore
+
+    store = store or SkillStore()
+    counters = usage()
+    rows = []
+    for skill in store.list_skills():
+        counter = counters.get(skill.name, {})
+        rows.append(
+            {
+                "skill": skill.name,
+                "version": skill.version,
+                "status": skill.status,
+                "calls": int(counter.get("calls", 0)),
+                "last_used_at": counter.get("last_used_at"),
+                "verified": bool(skill.checksum),
+                "signed": bool(skill.signature),
+                "eval_status": skill.eval_status or "none",
+            }
+        )
+    return sorted(rows, key=lambda row: (-row["calls"], row["skill"]))
+
+
+def telemetry_mode() -> str:
+    try:
+        from kronos.policy import get_policy
+
+        return get_policy().registry.telemetry
+    except Exception as e:  # pragma: no cover - policy is optional
+        log.debug("Could not read registry.telemetry: %s", e)
+        return "off"
+
+
+def shareable_aggregate(store=None) -> list[dict]:
+    """The anonymous payload — only when the policy says `share`.
+
+    No skill content, no timestamps, no exact counts, no agent or user identity:
+    a skill name, its version, a volume bucket and its own scenario verdict. That
+    is enough for "is this skill used and does it pass its check" and not enough to
+    describe anyone's workflow.
+    """
+    if telemetry_mode() != "share":
+        return []
+    return [
+        {
+            "skill": row["skill"],
+            "version": row["version"],
+            "calls_bucket": call_bucket(row["calls"]),
+            "eval_status": row["eval_status"],
+            "verified": row["verified"],
+        }
+        for row in local_report(store)
+    ]

--- a/policy.example.yaml
+++ b/policy.example.yaml
@@ -81,3 +81,22 @@ durable:
 pii:
   mask_in_logs: true
   mask_in_cassettes: true
+
+# Where skills may come from and how much they must prove (see docs/REGISTRY.md).
+registry:
+  # Public keys allowed to sign a skill, in ssh-keygen allowed_signers form.
+  trusted_keys: []
+  # Applies to a source in registry.yaml that declares no trust level.
+  trust_default: checksum      # signed | checksum | none
+  # A skill whose own scenario fails stays a draft.
+  require_eval_on_install: true
+  # off = nothing is assembled for sharing; local = counters are yours only;
+  # share = `kaos skills stats --share` prints an anonymous aggregate.
+  telemetry: off               # off | local | share
+
+# How much a self-improvement proposal must prove before the owner sees it.
+evolution:
+  # Share of scenarios allowed to regress. 0 = any new failure is auto-rejected.
+  max_regression_pct: 0
+  # false keeps every proposal pending, measurement attached, nothing auto-decided.
+  auto_reject: true

--- a/registry.example.yaml
+++ b/registry.example.yaml
@@ -1,0 +1,42 @@
+# Skill sources — where `kaos skills search|info|install` may fetch from.
+# Copy to registry.yaml. No file means no sources, and install says so.
+#
+# This is a list of places, not a service. Each source publishes an index.json:
+#
+#   {
+#     "version": 1,
+#     "skills": [
+#       {
+#         "name": "decision-memo",
+#         "description": "Write a one-page decision memo",
+#         "version": "1.2.0",
+#         "url": "github:acme/skills/decision-memo",
+#         "author": "acme",
+#         "requires_kaos": ">=0.2",
+#         "checksum": "sha256:…",
+#         "signed": true
+#       }
+#     ]
+#   }
+#
+# For a `github:user/repo` source the index is read from the repository root
+# (github:user/repo/subdir looks in that subdir).
+#
+# trust levels — how much a source must prove before a skill can activate:
+#   signed   — a signature from a key in policy.yaml registry.trusted_keys is
+#              required; only then does an installed skill become active
+#   checksum — the declared checksum must match; the skill installs as a draft
+#   none     — nothing is required; the skill installs as a draft
+#
+# A failed check never deletes anything: the worst case is a draft you can read.
+
+version: 1
+
+sources:
+  - name: kaos-official
+    url: github:spyrae/kaos-skills
+    trust: signed
+
+  - name: community
+    url: https://example.invalid/skills/index.json
+    trust: checksum

--- a/tests/test_persona_evolution_eval.py
+++ b/tests/test_persona_evolution_eval.py
@@ -1,0 +1,341 @@
+"""Persona proposals arrive measured (moat phase 12.4).
+
+The honest scope is the thing these tests pin hardest: scripted scenarios cannot
+score answer quality, so the measurement is allowed to *refute* a proposal and
+never to flatter one. A report that claimed a quality delta would be a number with
+nothing behind it.
+"""
+
+import json
+
+import pytest
+import yaml
+
+from kronos import evolution
+from kronos.config import settings
+from kronos.evolution_eval import (
+    DUPLICATE_LINE_THRESHOLD,
+    duplicate_ratio,
+    measure_proposal,
+    patched_workspace,
+    prompt_delta,
+    regression_pct,
+    render_report,
+    verdict,
+)
+
+PROPOSAL = {
+    "target": "soul",
+    "rationale": "Отвечать короче на простые вопросы",
+    "proposal": "- Держи ответ на прямой вопрос в двух предложениях, если не просят разбор.",
+}
+
+SCENARIO = {
+    "schema_version": 1,
+    "name": "answers-without-tools",
+    "input": "what is KAOS",
+    "script": [{"content": "KAOS is the runtime you are talking to."}],
+    "tool_outputs": {},
+    "expect": {"max_tool_calls": 0, "must_mention": ["runtime"]},
+}
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    """A live workspace with the persona files the proposal targets."""
+    import kronos.workspace as workspace_module
+    from kronos.workspace import Workspace
+
+    root = tmp_path / "workspaces" / "evo"
+    self_dir = root / "self"
+    self_dir.mkdir(parents=True)
+    (self_dir / "SOUL.md").write_text("# Soul\n\n- Be useful.\n", encoding="utf-8")
+    (self_dir / "IDENTITY.md").write_text("# Identity\n\nI am a test agent.\n", encoding="utf-8")
+
+    original = workspace_module.ws
+    workspace_module.ws = Workspace(root)
+    monkeypatch.setattr(settings, "workspace_path", str(root), raising=False)
+    yield root
+    workspace_module.ws = original
+
+
+@pytest.fixture
+def suite(tmp_path):
+    directory = tmp_path / "suite" / "answers-without-tools"
+    directory.mkdir(parents=True)
+    (directory / "scenario.yaml").write_text(yaml.safe_dump(SCENARIO, sort_keys=False), encoding="utf-8")
+    return tmp_path / "suite"
+
+
+@pytest.fixture
+def proposals_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path / "data"))
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "data" / "session.db"))
+    (tmp_path / "data").mkdir(exist_ok=True)
+    import kronos.db as _db
+
+    _db._instances.clear()
+    yield
+    _db._instances.clear()
+
+
+# --- the patched copy ----------------------------------------------------------
+
+
+def test_the_live_workspace_is_never_touched(workspace, tmp_path):
+    before = (workspace / "self" / "SOUL.md").read_text(encoding="utf-8")
+
+    patched_root = patched_workspace(PROPOSAL, into=tmp_path / "copy")
+
+    assert (workspace / "self" / "SOUL.md").read_text(encoding="utf-8") == before
+    assert "Держи ответ на прямой вопрос" in (patched_root / "self" / "SOUL.md").read_text(encoding="utf-8")
+
+
+def test_the_patch_lands_on_the_named_target(workspace, tmp_path):
+    patched_root = patched_workspace({**PROPOSAL, "target": "identity"}, into=tmp_path / "copy")
+
+    assert "Держи ответ" in (patched_root / "self" / "IDENTITY.md").read_text(encoding="utf-8")
+    assert "Держи ответ" not in (patched_root / "self" / "SOUL.md").read_text(encoding="utf-8")
+
+
+# --- prompt assembly ----------------------------------------------------------
+
+
+def test_the_prompt_delta_is_measured(workspace, tmp_path):
+    patched_root = patched_workspace(PROPOSAL, into=tmp_path / "copy")
+
+    delta = prompt_delta(PROPOSAL, patched_root)
+
+    assert delta["built"] is True
+    assert delta["chars_after"] > delta["chars_before"]
+    assert delta["growth_pct"] > 0
+
+
+def test_a_prompt_that_cannot_build_is_reported(workspace, tmp_path, monkeypatch):
+    patched_root = patched_workspace(PROPOSAL, into=tmp_path / "copy")
+    calls = {"n": 0}
+
+    def flaky_prompt(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return "current prompt"
+        raise RuntimeError("template exploded")
+
+    monkeypatch.setattr("kronos.persona.build_system_prompt", flaky_prompt)
+
+    delta = prompt_delta(PROPOSAL, patched_root)
+
+    assert delta["built"] is False
+    assert "patched persona does not build" in delta["error"]
+
+
+# --- redundancy ---------------------------------------------------------------
+
+
+def test_a_proposal_already_in_the_file_is_detected(workspace):
+    soul = workspace / "self" / "SOUL.md"
+    soul.write_text(soul.read_text(encoding="utf-8") + PROPOSAL["proposal"] + "\n", encoding="utf-8")
+
+    assert duplicate_ratio(PROPOSAL) == 1.0
+
+
+def test_new_guidance_is_not_a_duplicate(workspace):
+    assert duplicate_ratio(PROPOSAL) == 0.0
+
+
+# --- the verdict --------------------------------------------------------------
+
+
+def test_a_broken_prompt_is_rejected():
+    report = {"regressions": [{"scenario": "system-prompt", "kind": "prompt_broken", "detail": "boom"}]}
+
+    acceptable, reason = verdict(report, max_regression_pct=50)
+
+    assert acceptable is False
+    assert reason == "boom"
+
+
+def test_a_regression_above_the_threshold_is_rejected():
+    report = {
+        "suite": {"scenarios": 4},
+        "regressions": [{"scenario": "a", "kind": "new_failure", "detail": "failed"}],
+    }
+
+    assert regression_pct(report) == 25.0
+    assert verdict(report, max_regression_pct=0)[0] is False
+    assert verdict(report, max_regression_pct=50)[0] is True, "an operator may accept some noise"
+
+
+def test_a_redundant_proposal_is_rejected():
+    report = {"suite": {"scenarios": 4}, "regressions": [], "duplicate_ratio": DUPLICATE_LINE_THRESHOLD}
+
+    acceptable, reason = verdict(report, max_regression_pct=0)
+
+    assert acceptable is False
+    assert "already in the file" in reason
+
+
+def test_a_clean_proposal_reaches_the_owner():
+    report = {"suite": {"scenarios": 4}, "regressions": [], "duplicate_ratio": 0.0}
+
+    assert verdict(report, max_regression_pct=0) == (True, "no measurable regression")
+
+
+# --- the full measurement -----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_measurement_reports_what_it_cannot_prove(workspace, suite):
+    report = await measure_proposal(PROPOSAL, suite_dir=suite)
+
+    assert report["measured_quality"] is False
+    assert "scripted model" in report["why_not"]
+    assert report["suite"]["scenarios"] == 1
+    assert report["regressions"] == []
+    assert "no behaviour change in the offline suite" in report["notes"]
+
+
+@pytest.mark.asyncio
+async def test_a_missing_suite_leaves_the_proposal_unmeasured_not_failed(workspace, tmp_path):
+    report = await measure_proposal(PROPOSAL, suite_dir=tmp_path / "absent")
+
+    assert report["regressions"] == []
+    assert any("unmeasured" in note for note in report["notes"])
+    assert verdict(report, max_regression_pct=0)[0] is True, "no suite must not mean auto-reject"
+
+
+@pytest.mark.asyncio
+async def test_a_proposal_that_breaks_the_prompt_is_refuted(workspace, suite, monkeypatch):
+    calls = {"n": 0}
+
+    def flaky_prompt(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return "current prompt"
+        raise RuntimeError("template exploded")
+
+    monkeypatch.setattr("kronos.persona.build_system_prompt", flaky_prompt)
+
+    report = await measure_proposal(PROPOSAL, suite_dir=suite)
+
+    assert report["regressions"][0]["kind"] == "prompt_broken"
+    assert verdict(report, max_regression_pct=100)[0] is False
+
+
+@pytest.mark.asyncio
+async def test_the_report_renders_for_a_human(workspace, suite):
+    text = render_report(await measure_proposal(PROPOSAL, suite_dir=suite))
+
+    assert "Промпт:" in text
+    assert "Сценарии:" in text
+    assert "качество ответа офлайн не измеряется" in text
+
+
+# --- storage and the command surface ------------------------------------------
+
+
+def test_the_measurement_is_stored_with_the_proposal(proposals_db):
+    measurement = {"measured_quality": False, "suite": {"scenarios": 3}, "verdict": "no measurable regression"}
+
+    pid = evolution.create_proposal(
+        agent_name="evo",
+        target="soul",
+        rationale="короче",
+        proposal="- Короче.",
+        eval_json=json.dumps(measurement),
+    )
+
+    stored = evolution.get_proposal(pid, "evo")
+    assert json.loads(stored["eval_json"])["verdict"] == "no measurable regression"
+
+
+def test_a_proposal_without_a_measurement_still_works(proposals_db):
+    """Rows written before 12.4 have no eval_json."""
+    pid = evolution.create_proposal(agent_name="evo", target="soul", rationale="r", proposal="p")
+
+    assert evolution.get_proposal(pid, "evo")["eval_json"] in ("", None)
+
+
+def test_the_rejection_reason_is_kept(proposals_db):
+    pid = evolution.create_proposal(
+        agent_name="evo",
+        target="soul",
+        rationale="r",
+        proposal="p",
+        eval_json=json.dumps({"suite": {"scenarios": 2}}),
+    )
+
+    evolution.decide_proposal(pid, "evo", approved=False)
+    evolution.record_decision_reason(pid, "50% of scenarios regressed (a)")
+
+    stored = json.loads(evolution.get_proposal(pid, "evo")["eval_json"])
+    assert stored["decision_reason"] == "50% of scenarios regressed (a)"
+    assert stored["suite"]["scenarios"] == 2, "recording a reason must not drop the measurement"
+
+
+def test_rejected_proposals_stay_listable(proposals_db):
+    """A measurement that hides what it rejected is one nobody can audit."""
+    pid = evolution.create_proposal(agent_name="evo", target="soul", rationale="r", proposal="p")
+    evolution.decide_proposal(pid, "evo", approved=False)
+
+    assert evolution.list_pending("evo") == []
+    assert [row["id"] for row in evolution.list_proposals("evo", state="rejected")] == [pid]
+
+
+@pytest.mark.asyncio
+async def test_persona_list_shows_the_verdict(proposals_db, monkeypatch):
+    from kronos.bridge_commands import _handle_persona_command
+
+    monkeypatch.setattr(settings, "agent_name", "evo")
+    evolution.create_proposal(
+        agent_name="evo",
+        target="soul",
+        rationale="короче отвечать",
+        proposal="- Короче.",
+        eval_json=json.dumps({"verdict": "no measurable regression"}),
+    )
+
+    reply = await _handle_persona_command("/persona list")
+
+    assert "no measurable regression" in reply
+
+
+@pytest.mark.asyncio
+async def test_persona_show_prints_the_measurement(proposals_db, monkeypatch):
+    from kronos.bridge_commands import _handle_persona_command
+
+    monkeypatch.setattr(settings, "agent_name", "evo")
+    pid = evolution.create_proposal(
+        agent_name="evo",
+        target="soul",
+        rationale="короче отвечать",
+        proposal="- Короче.",
+        eval_json=json.dumps(
+            {
+                "measured_quality": False,
+                "prompt": {"built": True, "growth_pct": 1.2, "chars_after": 4200},
+                "suite": {"scenarios": 6, "base_failed": 0, "head_failed": 0},
+                "entries": [],
+                "notes": [],
+            }
+        ),
+    )
+
+    reply = await _handle_persona_command(f"/persona show {pid}")
+
+    assert "Промпт: +1.2%" in reply
+    assert "Сценарии: 6" in reply
+
+
+@pytest.mark.asyncio
+async def test_persona_list_rejected_shows_reasons(proposals_db, monkeypatch):
+    from kronos.bridge_commands import _handle_persona_command
+
+    monkeypatch.setattr(settings, "agent_name", "evo")
+    pid = evolution.create_proposal(agent_name="evo", target="soul", rationale="r", proposal="p")
+    evolution.decide_proposal(pid, "evo", approved=False)
+    evolution.record_decision_reason(pid, "60% of the proposal is already in the file")
+
+    reply = await _handle_persona_command("/persona list --rejected")
+
+    assert "already in the file" in reply

--- a/tests/test_skill_usage.py
+++ b/tests/test_skill_usage.py
@@ -1,0 +1,253 @@
+"""Which skills are used, and what may leave the machine (moat phase 12.5).
+
+Two properties carry this feature: the counter reflects real loads (not catalog
+listings), and nothing is assembled for sharing unless the policy says so. The
+second one is the test that matters — a telemetry feature is only as trustworthy
+as the proof that it stays silent.
+"""
+
+import pytest
+
+from kronos.config import settings
+from kronos.skills.store import SkillStore
+from kronos.skills.usage import (
+    call_bucket,
+    local_report,
+    record_call,
+    shareable_aggregate,
+    telemetry_mode,
+    usage,
+)
+
+SKILL_MD = """---
+name: decision-memo
+description: Write a one-page decision memo
+version: 1.2.0
+checksum: sha256:abc
+eval_status: passed
+---
+## Steps
+
+1. State the decision.
+"""
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    root = tmp_path / "workspace"
+    skills_dir = root / "self" / "skills" / "decision-memo"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text(SKILL_MD, encoding="utf-8")
+
+    plain = root / "self" / "skills" / "local-notes"
+    plain.mkdir(parents=True)
+    (plain / "SKILL.md").write_text("---\nname: local-notes\ndescription: Local\n---\nNotes.\n", encoding="utf-8")
+
+    data = tmp_path / "data"
+    data.mkdir()
+    monkeypatch.setattr(settings, "db_dir", str(data))
+    monkeypatch.setattr(settings, "db_path", str(data / "session.db"))
+    monkeypatch.setattr(settings, "workspace_path", str(root), raising=False)
+    import kronos.db as _db
+
+    _db._instances.clear()
+    yield root
+    _db._instances.clear()
+
+
+@pytest.fixture
+def store(workspace):
+    return SkillStore(str(workspace))
+
+
+# --- the counter --------------------------------------------------------------
+
+
+def test_loading_a_skill_counts_it(workspace):
+    from kronos.skills.tools import init_skill_tools, load_skill
+
+    init_skill_tools(SkillStore(str(workspace)))
+
+    load_skill.invoke({"skill_name": "decision-memo"})
+    load_skill.invoke({"skill_name": "decision-memo"})
+
+    assert usage()["decision-memo"]["calls"] == 2
+    assert usage()["decision-memo"]["last_used_at"] > 0
+
+
+def test_a_missing_skill_is_not_counted(workspace):
+    from kronos.skills.tools import init_skill_tools, load_skill
+
+    init_skill_tools(SkillStore(str(workspace)))
+
+    load_skill.invoke({"skill_name": "not-a-skill"})
+
+    assert usage() == {}, "being asked for a skill that does not exist is not usage"
+
+
+def test_listing_the_catalog_is_not_usage(store, workspace):
+    """Being offered to the model is not being used."""
+    store.build_catalog()
+
+    assert usage() == {}
+
+
+def test_the_counter_never_breaks_a_turn(workspace, monkeypatch):
+    def broken_db():
+        raise RuntimeError("database is locked")
+
+    monkeypatch.setattr("kronos.db.get_db", lambda name: broken_db())
+
+    record_call("decision-memo")  # must not raise
+
+
+@pytest.mark.parametrize(
+    "calls,expected",
+    [(0, "unused"), (1, "1-9"), (9, "1-9"), (10, "10-99"), (99, "10-99"), (100, "100+"), (5000, "100+")],
+)
+def test_call_buckets(calls, expected):
+    assert call_bucket(calls) == expected
+
+
+# --- the local report ---------------------------------------------------------
+
+
+def test_the_report_joins_usage_with_provenance(store, workspace):
+    record_call("decision-memo")
+
+    rows = {row["skill"]: row for row in local_report(store)}
+
+    assert rows["decision-memo"]["calls"] == 1
+    assert rows["decision-memo"]["verified"] is True
+    assert rows["decision-memo"]["eval_status"] == "passed"
+    assert rows["local-notes"]["calls"] == 0
+    assert rows["local-notes"]["verified"] is False
+    assert rows["local-notes"]["eval_status"] == "none"
+
+
+def test_the_report_puts_the_used_skills_first(store, workspace):
+    record_call("local-notes")
+
+    assert [row["skill"] for row in local_report(store)] == ["local-notes", "decision-memo"]
+
+
+def test_the_report_carries_no_outcome_rate(store, workspace):
+    """Nothing links a turn's result to its skills, so there is no ok_rate to show."""
+    record_call("decision-memo")
+
+    row = local_report(store)[0]
+
+    assert "ok_rate" not in row
+    assert "failed" not in row
+
+
+# --- sharing stays off --------------------------------------------------------
+
+
+def test_telemetry_is_off_by_default():
+    assert telemetry_mode() == "off"
+
+
+def test_nothing_is_assembled_while_telemetry_is_off(store, workspace):
+    record_call("decision-memo")
+
+    assert shareable_aggregate(store) == []
+
+
+def test_local_mode_still_shares_nothing(store, workspace, monkeypatch):
+    """`local` means "count for me", not "send somewhere"."""
+    from kronos import policy as policy_module
+
+    monkeypatch.setattr(policy_module, "_active", policy_module.Policy(registry={"telemetry": "local"}))
+    record_call("decision-memo")
+
+    assert shareable_aggregate(store) == []
+    assert local_report(store)[0]["calls"] == 1
+
+
+def test_the_shared_payload_is_anonymous_and_coarse(store, workspace, monkeypatch):
+    from kronos import policy as policy_module
+
+    monkeypatch.setattr(policy_module, "_active", policy_module.Policy(registry={"telemetry": "share"}))
+    for _ in range(12):
+        record_call("decision-memo")
+
+    payload = shareable_aggregate(store)
+    row = next(item for item in payload if item["skill"] == "decision-memo")
+
+    assert row["calls_bucket"] == "10-99", "exact counts are not shared"
+    assert set(row) == {"skill", "version", "calls_bucket", "eval_status", "verified"}
+    assert "last_used_at" not in row, "timestamps would describe a workflow"
+
+
+def test_the_share_command_refuses_while_telemetry_is_off(workspace, capsys, monkeypatch):
+    from kronos.cli import run_skills
+
+    monkeypatch.setattr(settings, "agent_name", "usage-demo")
+    monkeypatch.setattr("kronos.cli._skills_workspace_root", lambda agent: workspace)
+
+    code = run_skills("stats", output="share")
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "nothing was sent" in out.lower()
+
+
+def test_the_stats_command_says_what_it_does_not_measure(workspace, capsys, monkeypatch):
+    from kronos.cli import run_skills
+
+    monkeypatch.setattr("kronos.cli._skills_workspace_root", lambda agent: workspace)
+    record_call("decision-memo")
+
+    code = run_skills("stats")
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert "decision-memo" in out
+    assert "Outcomes are not tracked" in out
+
+
+# --- the control room ---------------------------------------------------------
+
+
+def test_the_dashboard_lists_provenance_and_usage(workspace, monkeypatch):
+    from fastapi.testclient import TestClient
+
+    monkeypatch.setattr(settings, "swarm_db_path", str(workspace.parent / "swarm.db"))
+    record_call("decision-memo")
+
+    from dashboard import auth
+    from dashboard.server import create_app
+
+    app = create_app()
+    app.dependency_overrides[auth.verify_token] = lambda: True
+    rows = {row["name"]: row for row in TestClient(app).get("/api/skills/").json()["skills"]}
+
+    assert rows["decision-memo"]["verified"] is True
+    assert rows["decision-memo"]["eval_status"] == "passed"
+    assert rows["decision-memo"]["calls"] == 1
+    assert rows["local-notes"]["verified"] is False
+
+
+def test_yaml_bare_off_is_understood(tmp_path, monkeypatch):
+    """YAML 1.1 parses `telemetry: off` as False; that must still mean off."""
+    from kronos.policy import ENV_POLICY_FILE, RegistryPolicy, load_policy, reset_policy
+
+    assert RegistryPolicy(telemetry=False).telemetry == "off"
+
+    path = tmp_path / "policy.yaml"
+    path.write_text("version: 1\nregistry:\n  telemetry: off\n", encoding="utf-8")
+    monkeypatch.setenv(ENV_POLICY_FILE, str(path))
+    reset_policy()
+    try:
+        assert load_policy().registry.telemetry == "off"
+    finally:
+        reset_policy()
+
+
+def test_a_boolean_true_telemetry_is_refused():
+    """`telemetry: on` is not a mode, and guessing which one it meant would be worse."""
+    from kronos.policy import RegistryPolicy
+
+    with pytest.raises(ValueError, match="not a boolean true"):
+        RegistryPolicy(telemetry=True)

--- a/tests/test_skills_autoeval.py
+++ b/tests/test_skills_autoeval.py
@@ -1,0 +1,375 @@
+"""A skill's own scenario, replayed at install time (moat phase 12.3).
+
+A signature says who wrote a skill, not that it works. The scenario format from
+Phase 8 is self-contained — the model's turns are scripted inside the YAML — so a
+publisher can ship a check and an installer can replay it with no key and no
+network. These tests pin what that check may and may not decide.
+"""
+
+import json
+
+import pytest
+import yaml
+
+from kronos.config import settings
+from kronos.skills.autoeval import (
+    EVAL_ERROR,
+    EVAL_FAILED,
+    EVAL_MISSING,
+    EVAL_PASSED,
+    SCENARIO_RELPATH,
+    fetch_scenario,
+    name_conflicts,
+    record_outcome,
+    run_skill_eval,
+    scenario_url,
+)
+from kronos.skills.registry import RegistryEntry, install
+from kronos.skills.store import SkillStore
+
+SKILL_MD = """---
+name: decision-memo
+description: Write a one-page decision memo
+version: 1.2.0
+author: publisher
+---
+## Steps
+
+1. State the decision.
+"""
+
+PASSING_SCENARIO = {
+    "schema_version": 1,
+    "name": "memo-without-tools",
+    "input": "write the memo",
+    "script": [{"content": "Here is the decision memo."}],
+    "tool_outputs": {},
+    "expect": {"max_tool_calls": 0, "must_mention": ["decision memo"]},
+}
+
+FAILING_SCENARIO = {
+    **PASSING_SCENARIO,
+    "name": "memo-that-contradicts-itself",
+    "expect": {"max_tool_calls": 0, "must_mention": ["quarterly budget"]},
+}
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    root = tmp_path / "workspace"
+    (root / "self" / "skills").mkdir(parents=True)
+    data = tmp_path / "data"
+    data.mkdir()
+    monkeypatch.setattr(settings, "db_dir", str(data))
+    return root
+
+
+@pytest.fixture
+def store(workspace):
+    return SkillStore(str(workspace))
+
+
+@pytest.fixture
+def served(monkeypatch):
+    """Serve SKILL.md and (optionally) a scenario, by URL suffix."""
+    payloads = {"skill": SKILL_MD, "scenario": None}
+
+    def fake_fetch(url: str, timeout: int = 15) -> str:
+        if url.endswith(SCENARIO_RELPATH):
+            if payloads["scenario"] is None:
+                raise OSError("HTTP Error 404: Not Found")
+            return payloads["scenario"]
+        return payloads["skill"]
+
+    monkeypatch.setattr("kronos.skills.hub._fetch_url", fake_fetch)
+    return payloads
+
+
+def _entry(**overrides) -> RegistryEntry:
+    base = {
+        "name": "decision-memo",
+        "url": "https://example.invalid/decision-memo/SKILL.md",
+        "source": "test-source",
+        "trust": "none",
+    }
+    return RegistryEntry(**{**base, **overrides})
+
+
+def _write_scenario(skill_dir, payload: dict) -> None:
+    target = skill_dir / SCENARIO_RELPATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+# --- where the scenario lives --------------------------------------------------
+
+
+def test_the_scenario_is_a_sibling_of_the_skill_by_convention():
+    assert scenario_url("https://x.invalid/a/SKILL.md") == "https://x.invalid/a/evals/scenario.yaml"
+    assert scenario_url("github:acme/skills/decision-memo") == "github:acme/skills/decision-memo/evals/scenario.yaml"
+    assert scenario_url("github:acme/skills/memo/SKILL.md") == "github:acme/skills/memo/evals/scenario.yaml"
+
+
+def test_an_explicit_url_wins():
+    assert scenario_url("https://x.invalid/a/SKILL.md", "https://y.invalid/s.yaml") == "https://y.invalid/s.yaml"
+
+
+def test_an_unrecognised_layout_yields_no_scenario_url():
+    assert scenario_url("https://x.invalid/skill.txt") == ""
+    assert scenario_url("") == ""
+
+
+# --- fetching -----------------------------------------------------------------
+
+
+def test_a_missing_scenario_is_the_normal_case(tmp_path, monkeypatch):
+    def broken(url: str, timeout: int = 15) -> str:
+        raise OSError("HTTP Error 404: Not Found")
+
+    monkeypatch.setattr("kronos.skills.hub._fetch_url", broken)
+
+    assert fetch_scenario("https://x.invalid/a/evals/scenario.yaml", tmp_path) is None
+
+
+def test_an_html_error_page_from_a_guessed_url_is_not_a_scenario(tmp_path, monkeypatch):
+    """Many hosts answer 200 with a page for a missing file."""
+    monkeypatch.setattr("kronos.skills.hub._fetch_url", lambda url, timeout=15: "<!DOCTYPE html><html>404</html>")
+
+    assert fetch_scenario("https://x.invalid/a/evals/scenario.yaml", tmp_path) is None
+    assert not (tmp_path / SCENARIO_RELPATH).exists()
+
+
+def test_garbage_from_a_declared_url_is_kept_so_it_can_be_reported(tmp_path, monkeypatch):
+    """If the publisher points at a check, a broken check is their error."""
+    monkeypatch.setattr("kronos.skills.hub._fetch_url", lambda url, timeout=15: "not: [a scenario")
+
+    path = fetch_scenario("https://x.invalid/s.yaml", tmp_path, declared=True)
+
+    assert path is not None and path.exists()
+
+
+def test_a_real_scenario_is_written_next_to_the_skill(tmp_path, monkeypatch):
+    monkeypatch.setattr("kronos.skills.hub._fetch_url", lambda url, timeout=15: yaml.safe_dump(PASSING_SCENARIO))
+
+    path = fetch_scenario("https://x.invalid/a/evals/scenario.yaml", tmp_path)
+
+    assert path == tmp_path / SCENARIO_RELPATH
+    assert "memo-without-tools" in path.read_text(encoding="utf-8")
+
+
+# --- replay -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_scenario_is_reported_as_missing(tmp_path):
+    outcome = await run_skill_eval(tmp_path)
+
+    assert outcome.status == EVAL_MISSING
+    assert outcome.passed is False
+    assert outcome.ran is False
+
+
+@pytest.mark.asyncio
+async def test_a_passing_scenario_passes_offline(tmp_path):
+    _write_scenario(tmp_path, PASSING_SCENARIO)
+
+    outcome = await run_skill_eval(tmp_path)
+
+    assert outcome.status == EVAL_PASSED, outcome.detail
+    assert outcome.passed is True
+
+
+@pytest.mark.asyncio
+async def test_a_failing_scenario_says_what_failed(tmp_path):
+    _write_scenario(tmp_path, FAILING_SCENARIO)
+
+    outcome = await run_skill_eval(tmp_path)
+
+    assert outcome.status == EVAL_FAILED
+    assert "quarterly budget" in outcome.detail
+
+
+@pytest.mark.asyncio
+async def test_an_unusable_scenario_is_an_error_not_a_pass(tmp_path):
+    target = tmp_path / SCENARIO_RELPATH
+    target.parent.mkdir(parents=True)
+    target.write_text("name: broken\n", encoding="utf-8")  # no script to replay
+
+    outcome = await run_skill_eval(tmp_path)
+
+    assert outcome.status == EVAL_ERROR
+    assert outcome.passed is False
+
+
+# --- the verdict is recorded ---------------------------------------------------
+
+
+def test_the_verdict_lands_in_frontmatter_without_touching_the_checksum(store, workspace):
+    from kronos.skills.autoeval import EvalOutcome
+    from kronos.skills.integrity import compute_checksum
+
+    skill_dir = workspace / "self" / "skills" / "decision-memo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(SKILL_MD, encoding="utf-8")
+    fresh = SkillStore(str(workspace))
+    before = compute_checksum(skill_dir)
+
+    record_outcome(fresh, "decision-memo", EvalOutcome(EVAL_PASSED, "scenario 'x' passed"))
+
+    assert compute_checksum(skill_dir) == before, "a local verdict must not invalidate a published checksum"
+    reloaded = SkillStore(str(workspace)).get("decision-memo")
+    assert reloaded.eval_status == EVAL_PASSED
+    assert "passed" in reloaded.eval_detail
+
+
+def test_the_manifest_exposes_verified_signed_and_eval_status(store, workspace):
+    skill_dir = workspace / "self" / "skills" / "decision-memo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        SKILL_MD.replace("author: publisher", "author: publisher\nchecksum: sha256:abc\neval_status: passed"),
+        encoding="utf-8",
+    )
+
+    manifest = SkillStore(str(workspace)).generate_manifest()
+    row = next(entry for entry in manifest["skills"] if entry["name"] == "decision-memo")
+
+    assert row["verified"] is True
+    assert row["signed"] is False
+    assert row["eval_status"] == "passed"
+
+
+# --- name conflicts -----------------------------------------------------------
+
+
+def test_an_installed_name_is_a_conflict(store, workspace):
+    skill_dir = workspace / "self" / "skills" / "decision-memo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(SKILL_MD, encoding="utf-8")
+
+    reason = name_conflicts("decision-memo", SkillStore(str(workspace)))
+
+    assert "already installed" in reason
+
+
+def test_a_tool_name_is_a_conflict(store):
+    """A skill shadowing a tool would make load_skill and the router disagree."""
+    reason = name_conflicts("schedule_task", store, tool_names=["schedule_task"])
+
+    assert "name of an existing tool" in reason
+
+
+def test_the_built_in_tool_names_are_discoverable(store):
+    from kronos.skills.autoeval import known_tool_names
+
+    names = known_tool_names()
+
+    assert "schedule_task" in names, "the inventory must actually see the built-in tools"
+    assert name_conflicts("schedule_task", store) != ""
+
+
+def test_a_free_name_has_no_conflict(store):
+    assert name_conflicts("brand-new-skill", store, tool_names=["schedule_task"]) == ""
+
+
+# --- install gating -----------------------------------------------------------
+
+
+def test_a_skill_with_a_passing_scenario_records_it(store, served):
+    served["scenario"] = yaml.safe_dump(PASSING_SCENARIO)
+
+    result = install("decision-memo", store=store, entries=[_entry()])
+
+    assert result.installed is True
+    assert result.report["eval_status"] == EVAL_PASSED
+    assert store.get("decision-memo").eval_status == EVAL_PASSED
+
+
+def test_a_failing_scenario_keeps_the_skill_a_draft(store, served):
+    served["scenario"] = yaml.safe_dump(FAILING_SCENARIO)
+
+    result = install("decision-memo", store=store, entries=[_entry()])
+
+    assert result.status == "draft"
+    assert "quarterly budget" in result.reason
+    assert store.get("decision-memo").eval_status == EVAL_FAILED
+
+
+def test_a_skill_without_a_scenario_is_marked_unverified(store, served):
+    result = install("decision-memo", store=store, entries=[_entry()])
+
+    assert result.installed is True
+    assert result.report["eval_status"] == EVAL_MISSING
+    assert "unverified" in result.reason
+
+
+def test_no_eval_flag_skips_the_check_entirely(store, served, monkeypatch):
+    served["scenario"] = yaml.safe_dump(FAILING_SCENARIO)
+    calls = {"n": 0}
+
+    def counted(skill_dir):
+        calls["n"] += 1
+        raise AssertionError("must not run")
+
+    monkeypatch.setattr("kronos.skills.autoeval.run_skill_eval", counted)
+
+    result = install("decision-memo", store=store, entries=[_entry()], run_eval=False)
+
+    assert result.installed is True
+    assert calls["n"] == 0
+
+
+def test_a_name_conflict_is_refused_before_fetching(store, workspace, monkeypatch):
+    skill_dir = workspace / "self" / "skills" / "taken"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(SKILL_MD.replace("decision-memo", "taken"), encoding="utf-8")
+    fresh = SkillStore(str(workspace))
+
+    def must_not_fetch(url: str, timeout: int = 15) -> str:
+        raise AssertionError("install must not fetch a name it cannot use")
+
+    monkeypatch.setattr("kronos.skills.hub._fetch_url", must_not_fetch)
+
+    result = install("taken", store=fresh, entries=[_entry(name="taken")])
+
+    assert result.installed is False
+    assert "already installed" in result.reason
+
+
+def test_the_index_can_point_at_a_scenario_elsewhere(store, monkeypatch):
+    fetched: list[str] = []
+
+    def fake_fetch(url: str, timeout: int = 15) -> str:
+        fetched.append(url)
+        if url == "https://elsewhere.invalid/checks/memo.yaml":
+            return yaml.safe_dump(PASSING_SCENARIO)
+        return SKILL_MD
+
+    monkeypatch.setattr("kronos.skills.hub._fetch_url", fake_fetch)
+
+    result = install(
+        "decision-memo",
+        store=store,
+        entries=[_entry(scenario_url="https://elsewhere.invalid/checks/memo.yaml")],
+    )
+
+    assert "https://elsewhere.invalid/checks/memo.yaml" in fetched
+    assert result.report["eval_status"] == EVAL_PASSED
+
+
+def test_the_policy_can_stop_the_eval_from_gating(store, served, monkeypatch):
+    """An operator may want the verdict recorded but not enforced."""
+    from kronos import policy as policy_module
+
+    served["scenario"] = yaml.safe_dump(FAILING_SCENARIO)
+    monkeypatch.setattr(
+        policy_module,
+        "_active",
+        policy_module.Policy(registry={"require_eval_on_install": False}),
+    )
+
+    result = install("decision-memo", store=store, entries=[_entry()])
+
+    # Still a draft here (nothing signed it), but the failure is not the reason
+    # activation was withheld — the recorded verdict proves the check ran.
+    assert result.report["eval_status"] == EVAL_FAILED
+    assert json.dumps(result.report)  # report stays serialisable for the dashboard

--- a/tests/test_skills_integrity.py
+++ b/tests/test_skills_integrity.py
@@ -1,0 +1,428 @@
+"""Skill provenance: checksum, signature, compatibility (moat phase 12.1).
+
+A skill is instructions the agent will follow, so "is this what the publisher
+wrote" has to be answerable offline. Three separate questions, and the tests keep
+them separate: content integrity (checksum), authorship (signature), and whether
+the skill claims to need a different KAOS (compatibility).
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from kronos.skills.integrity import (
+    HASH_PREFIX,
+    canonical_form,
+    check_compatibility,
+    compute_checksum,
+    verify_checksum,
+    verify_signature,
+    verify_skill,
+)
+from kronos.skills.store import Skill, SkillStore, _parse_frontmatter
+
+SKILL_BODY = """## When to use
+
+Use this when a decision needs a written memo.
+
+## Steps
+
+1. State the decision.
+2. State the alternatives.
+"""
+
+
+def _write_skill(
+    root: Path,
+    name: str = "decision-memo",
+    *,
+    meta_extra: str = "",
+    body: str = SKILL_BODY,
+    references: dict[str, str] | None = None,
+) -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    frontmatter = f"---\nname: {name}\ndescription: Write a decision memo\nversion: 1.2.0\n{meta_extra}---\n"
+    (skill_dir / "SKILL.md").write_text(frontmatter + body, encoding="utf-8")
+    for ref_name, ref_body in (references or {}).items():
+        refs_dir = skill_dir / "references"
+        refs_dir.mkdir(exist_ok=True)
+        (refs_dir / f"{ref_name}.md").write_text(ref_body, encoding="utf-8")
+    return skill_dir
+
+
+def _skill_from_dir(skill_dir: Path) -> Skill:
+    """Load one skill the way the store would, without a whole workspace."""
+    meta, body = _parse_frontmatter((skill_dir / "SKILL.md").read_text(encoding="utf-8"))
+    refs_dir = skill_dir / "references"
+    references = {p.stem: p for p in refs_dir.iterdir()} if refs_dir.is_dir() else {}
+    return Skill(
+        name=meta.get("name", skill_dir.name),
+        description=meta.get("description", ""),
+        content=body,
+        path=skill_dir / "SKILL.md",
+        references=references,
+        version=meta.get("version", "1.0.0"),
+        requires_kaos=meta.get("requires_kaos", ""),
+        checksum=meta.get("checksum", ""),
+        signature=meta.get("signature", ""),
+    )
+
+
+# --- checksum -----------------------------------------------------------------
+
+
+def test_the_same_content_hashes_the_same(tmp_path):
+    first = compute_checksum(_write_skill(tmp_path / "a"))
+    second = compute_checksum(_write_skill(tmp_path / "b"))
+
+    assert first == second
+    assert first.startswith(HASH_PREFIX)
+
+
+def test_one_changed_byte_in_the_body_breaks_it(tmp_path):
+    original = compute_checksum(_write_skill(tmp_path / "a"))
+    tampered = compute_checksum(_write_skill(tmp_path / "b", body=SKILL_BODY.replace("memo", "memo!")))
+
+    assert original != tampered
+
+
+def test_a_changed_reference_breaks_it(tmp_path):
+    """References carry instructions too, so they are inside the hash."""
+    original = compute_checksum(_write_skill(tmp_path / "a", references={"template": "# Memo\n"}))
+    tampered = compute_checksum(_write_skill(tmp_path / "b", references={"template": "# Memo (edited)\n"}))
+
+    assert original != tampered
+
+
+def test_reference_order_does_not_matter(tmp_path):
+    first = _write_skill(tmp_path / "a", references={"aaa": "one", "bbb": "two"})
+    second = _write_skill(tmp_path / "b", references={"bbb": "two", "aaa": "one"})
+
+    assert compute_checksum(first) == compute_checksum(second)
+
+
+def test_local_bookkeeping_fields_are_not_hashed(tmp_path):
+    """Import rewrites status and adds provenance; that must not break the hash."""
+    published = compute_checksum(_write_skill(tmp_path / "a"))
+    imported = compute_checksum(
+        _write_skill(
+            tmp_path / "b",
+            meta_extra=(
+                "status: draft\nreview_required: true\nimported_from: github:acme/skills/decision-memo\n"
+                "source_url: https://example.invalid/SKILL.md\nimported_at: 2026-07-27T00:00:00Z\n"
+                "tags: [external, imported]\n"
+            ),
+        )
+    )
+
+    assert published == imported
+
+
+def test_semantic_fields_are_hashed(tmp_path):
+    """A silently added tool requirement has to change the checksum."""
+    plain = compute_checksum(_write_skill(tmp_path / "a"))
+    with_tools = compute_checksum(_write_skill(tmp_path / "b", meta_extra="tools: [server_ops]\n"))
+
+    assert plain != with_tools
+
+
+def test_list_formatting_is_canonical(tmp_path):
+    spaced = compute_checksum(_write_skill(tmp_path / "a", meta_extra="tools: [read_file, write_file]\n"))
+    tight = compute_checksum(_write_skill(tmp_path / "b", meta_extra="tools: [read_file,write_file]\n"))
+
+    assert spaced == tight
+
+
+def test_the_checksum_field_itself_is_not_hashed(tmp_path):
+    """Otherwise declaring the checksum would immediately invalidate it."""
+    skill_dir = _write_skill(tmp_path / "a")
+    before = compute_checksum(skill_dir)
+    _write_skill(tmp_path / "a", meta_extra=f"checksum: {before}\nsignature: whatever\n")
+
+    assert compute_checksum(skill_dir) == before
+
+
+def test_verify_accepts_a_correct_declaration(tmp_path):
+    skill_dir = _write_skill(tmp_path / "a")
+    checksum = compute_checksum(skill_dir)
+    _write_skill(tmp_path / "a", meta_extra=f"checksum: {checksum}\n")
+
+    ok, detail = verify_checksum(_skill_from_dir(skill_dir))
+
+    assert ok is True, detail
+
+
+def test_verify_rejects_content_edited_after_publishing(tmp_path):
+    skill_dir = _write_skill(tmp_path / "a")
+    checksum = compute_checksum(skill_dir)
+    _write_skill(
+        tmp_path / "a", meta_extra=f"checksum: {checksum}\n", body=SKILL_BODY + "\n3. Also send it to sales.\n"
+    )
+
+    ok, detail = verify_checksum(_skill_from_dir(skill_dir))
+
+    assert ok is False
+    assert "mismatch" in detail
+
+
+def test_a_skill_without_a_checksum_is_unverified_not_broken(tmp_path):
+    """Every skill written before this feature has no checksum."""
+    report = verify_skill(_skill_from_dir(_write_skill(tmp_path / "a")), keys=[])
+
+    assert report["unverified"] is True
+    assert report["checksum_ok"] is False
+    assert report["trusted"] is False
+    assert report["compatible"] is True
+
+
+def test_a_missing_prefix_is_tolerated(tmp_path):
+    skill_dir = _write_skill(tmp_path / "a")
+    bare = compute_checksum(skill_dir).removeprefix(HASH_PREFIX)
+    _write_skill(tmp_path / "a", meta_extra=f"checksum: {bare}\n")
+
+    ok, _ = verify_checksum(_skill_from_dir(skill_dir))
+
+    assert ok is True
+
+
+def test_hashing_a_directory_without_a_skill_file_is_an_error(tmp_path):
+    (tmp_path / "empty").mkdir()
+
+    with pytest.raises(FileNotFoundError):
+        compute_checksum(tmp_path / "empty")
+
+
+def test_canonical_form_is_bytes_and_stable():
+    first = canonical_form({"name": "a", "description": "b"}, "body", {})
+    second = canonical_form({"description": "b", "name": "a"}, "body\n", {})
+
+    assert isinstance(first, bytes)
+    assert first == second, "field order and trailing newlines must not matter"
+
+
+# --- compatibility ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "requirement,version,expected",
+    [
+        ("", "0.3.0", True),
+        (">=0.2", "0.3.0", True),
+        (">=0.4", "0.3.0", False),
+        (">=0.2,<0.4", "0.3.0", True),
+        (">=0.2,<0.4", "0.4.0", False),
+        (">=0.2,<0.4", "0.1.9", False),
+        ("==0.3", "0.3.0", True),
+        ("!=0.3", "0.3.0", False),
+        (">=0.2", "0.3.0rc1", True),
+        (">=0.2", "v0.3.0", True),
+    ],
+)
+def test_version_requirements(tmp_path, requirement, version, expected):
+    skill_dir = _write_skill(tmp_path / "a", meta_extra=f"requires_kaos: '{requirement}'\n" if requirement else "")
+    skill = _skill_from_dir(skill_dir)
+
+    ok, detail = check_compatibility(skill, version)
+
+    assert ok is expected, detail
+
+
+def test_a_quoted_requirement_is_parsed(tmp_path):
+    """YAML quoting is conventional here, and the parser keeps the quotes."""
+    skill = _skill_from_dir(_write_skill(tmp_path / "a", meta_extra='requires_kaos: ">=0.2,<0.4"\n'))
+
+    assert check_compatibility(skill, "0.3.0") == (True, "compatible with KAOS 0.3.0")
+    assert check_compatibility(skill, "0.5.0")[0] is False
+
+
+def test_an_unknown_running_version_does_not_fail_every_skill(tmp_path):
+    """A source checkout reports 0.0.0+unknown — the unknown is on our side."""
+    skill = _skill_from_dir(_write_skill(tmp_path / "a", meta_extra="requires_kaos: '>=0.2,<0.9'\n"))
+
+    ok, detail = check_compatibility(skill, "0.0.0+unknown")
+
+    assert ok is True
+    assert "cannot determine the running KAOS version" in detail
+
+
+def test_an_unparsable_requirement_fails_closed(tmp_path):
+    """A requirement nobody can read is not evidence of compatibility."""
+    skill = _skill_from_dir(_write_skill(tmp_path / "a", meta_extra="requires_kaos: latest-and-greatest\n"))
+
+    ok, detail = check_compatibility(skill, "0.3.0")
+
+    assert ok is False
+    assert "cannot parse" in detail
+
+
+def test_compatibility_defaults_to_the_running_version(tmp_path):
+    from kronos import __version__
+
+    skill = _skill_from_dir(_write_skill(tmp_path / "a", meta_extra=f"requires_kaos: '>={__version__}'\n"))
+
+    ok, detail = check_compatibility(skill)
+
+    assert ok is True, detail
+
+
+# --- signature ----------------------------------------------------------------
+
+
+def test_no_signature_is_reported_not_guessed(tmp_path):
+    ok, detail = verify_signature(_skill_from_dir(_write_skill(tmp_path / "a")), trusted_keys=["ssh-ed25519 AAAA x"])
+
+    assert ok is False
+    assert detail == "no signature declared"
+
+
+def test_a_signature_without_trusted_keys_cannot_be_checked(tmp_path):
+    skill = _skill_from_dir(_write_skill(tmp_path / "a", meta_extra="signature: abc\n"))
+
+    ok, detail = verify_signature(skill, trusted_keys=[])
+
+    assert ok is False
+    assert "no trusted keys" in detail
+
+
+def test_a_signature_over_a_wrong_checksum_is_refused(tmp_path):
+    """Signing covers the checksum, so a broken checksum voids the signature."""
+    skill = _skill_from_dir(_write_skill(tmp_path / "a", meta_extra="checksum: sha256:deadbeef\nsignature: abc\n"))
+
+    ok, detail = verify_signature(skill, trusted_keys=["ssh-ed25519 AAAA publisher"])
+
+    assert ok is False
+    assert "signature not checked" in detail
+
+
+@pytest.mark.skipif(shutil.which("ssh-keygen") is None, reason="ssh-keygen not available")
+class TestRealSignatures:
+    """Round-trip against the real tool, since that is what publishers will use."""
+
+    @pytest.fixture
+    def keypair(self, tmp_path):
+        key = tmp_path / "publisher_key"
+        subprocess.run(
+            ["ssh-keygen", "-t", "ed25519", "-N", "", "-C", "publisher@example.invalid", "-f", str(key)],
+            check=True,
+            capture_output=True,
+        )
+        return key, (key.with_suffix(".pub")).read_text(encoding="utf-8").strip()
+
+    def _sign(self, key: Path, payload: str, tmp_path: Path) -> str:
+        data = tmp_path / "payload.txt"
+        data.write_text(payload, encoding="utf-8")
+        subprocess.run(
+            ["ssh-keygen", "-Y", "sign", "-f", str(key), "-n", "kaos-skill", str(data)],
+            check=True,
+            capture_output=True,
+        )
+        return data.with_suffix(".txt.sig").read_text(encoding="utf-8")
+
+    def test_a_signature_from_a_trusted_key_verifies(self, tmp_path, keypair):
+        key, public_key = keypair
+        skill_dir = _write_skill(tmp_path / "skill")
+        checksum = compute_checksum(skill_dir)
+        signature = self._sign(key, checksum, tmp_path)
+        _write_skill(
+            tmp_path / "skill",
+            meta_extra=f"checksum: {checksum}\nsignature: {signature.strip().splitlines()[1]}\n",
+        )
+        skill = _skill_from_dir(skill_dir)
+        skill.signature = signature  # full PEM, as a publisher would paste it
+
+        ok, detail = verify_signature(skill, trusted_keys=[public_key])
+
+        assert ok is True, detail
+        assert "publisher@example.invalid" in detail
+
+    def test_a_signature_from_an_untrusted_key_is_refused(self, tmp_path, keypair):
+        key, _ = keypair
+        other = tmp_path / "other_key"
+        subprocess.run(
+            ["ssh-keygen", "-t", "ed25519", "-N", "", "-C", "stranger@example.invalid", "-f", str(other)],
+            check=True,
+            capture_output=True,
+        )
+        skill_dir = _write_skill(tmp_path / "skill")
+        checksum = compute_checksum(skill_dir)
+        _write_skill(tmp_path / "skill", meta_extra=f"checksum: {checksum}\n")
+        skill = _skill_from_dir(skill_dir)
+        skill.signature = self._sign(key, checksum, tmp_path)
+
+        ok, detail = verify_signature(
+            skill,
+            trusted_keys=[other.with_suffix(".pub").read_text(encoding="utf-8").strip()],
+        )
+
+        assert ok is False
+        assert "does not match any trusted key" in detail
+
+    def test_editing_the_skill_after_signing_is_caught(self, tmp_path, keypair):
+        key, public_key = keypair
+        skill_dir = _write_skill(tmp_path / "skill")
+        checksum = compute_checksum(skill_dir)
+        signature = self._sign(key, checksum, tmp_path)
+        _write_skill(
+            tmp_path / "skill",
+            meta_extra=f"checksum: {checksum}\n",
+            body=SKILL_BODY + "\n3. Then email the CFO.\n",
+        )
+        skill = _skill_from_dir(skill_dir)
+        skill.signature = signature
+
+        ok, detail = verify_signature(skill, trusted_keys=[public_key])
+
+        assert ok is False
+        assert "signature not checked" in detail
+
+    def test_a_signed_skill_reports_as_trusted(self, tmp_path, keypair):
+        key, public_key = keypair
+        skill_dir = _write_skill(tmp_path / "skill")
+        checksum = compute_checksum(skill_dir)
+        signature = self._sign(key, checksum, tmp_path)
+        _write_skill(tmp_path / "skill", meta_extra=f"checksum: {checksum}\n")
+        skill = _skill_from_dir(skill_dir)
+        skill.signature = signature
+
+        report = verify_skill(skill, keys=[public_key])
+
+        assert report["trusted"] is True
+        assert report["signature_ok"] is True
+        assert report["unverified"] is False
+
+
+# --- policy wiring ------------------------------------------------------------
+
+
+def test_trusted_keys_come_from_the_policy(monkeypatch):
+    from kronos import policy as policy_module
+    from kronos.skills.integrity import trusted_keys
+
+    monkeypatch.setattr(
+        policy_module,
+        "_active",
+        policy_module.Policy(registry={"trusted_keys": ["ssh-ed25519 AAAA publisher"]}),
+    )
+
+    assert trusted_keys() == ["ssh-ed25519 AAAA publisher"]
+
+
+def test_the_store_exposes_provenance_fields(tmp_path, monkeypatch):
+    """`kaos skills verify` reads these off the loaded skill, not the file."""
+    workspace = tmp_path / "workspace"
+    skills_dir = workspace / "self" / "skills"
+    skills_dir.mkdir(parents=True)
+    skill_dir = _write_skill(skills_dir, meta_extra="requires_kaos: '>=0.2'\nchecksum: sha256:abc\nsignature: sig\n")
+    checksum = compute_checksum(skill_dir)
+
+    store = SkillStore(str(workspace))
+    skill = store.get("decision-memo")
+
+    assert skill is not None
+    assert skill.requires_kaos == "'>=0.2'"
+    assert skill.checksum == "sha256:abc"
+    assert skill.signature == "sig"
+    assert checksum.startswith(HASH_PREFIX)

--- a/tests/test_skills_registry.py
+++ b/tests/test_skills_registry.py
@@ -1,0 +1,467 @@
+"""Skill sources, index and install with proof (moat phase 12.2).
+
+The registry is a file, so the risks are not availability but trust: a source
+must not become trusted by being reachable, a tampered skill must not activate,
+and an unreachable source must not make the working ones useless.
+"""
+
+import json
+import shutil
+import subprocess
+
+import pytest
+import yaml
+
+from kronos.config import settings
+from kronos.skills.integrity import compute_checksum
+from kronos.skills.registry import (
+    RegistryEntry,
+    RegistryError,
+    RegistrySource,
+    find_entry,
+    index_url,
+    install,
+    load_index,
+    load_sources,
+    parse_index,
+    search,
+)
+from kronos.skills.store import SkillStore
+
+SKILL_MD = """---
+name: decision-memo
+description: Write a one-page decision memo
+version: 1.2.0
+author: publisher
+---
+## Steps
+
+1. State the decision.
+2. State the alternatives.
+"""
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    root = tmp_path / "workspace"
+    (root / "self" / "skills").mkdir(parents=True)
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path / "data"))
+    (tmp_path / "data").mkdir()
+    return root
+
+
+@pytest.fixture
+def store(workspace):
+    return SkillStore(str(workspace))
+
+
+def _sources_file(tmp_path, payload: dict) -> str:
+    path = tmp_path / "registry.yaml"
+    path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+    return str(path)
+
+
+def _published_checksum(tmp_path) -> str:
+    """The checksum a publisher would compute for SKILL_MD."""
+    skill_dir = tmp_path / "published" / "decision-memo"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(SKILL_MD, encoding="utf-8")
+    return compute_checksum(skill_dir)
+
+
+def _entry(**overrides) -> RegistryEntry:
+    base = {
+        "name": "decision-memo",
+        "description": "Write a one-page decision memo",
+        "version": "1.2.0",
+        "url": "https://example.invalid/decision-memo/SKILL.md",
+        "source": "test-source",
+        "trust": "checksum",
+    }
+    return RegistryEntry(**{**base, **overrides})
+
+
+@pytest.fixture
+def served(monkeypatch):
+    """Serve SKILL.md content over the import path without network."""
+    served_text = {"value": SKILL_MD}
+
+    def fake_fetch(url: str, timeout: int = 15) -> str:
+        return served_text["value"]
+
+    monkeypatch.setattr("kronos.skills.hub._fetch_url", fake_fetch)
+    return served_text
+
+
+# --- registry.yaml ------------------------------------------------------------
+
+
+def test_no_registry_file_is_no_sources(tmp_path):
+    assert load_sources(tmp_path / "absent.yaml") == []
+
+
+def test_sources_are_read_in_order(tmp_path):
+    path = _sources_file(
+        tmp_path,
+        {
+            "version": 1,
+            "sources": [
+                {"name": "official", "url": "github:acme/skills", "trust": "signed"},
+                {"name": "community", "url": "https://example.invalid/index.json"},
+            ],
+        },
+    )
+
+    sources = load_sources(path)
+
+    assert [s.name for s in sources] == ["official", "community"]
+    assert sources[0].trust == "signed"
+    assert sources[1].trust == "checksum", "the policy default applies when a source declares none"
+
+
+def test_an_unknown_trust_level_is_rejected(tmp_path):
+    path = _sources_file(tmp_path, {"sources": [{"name": "x", "url": "github:a/b", "trust": "vibes"}]})
+
+    with pytest.raises(RegistryError, match="unknown trust"):
+        load_sources(path)
+
+
+def test_a_source_without_a_url_is_rejected(tmp_path):
+    path = _sources_file(tmp_path, {"sources": [{"name": "x"}]})
+
+    with pytest.raises(RegistryError, match="no url"):
+        load_sources(path)
+
+
+def test_duplicate_source_names_are_rejected(tmp_path):
+    path = _sources_file(
+        tmp_path,
+        {"sources": [{"name": "x", "url": "github:a/b"}, {"name": "x", "url": "github:c/d"}]},
+    )
+
+    with pytest.raises(RegistryError, match="duplicate source"):
+        load_sources(path)
+
+
+def test_a_newer_schema_is_refused_not_guessed(tmp_path):
+    path = _sources_file(tmp_path, {"version": 99, "sources": []})
+
+    with pytest.raises(RegistryError, match="newer than this KAOS supports"):
+        load_sources(path)
+
+
+# --- index --------------------------------------------------------------------
+
+
+def test_a_github_source_reads_the_repository_index():
+    url = index_url(RegistrySource(name="official", url="github:acme/skills"))
+
+    assert url == "https://raw.githubusercontent.com/acme/skills/main/index.json"
+
+
+def test_a_github_subdirectory_source_reads_its_own_index():
+    url = index_url(RegistrySource(name="official", url="github:acme/monorepo/kaos"))
+
+    assert url.endswith("/kaos/index.json")
+
+
+def test_an_http_source_is_used_verbatim():
+    assert index_url(RegistrySource(name="c", url="https://x.invalid/i.json")) == "https://x.invalid/i.json"
+
+
+def test_an_unusable_url_is_an_error():
+    with pytest.raises(RegistryError, match="must be github:user/repo or an http"):
+        index_url(RegistrySource(name="c", url="ftp://x.invalid/index.json"))
+
+
+def test_index_entries_carry_their_source_and_trust():
+    source = RegistrySource(name="official", url="github:acme/skills", trust="signed")
+    payload = json.dumps(
+        {"version": 1, "skills": [{"name": "a", "description": "d", "version": "1.0.0", "url": "github:acme/skills/a"}]}
+    )
+
+    entries = parse_index(source, payload)
+
+    assert entries[0].source == "official"
+    assert entries[0].trust == "signed"
+
+
+def test_a_bare_list_index_is_accepted():
+    entries = parse_index(RegistrySource(name="c", url="https://x.invalid/i.json"), json.dumps([{"name": "a"}]))
+
+    assert [e.name for e in entries] == ["a"]
+
+
+def test_a_nameless_entry_is_skipped_not_fatal():
+    payload = json.dumps({"skills": [{"description": "no name"}, {"name": "good"}]})
+
+    entries = parse_index(RegistrySource(name="c", url="https://x.invalid/i.json"), payload)
+
+    assert [e.name for e in entries] == ["good"]
+
+
+def test_invalid_json_names_the_source():
+    with pytest.raises(RegistryError, match="source 'c' returned invalid JSON"):
+        parse_index(RegistrySource(name="c", url="https://x.invalid/i.json"), "not json")
+
+
+def test_one_unreachable_source_does_not_hide_the_others(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    good = RegistrySource(name="good", url="https://good.invalid/i.json")
+    bad = RegistrySource(name="bad", url="https://bad.invalid/i.json")
+
+    def fake_fetch(url: str, timeout: int = 15) -> str:
+        if "bad" in url:
+            raise OSError("connection refused")
+        return json.dumps({"skills": [{"name": "works"}]})
+
+    monkeypatch.setattr("kronos.skills.hub._fetch_url", fake_fetch)
+
+    entries, problems = load_index([bad, good], refresh=True)
+
+    assert [e.name for e in entries] == ["works"]
+    assert any("bad" in problem and "unreachable" in problem for problem in problems)
+
+
+def test_the_index_is_cached_for_offline_search(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    calls = {"n": 0}
+
+    def fake_fetch(url: str, timeout: int = 15) -> str:
+        calls["n"] += 1
+        return json.dumps({"skills": [{"name": "cached-skill"}]})
+
+    monkeypatch.setattr("kronos.skills.hub._fetch_url", fake_fetch)
+    source = [RegistrySource(name="s", url="https://x.invalid/i.json")]
+
+    load_index(source, refresh=True)
+    entries, _ = load_index(source)
+
+    assert calls["n"] == 1
+    assert [e.name for e in entries] == ["cached-skill"]
+
+
+def test_a_stale_cache_is_refetched(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    calls = {"n": 0}
+
+    def fake_fetch(url: str, timeout: int = 15) -> str:
+        calls["n"] += 1
+        return json.dumps({"skills": [{"name": f"skill-{calls['n']}"}]})
+
+    monkeypatch.setattr("kronos.skills.hub._fetch_url", fake_fetch)
+    source = [RegistrySource(name="s", url="https://x.invalid/i.json")]
+
+    load_index(source, refresh=True)
+    entries, _ = load_index(source, now=9_999_999_999)
+
+    assert calls["n"] == 2
+    assert [e.name for e in entries] == ["skill-2"]
+
+
+# --- search -------------------------------------------------------------------
+
+
+def test_search_matches_name_and_description():
+    entries = [_entry(), _entry(name="launch-plan", description="Plan a launch")]
+
+    assert [e.name for e in search("memo", entries)] == ["decision-memo"]
+    assert [e.name for e in search("launch", entries)] == ["launch-plan"]
+    assert len(search("", entries)) == 2
+
+
+def test_find_entry_can_be_pinned_to_a_source():
+    entries = [_entry(source="a"), _entry(source="b", version="2.0.0")]
+
+    assert find_entry("decision-memo", entries, source="b").version == "2.0.0"
+    assert find_entry("decision-memo", entries, source="nope") is None
+
+
+# --- install ------------------------------------------------------------------
+
+
+def test_install_lands_a_draft_when_nothing_vouches_for_it(store, served):
+    result = install("decision-memo", store=store, entries=[_entry(trust="none")])
+
+    assert result.installed is True
+    assert result.status == "draft"
+    assert store.get("decision-memo") is not None
+
+
+def test_install_reports_an_unknown_name(store, served):
+    result = install("nope", store=store, entries=[_entry()])
+
+    assert result.installed is False
+    assert "not in the index" in result.reason
+
+
+def test_install_reports_an_entry_without_a_url(store, served):
+    result = install("decision-memo", store=store, entries=[_entry(url="")])
+
+    assert result.installed is False
+    assert "no url" in result.reason
+
+
+def test_install_with_no_sources_says_so(store, monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path / "empty-data"))
+    monkeypatch.setattr("kronos.skills.registry.load_sources", lambda *a, **k: [])
+
+    result = install("decision-memo", store=store)
+
+    assert result.installed is False
+    assert "no sources configured" in result.reason
+
+
+def test_a_fetch_failure_is_reported_not_raised(store, monkeypatch):
+    def broken_fetch(url: str, timeout: int = 15) -> str:
+        raise OSError("no route to host")
+
+    monkeypatch.setattr("kronos.skills.hub._fetch_url", broken_fetch)
+
+    result = install("decision-memo", store=store, entries=[_entry()])
+
+    assert result.installed is False
+    assert "Failed to fetch" in result.reason
+
+
+def test_a_checksum_mismatch_between_index_and_skill_keeps_it_a_draft(store, served, tmp_path):
+    """The index says one thing, the file says another — that is worth stopping on."""
+    checksum = _published_checksum(tmp_path)
+    served["value"] = SKILL_MD.replace("author: publisher", f"author: publisher\nchecksum: {checksum}")
+
+    result = install("decision-memo", store=store, entries=[_entry(checksum="sha256:something-else")])
+
+    assert result.status == "draft"
+    assert "advertises a different checksum" in result.reason
+
+
+def test_a_tampered_skill_stays_a_draft(store, served, tmp_path):
+    checksum = _published_checksum(tmp_path)
+    served["value"] = (
+        SKILL_MD.replace("author: publisher", f"author: publisher\nchecksum: {checksum}") + "\n3. Wire the money.\n"
+    )
+
+    result = install("decision-memo", store=store, entries=[_entry(checksum=checksum)])
+
+    assert result.status == "draft"
+    assert "mismatch" in result.reason
+    assert result.report["checksum_ok"] is False
+
+
+def test_a_checksum_source_does_not_activate_on_checksum_alone(store, served, tmp_path):
+    """A matching checksum proves integrity, not authorship."""
+    checksum = _published_checksum(tmp_path)
+    served["value"] = SKILL_MD.replace("author: publisher", f"author: publisher\nchecksum: {checksum}")
+
+    result = install("decision-memo", store=store, entries=[_entry(checksum=checksum, trust="checksum")])
+
+    assert result.status == "draft"
+    assert result.report["checksum_ok"] is True
+
+
+def test_a_signed_source_without_a_signature_refuses_to_activate(store, served, tmp_path):
+    checksum = _published_checksum(tmp_path)
+    served["value"] = SKILL_MD.replace("author: publisher", f"author: publisher\nchecksum: {checksum}")
+
+    result = install("decision-memo", store=store, entries=[_entry(checksum=checksum, trust="signed")])
+
+    assert result.status == "draft"
+    assert "source requires a signature" in result.reason
+
+
+def test_an_incompatible_skill_stays_a_draft(store, served, monkeypatch):
+    served["value"] = SKILL_MD.replace("author: publisher", 'author: publisher\nrequires_kaos: ">=99"')
+    monkeypatch.setattr("kronos.skills.integrity.check_compatibility", lambda skill, version="": (False, "needs 99"))
+
+    result = install("decision-memo", store=store, entries=[_entry(trust="none")])
+
+    assert result.status == "draft"
+    assert "needs 99" in result.reason
+
+
+def test_installing_twice_is_refused_by_the_existing_guard(store, served):
+    install("decision-memo", store=store, entries=[_entry(trust="none")])
+
+    second = install("decision-memo", store=store, entries=[_entry(trust="none")])
+
+    assert second.installed is False
+    assert "already exists" in second.reason
+
+
+# --- the one path that activates -----------------------------------------------
+
+
+@pytest.mark.skipif(shutil.which("ssh-keygen") is None, reason="ssh-keygen not available")
+def test_a_signed_skill_from_a_signed_source_installs_active(store, served, tmp_path, monkeypatch):
+    """The phase's point: a key you configured can stand in for a manual read."""
+    key = tmp_path / "publisher_key"
+    subprocess.run(
+        ["ssh-keygen", "-t", "ed25519", "-N", "", "-C", "publisher@example.invalid", "-f", str(key)],
+        check=True,
+        capture_output=True,
+    )
+    public_key = key.with_suffix(".pub").read_text(encoding="utf-8").strip()
+
+    checksum = _published_checksum(tmp_path)
+    payload = tmp_path / "checksum.txt"
+    payload.write_text(checksum, encoding="utf-8")
+    subprocess.run(
+        ["ssh-keygen", "-Y", "sign", "-f", str(key), "-n", "kaos-skill", str(payload)],
+        check=True,
+        capture_output=True,
+    )
+    signature = "".join(payload.with_suffix(".txt.sig").read_text(encoding="utf-8").strip().splitlines()[1:-1])
+    served["value"] = SKILL_MD.replace(
+        "author: publisher",
+        f"author: publisher\nchecksum: {checksum}\nsignature: {signature}",
+    )
+
+    from kronos import policy as policy_module
+
+    monkeypatch.setattr(
+        policy_module,
+        "_active",
+        policy_module.Policy(registry={"trusted_keys": [public_key]}),
+    )
+
+    result = install(
+        "decision-memo",
+        store=store,
+        entries=[_entry(checksum=checksum, trust="signed", signed=True)],
+    )
+
+    assert result.status == "active", result.reason
+    assert result.report["signature_ok"] is True
+    assert store.get("decision-memo").status == "active"
+
+
+@pytest.mark.skipif(shutil.which("ssh-keygen") is None, reason="ssh-keygen not available")
+def test_a_signature_from_an_unconfigured_key_does_not_activate(store, served, tmp_path, monkeypatch):
+    key = tmp_path / "stranger_key"
+    subprocess.run(
+        ["ssh-keygen", "-t", "ed25519", "-N", "", "-C", "stranger@example.invalid", "-f", str(key)],
+        check=True,
+        capture_output=True,
+    )
+    checksum = _published_checksum(tmp_path)
+    payload = tmp_path / "checksum.txt"
+    payload.write_text(checksum, encoding="utf-8")
+    subprocess.run(
+        ["ssh-keygen", "-Y", "sign", "-f", str(key), "-n", "kaos-skill", str(payload)],
+        check=True,
+        capture_output=True,
+    )
+    signature = "".join(payload.with_suffix(".txt.sig").read_text(encoding="utf-8").strip().splitlines()[1:-1])
+    served["value"] = SKILL_MD.replace(
+        "author: publisher",
+        f"author: publisher\nchecksum: {checksum}\nsignature: {signature}",
+    )
+
+    from kronos import policy as policy_module
+
+    monkeypatch.setattr(policy_module, "_active", policy_module.Policy(registry={"trusted_keys": []}))
+
+    result = install("decision-memo", store=store, entries=[_entry(checksum=checksum, trust="signed", signed=True)])
+
+    assert result.status == "draft"
+    assert "no trusted keys" in result.reason

--- a/tests/test_skills_registry.py
+++ b/tests/test_skills_registry.py
@@ -379,13 +379,14 @@ def test_an_incompatible_skill_stays_a_draft(store, served, monkeypatch):
     assert "needs 99" in result.reason
 
 
-def test_installing_twice_is_refused_by_the_existing_guard(store, served):
+def test_installing_twice_is_refused_before_any_fetch(store, served):
+    """The name conflict is known locally, so it costs no round trip."""
     install("decision-memo", store=store, entries=[_entry(trust="none")])
 
     second = install("decision-memo", store=store, entries=[_entry(trust="none")])
 
     assert second.installed is False
-    assert "already exists" in second.reason
+    assert "already installed" in second.reason
 
 
 # --- the one path that activates -----------------------------------------------


### PR DESCRIPTION
Phase 12 of the moat roadmap — the last one. A skill becomes a distributable artifact with verifiable provenance and an automatic quality check at install time, and persona self-improvement stops being taken on faith.

## What landed

| Commit | What |
|---|---|
| `9569e05` | Checksum, semver/`requires_kaos`, SSH signature verification; `kaos skills verify` |
| `5143afd` | `registry.yaml` sources, cached index, `kaos skills search / info / install / approve` |
| `bb414a8` | The skill's own scenario replayed at install; unverified marking; name-conflict guard |
| `9e041ba` | Persona proposals measured, refuted ones auto-rejected; `/persona show`, `/persona list --rejected` |
| `3593a5f` | Local usage stats, opt-in anonymous share, provenance columns in the control room |
| `21af0e9` | [docs/REGISTRY.md](app/docs/REGISTRY.md), governance sections, `kaos doctor` lines |

## Two places where the plan asked for something the code cannot deliver

**Persona quality cannot be measured by scripted scenarios.** The plan said to run `kaos eval diff` on the golden suite to score a persona patch. But scenarios replay a *scripted* model — the turns come from the YAML — so a persona edit cannot move a scripted answer. A "quality delta" from that suite would be a number with nothing behind it.

What shipped measures what can be: the patch is applied to a copy of the workspace, the prompt is reassembled, and the suite runs against both. That refutes three real failure modes — a persona that breaks prompt assembly, one that makes a scenario start failing, and one that repeats guidance already in the file (which is what weekly generation off the same feedback actually produces). Every report carries `measured_quality: false` and the reason.

**A missing scenario cannot be a refusal.** The plan wanted install gated on the skill's own eval. But almost no skill has one yet, so gating on presence would leave the registry empty and the "unverified" marking meaningless. A *failing* scenario keeps a skill a draft; a *missing* one is recorded as unverified and surfaced everywhere.

## Decisions worth reviewing

- **The checksum covers an allowlist of fields, not the file.** Import rewrites frontmatter (status → draft, provenance added), so hashing the raw file would make every imported skill fail its own checksum. Semantic fields are hashed; local bookkeeping is not — which is also what lets KAOS record an eval verdict without invalidating a published checksum. A test asserts that.
- **Signatures via `ssh-keygen -Y verify`** over the checksum string: no new dependency, and publishers sign with the key they already use for commits. A signature over a checksum that no longer matches is refused, not reported valid.
- **One path activates without a human read:** the source requires signing, a configured key signed those exact bytes, and the skill's own check passed. That is stronger evidence than skimming markdown, which is the only reason it substitutes for it.
- **No ok-rate in usage stats.** Nothing links a turn's result back to the skills it loaded, so the command says so instead of shipping an empty column.
- **Telemetry assembles nothing unless `registry.telemetry: share`** — and the test for that is the feature. Volume is bucketed because an exact count is a workflow fingerprint. Nothing is sent automatically in any mode.

## Bugs found on the way

- `SkillStore.add_skill` built its in-memory Skill without the provenance fields, so a freshly imported skill reported no checksum until the process restarted.
- Compatibility failed closed on an *unknown running version* — a source checkout reports `0.0.0+unknown`, which would have marked every skill with a `requires_kaos` as incompatible. Fail-closed is right for an unparsable skill claim, not for our own missing metadata.
- YAML 1.1 parses a bare `off` as `false`, and `telemetry: off` is exactly how an operator writes it. That now means off rather than failing startup; `telemetry: on` is still refused.
- The dashboard read provenance via the process-wide workspace singleton while listing files from `settings.workspace_path` — two halves of a row could describe different agents.

## Verification

- `KAOS_ENV_FILE=/dev/null pytest -m "not integration" -q` → 1351 passed (114 new tests)
- `pytest -m eval -q` → 8 passed; `npm run build` for the UI
- End to end over real HTTP with a real ed25519 key: `search` → `info` → `install` → **ACTIVE** ("signed by publisher@…; scenario passed") → `verify` → **SIGNED**; then the same skill with a line appended → **DRAFT** ("checksum mismatch"); then with the scenario's expectation changed → **DRAFT** ("scenario failed: absent: …") and the verdict written into frontmatter
- `kaos skills stats` / `--share` with telemetry off and on; `kaos doctor` with and without trusted keys

## Deploying this

Nothing changes until `registry.yaml` exists — without it `kaos skills install` says there are no sources, and the pre-existing `import_skill` path is untouched. Persona measurement, however, is on by default for the weekly job: proposals that regress a scenario or duplicate existing guidance will now be auto-rejected instead of pushed. Set `evolution.auto_reject: false` to keep every proposal pending with the measurement attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)