### PR TITLE
Close two known debts: exact exchange ceiling, skill references on install

### DIFF
--- a/docs/REGISTRY.md
+++ b/docs/REGISTRY.md
@@ -146,7 +146,8 @@ repository root; `github:user/repo/subdir` reads that subdirectory):
       "author": "you@example.com",
       "requires_kaos": ">=0.2",
       "checksum": "sha256:…",
-      "signed": true
+      "signed": true,
+      "references": ["template", "checklist"]
     }
   ]
 }
@@ -154,6 +155,13 @@ repository root; `github:user/repo/subdir` reads that subdirectory):
 
 An entry advertising a different checksum than the skill declares keeps the skill a
 draft — two sources of truth disagreeing is worth stopping on.
+
+**`references` is not optional if your skill has any.** Raw HTTP offers no
+directory listing, so the installer fetches exactly the names you declare from
+`<skill>/references/<name>.md` and nothing else. Leave them out and the skill
+installs with dangling pointers *and* fails its own checksum, because the checksum
+covers reference files. A name containing a path separator is refused rather than
+fetched — the index is remote input.
 
 ## Trust levels
 

--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -1143,11 +1143,19 @@ async def run_bridge(agent: KronosAgent) -> None:
                 )
 
                 # Resolve root user message id for claim bookkeeping. For
-                # user-triggered messages, root = the user's message itself.
-                # For peer reactions (Tier 3) we look up the reply parent.
-                reply_to = getattr(event.message, "reply_to", None)
-                parent_msg_id = getattr(reply_to, "reply_to_msg_id", None) if reply_to else None
-                root_msg_id = parent_msg_id if decision.tier == 3 and parent_msg_id else event.message.id
+                # user-triggered messages, root = the user's message itself. For
+                # anything a peer sent, walk the reply chain in the ledger to the
+                # user message it descends from — otherwise every hop of an
+                # agent↔agent exchange is its own root and no per-root budget
+                # can bind.
+                if _group_router._is_peer(user_id):
+                    root_msg_id = swarm.resolve_user_root(
+                        chat_id=event.chat_id,
+                        topic_id=topic_id_inbound,
+                        msg_id=event.message.id,
+                    )
+                else:
+                    root_msg_id = event.message.id
 
                 eta_ts = time.time() + max(decision.delay, 0.0)
                 swarm.claim_reply(

--- a/kronos/group_router.py
+++ b/kronos/group_router.py
@@ -54,10 +54,19 @@ PEER_REACTION_COOLDOWN = 300  # 5 minutes
 # itself a reply to them — which is how two agents ping-pong forever. Every
 # other loop guard is bypassed at Tier 1 by design, because Tier 1 exists so the
 # *user's* explicit address is always honoured; a peer's does not earn that.
-# Bounded per window instead: a real exchange gets a couple of turns, a loop
-# cannot outlive the window.
+#
+# Two bounds, and they are not redundant:
+#
+#   * MAX_AGENT_REPLIES_PER_ROOT is the exact one — a ceiling on everything the
+#     swarm says about one user message, counted in the shared ledger, so it
+#     binds across agents and across process restarts. A normal exchange is
+#     1-3 replies; a loop hits the ceiling and stops.
+#   * MAX_PEER_EXCHANGES per window is the fallback. Ledger reads fail open
+#     (a locked database must not mute an agent), so without a local bound a
+#     ledger outage would restore the unbounded loop.
 PEER_EXCHANGE_WINDOW = 600  # 10 minutes
 MAX_PEER_EXCHANGES = 2
+MAX_AGENT_REPLIES_PER_ROOT = 6
 
 # Topic classification is agent-independent and messages repeat (edits, retries),
 # so the lite-tier answer is cached per process for five minutes.
@@ -137,11 +146,25 @@ class EventFacts:
     text: str = ""
     sender_id: int = 0
     msg_id: int = 0
+    # Where the message lives, so the router can ask the ledger about the
+    # exchange this message belongs to.
+    chat_id: int = 0
+    topic_id: int = 0
     is_reply: bool = False
     reply_sender_id: int | None = None
     mentioned_usernames: set[str] = field(default_factory=set)
     mentioned_user_ids: set[int] = field(default_factory=set)
     topic_label: str = ""
+
+
+def _topic_id_of(event) -> int:
+    """Forum topic id, or 0. Same extraction the transport uses for the ledger."""
+    try:
+        from kronos.bridge_topics import _extract_topic_id_from_message
+
+        return int(_extract_topic_id_from_message(getattr(event, "message", None), is_private=False) or 0)
+    except Exception:
+        return 0
 
 
 async def event_facts(event) -> EventFacts:
@@ -153,6 +176,8 @@ async def event_facts(event) -> EventFacts:
         text=event.raw_text or "",
         sender_id=getattr(event, "sender_id", 0) or 0,
         msg_id=getattr(getattr(event, "message", None), "id", 0) or 0,
+        chat_id=int(getattr(event, "chat_id", 0) or 0),
+        topic_id=_topic_id_of(event),
         is_reply=bool(getattr(event, "is_reply", False)),
         topic_label=str(getattr(event, "topic_label", "") or ""),
     )
@@ -195,7 +220,12 @@ class GroupRouter:
         my_id: int,
         my_username: str | None,
         allowed_user_ids: set[int],
+        swarm=None,
     ):
+        # Explicit ledger beats the process singleton: the local bus and tests
+        # hold their own store, and a router silently reading a different
+        # database would report an empty exchange and never reach its ceiling.
+        self._swarm = swarm
         self.agent_name = agent_name
         self.my_id = my_id
         self.my_username = (my_username or "").lower().lstrip("@")
@@ -287,14 +317,9 @@ class GroupRouter:
             # forever: my answer is a reply to them, which reads as an address
             # back to me on their side.
             if addressing.explicit_to_me:
-                if not self._peer_exchange_allowed():
-                    return RoutingDecision(
-                        False,
-                        0,
-                        0,
-                        f"peer exchange budget spent ({MAX_PEER_EXCHANGES} per {PEER_EXCHANGE_WINDOW}s)",
-                        addressing=addressing,
-                    )
+                exhausted = self._exchange_budget_spent(facts)
+                if exhausted:
+                    return RoutingDecision(False, 0, 0, exhausted, addressing=addressing)
                 self._peer_exchanges.append(time.monotonic())
                 return RoutingDecision(
                     True,
@@ -440,6 +465,45 @@ class GroupRouter:
         cutoff = time.monotonic() - PEER_EXCHANGE_WINDOW
         self._peer_exchanges = [ts for ts in self._peer_exchanges if ts > cutoff]
         return len(self._peer_exchanges) < MAX_PEER_EXCHANGES
+
+    def _exchange_budget_spent(self, facts: "EventFacts") -> str:
+        """Why this peer exchange must stop, or "" while it may continue.
+
+        The ledger answer is the real one: it counts what the whole swarm said
+        about the user message this chain descends from, so it binds across
+        agents and survives a restart. The per-process window is checked too,
+        because the ledger read fails open and something has to hold if it does.
+        """
+        replies = self._replies_to_root(facts)
+        if replies >= MAX_AGENT_REPLIES_PER_ROOT:
+            return f"exchange ceiling reached ({replies} agent replies to this user message)"
+        if not self._peer_exchange_allowed():
+            return f"peer exchange budget spent ({MAX_PEER_EXCHANGES} per {PEER_EXCHANGE_WINDOW}s)"
+        return ""
+
+    def _replies_to_root(self, facts: "EventFacts") -> int:
+        """How much the swarm has already said about this exchange's user root."""
+        if not facts.chat_id:
+            return 0
+        try:
+            from kronos.swarm_store import get_swarm
+
+            swarm = self._swarm or get_swarm()
+            root = swarm.resolve_user_root(
+                chat_id=facts.chat_id,
+                topic_id=facts.topic_id,
+                msg_id=facts.msg_id,
+            )
+            return swarm.count_replies_to_root(
+                chat_id=facts.chat_id,
+                topic_id=facts.topic_id,
+                root_msg_id=root,
+            )
+        except Exception as e:
+            # Fail open: an unreadable ledger must not mute an agent. The window
+            # bound above is what keeps a loop finite while this is broken.
+            log.debug("[GroupRouter] Could not measure the exchange: %s", e)
+            return 0
 
     def _quiet_reason(self) -> str:
         """Non-empty when this agent has spent its personal daily budget."""

--- a/kronos/skills/registry.py
+++ b/kronos/skills/registry.py
@@ -79,6 +79,10 @@ class RegistryEntry:
     trust: str = "checksum"
     # Optional override; by default the scenario is a sibling of SKILL.md.
     scenario_url: str = ""
+    # Reference files that belong to the skill. Declared, not discovered: raw
+    # HTTP has no directory listing, and guessing would mean either missing files
+    # or probing a publisher's host.
+    references: list[str] = field(default_factory=list)
 
     def matches(self, query: str) -> bool:
         needle = query.strip().lower()
@@ -214,6 +218,7 @@ def parse_index(source: RegistrySource, payload: str) -> list[RegistryEntry]:
                 checksum=str(item.get("checksum", "")).strip(),
                 signed=bool(item.get("signed", False)),
                 scenario_url=str(item.get("scenario_url", "")).strip(),
+                references=[str(name).strip() for name in (item.get("references") or []) if str(name).strip()],
                 source=source.name,
                 trust=source.trust,
             )
@@ -345,8 +350,79 @@ def install(
     if "imported successfully" not in message:
         return InstallResult(skill=name, installed=False, reason=message)
 
+    # Before verification, not after: the checksum covers reference files, so a
+    # skill whose references were still missing would fail its own checksum.
+    reference_problems = fetch_references(entry, store=store)
+
     outcome = evaluate_installed(entry, store=store) if run_eval else None
-    return finish_install(entry, store=store, allow_activate=allow_activate, outcome=outcome)
+    return finish_install(
+        entry,
+        store=store,
+        allow_activate=allow_activate,
+        outcome=outcome,
+        problems=reference_problems,
+    )
+
+
+def _reference_filename(name: str) -> str:
+    """A safe file name under `references/`, or "" if the index is hostile.
+
+    An index is remote input: a name with a separator or `..` would write
+    wherever it liked. Only a plain `*.md` basename is accepted.
+    """
+    cleaned = name.strip()
+    if not cleaned or "/" in cleaned or "\\" in cleaned or cleaned.startswith("."):
+        return ""
+    if Path(cleaned).name != cleaned:
+        return ""
+    if not cleaned.endswith(".md"):
+        cleaned = f"{cleaned}.md"
+    return cleaned
+
+
+def fetch_references(entry: RegistryEntry, *, store: SkillStore) -> list[str]:
+    """Fetch the skill's reference files. Returns one message per problem.
+
+    Not cosmetic: a SKILL.md that points at `references/checklist.md` is broken
+    without it, and — because the checksum covers reference files — a published
+    skill with references could never verify after install while they were left
+    behind.
+    """
+    if not entry.references:
+        return []
+
+    skill = store.get(entry.name)
+    if skill is None:  # pragma: no cover - import reported success
+        return ["skill vanished before its references could be fetched"]
+
+    base = entry.url.removesuffix("/SKILL.md").rstrip("/")
+    refs_dir = skill.path.parent / "references"
+    problems: list[str] = []
+
+    from kronos.skills.hub import _fetch_url, _resolve_source
+
+    for raw_name in entry.references:
+        filename = _reference_filename(raw_name)
+        if not filename:
+            problems.append(f"refused unsafe reference name '{raw_name}'")
+            continue
+
+        source = f"{base}/references/{filename}"
+        resolved = _resolve_source(source) if source.startswith("github:") else source
+        try:
+            payload = _fetch_url(resolved)
+        except Exception as e:
+            problems.append(f"reference '{filename}' could not be fetched: {e}")
+            continue
+
+        refs_dir.mkdir(parents=True, exist_ok=True)
+        target = refs_dir / filename
+        target.write_text(payload, encoding="utf-8")
+        # Register it on the loaded skill too, so `load_skill_reference` works
+        # without waiting for a restart.
+        skill.references[target.stem] = target
+
+    return problems
 
 
 def evaluate_installed(entry: RegistryEntry, *, store: SkillStore):
@@ -386,6 +462,7 @@ def finish_install(
     store: SkillStore,
     allow_activate: bool = True,
     outcome=None,
+    problems: list[str] | None = None,
 ) -> InstallResult:
     """Verify a freshly imported skill and set its status accordingly."""
     from kronos.skills.autoeval import EVAL_ERROR, EVAL_FAILED, EVAL_MISSING
@@ -399,7 +476,9 @@ def finish_install(
     report["source"] = entry.source
     report["trust"] = entry.trust
 
-    reasons: list[str] = []
+    # A skill missing part of itself is not ready to activate, whatever else
+    # checks out.
+    reasons: list[str] = list(problems or [])
     if entry.checksum and skill.checksum and entry.checksum.strip() != skill.checksum.strip():
         reasons.append("the index advertises a different checksum than the skill declares")
     if not report["compatible"]:

--- a/kronos/swarm_local.py
+++ b/kronos/swarm_local.py
@@ -104,6 +104,7 @@ class LocalSwarmBus:
             my_id=sender_id,
             my_username=username or f"{name}agnt",
             allowed_user_ids={USER_ID},
+            swarm=self.store,
         )
         agent = LocalAgent(
             name=name,
@@ -147,6 +148,8 @@ class LocalSwarmBus:
             text=text,
             sender_id=sender_id,
             msg_id=msg_id,
+            chat_id=self.chat_id,
+            topic_id=self.topic_id,
             is_reply=reply_to is not None,
             reply_sender_id=self._sender_of(reply_to),
             topic_label=topic_label,
@@ -259,8 +262,12 @@ class LocalSwarmBus:
         return None
 
     def _root_msg_id(self, facts: EventFacts, tier: int) -> int:
-        """Tier 3 claims attach to the user message the peer replied to."""
-        if tier == 3:
+        """Anything a peer sent attaches to the user message it descends from.
+
+        Same rule as the bridge: without it every hop of an agent↔agent exchange
+        is its own root and the per-root ceiling never binds.
+        """
+        if facts.sender_id != USER_ID:
             return self._root_of.get(facts.msg_id, facts.msg_id)
         return facts.msg_id
 

--- a/kronos/swarm_store.py
+++ b/kronos/swarm_store.py
@@ -693,6 +693,60 @@ class SwarmStore:
             (reason, chat_id, topic_id or 0, trigger_msg_id, agent_name),
         )
 
+    def resolve_user_root(
+        self,
+        *,
+        chat_id: int,
+        topic_id: int | None,
+        msg_id: int,
+        max_hops: int = 8,
+    ) -> int:
+        """Walk reply links up to the user message that started this exchange.
+
+        Every agent reply is recorded with the message it answered, so an
+        agent↔agent chain leads back to a user message in a few hops. Without
+        this, each hop of a peer exchange looks like its own root and any
+        per-root budget silently never binds.
+
+        Falls back to the message itself: an unknown or unlinked message is its
+        own root, which is the conservative reading.
+        """
+        current = msg_id
+        for _ in range(max_hops):
+            row = self._db.read_one(
+                """
+                SELECT sender_type, reply_to_msg_id FROM swarm_messages
+                WHERE chat_id = ? AND topic_id = ? AND msg_id = ?
+                """,
+                (chat_id, topic_id or 0, current),
+            )
+            if row is None or row["sender_type"] == "user" or not row["reply_to_msg_id"]:
+                return current
+            current = int(row["reply_to_msg_id"])
+        return current
+
+    def count_replies_to_root(
+        self,
+        *,
+        chat_id: int,
+        topic_id: int | None,
+        root_msg_id: int,
+    ) -> int:
+        """Everything the swarm has said about one user message, any tier.
+
+        Unlike the implicit cap in ``can_send_claim`` this counts tier 1 too —
+        it is a ceiling on the whole exchange, not on volunteering.
+        """
+        row = self._db.read_one(
+            """
+            SELECT COUNT(*) AS c FROM reply_claims
+            WHERE chat_id = ? AND topic_id = ? AND root_msg_id = ?
+              AND state IN ('executing', 'sent')
+            """,
+            (chat_id, topic_id or 0, root_msg_id),
+        )
+        return int(row["c"]) if row else 0
+
     def count_sent_replies(
         self,
         *,

--- a/registry.example.yaml
+++ b/registry.example.yaml
@@ -14,7 +14,8 @@
 #         "author": "acme",
 #         "requires_kaos": ">=0.2",
 #         "checksum": "sha256:…",
-#         "signed": true
+#         "signed": true,
+#         "references": ["template", "checklist"]
 #       }
 #     ]
 #   }

--- a/tests/test_skills_registry.py
+++ b/tests/test_skills_registry.py
@@ -466,3 +466,93 @@ def test_a_signature_from_an_unconfigured_key_does_not_activate(store, served, t
 
     assert result.status == "draft"
     assert "no trusted keys" in result.reason
+
+
+# --- reference files (phase 12 follow-up) --------------------------------------
+
+REFERENCE_MD = "# Memo template\n\n- Decision:\n- Alternatives:\n"
+
+
+@pytest.fixture
+def served_with_reference(monkeypatch):
+    """Serve SKILL.md and one reference, addressed by URL."""
+    payloads = {
+        "https://example.invalid/decision-memo/SKILL.md": SKILL_MD,
+        "https://example.invalid/decision-memo/references/template.md": REFERENCE_MD,
+    }
+    requested: list[str] = []
+
+    def fake_fetch(url: str, timeout: int = 15) -> str:
+        requested.append(url)
+        if url in payloads:
+            return payloads[url]
+        raise OSError("HTTP Error 404: Not Found")
+
+    monkeypatch.setattr("kronos.skills.hub._fetch_url", fake_fetch)
+    return payloads, requested
+
+
+def test_declared_references_are_installed(store, served_with_reference):
+    _, requested = served_with_reference
+
+    result = install("decision-memo", store=store, entries=[_entry(trust="none", references=["template"])])
+
+    assert result.installed is True
+    reference = store.get("decision-memo").path.parent / "references" / "template.md"
+    assert reference.is_file()
+    assert "Memo template" in reference.read_text(encoding="utf-8")
+    assert "references/template.md" in " ".join(requested)
+
+
+def test_a_reference_is_usable_without_a_restart(store, served_with_reference):
+    """load_skill_reference reads the loaded skill, not the directory."""
+    install("decision-memo", store=store, entries=[_entry(trust="none", references=["template"])])
+
+    assert "Memo template" in store.get_reference("decision-memo", "template")
+
+
+def test_a_skill_with_references_can_verify_its_checksum(store, served_with_reference, tmp_path):
+    """The checksum covers reference files, so leaving them behind broke it."""
+    published = tmp_path / "published" / "decision-memo"
+    (published / "references").mkdir(parents=True)
+    (published / "SKILL.md").write_text(SKILL_MD, encoding="utf-8")
+    (published / "references" / "template.md").write_text(REFERENCE_MD, encoding="utf-8")
+    checksum = compute_checksum(published)
+
+    payloads, _ = served_with_reference
+    payloads["https://example.invalid/decision-memo/SKILL.md"] = SKILL_MD.replace(
+        "author: publisher", f"author: publisher\nchecksum: {checksum}"
+    )
+
+    result = install(
+        "decision-memo",
+        store=store,
+        entries=[_entry(checksum=checksum, trust="checksum", references=["template"])],
+    )
+
+    assert result.report["checksum_ok"] is True, result.reason
+
+
+def test_a_missing_reference_is_reported_and_blocks_activation(store, served_with_reference):
+    result = install("decision-memo", store=store, entries=[_entry(trust="none", references=["absent"])])
+
+    assert result.installed is True
+    assert result.status == "draft"
+    assert "reference 'absent.md' could not be fetched" in result.reason
+
+
+@pytest.mark.parametrize("hostile", ["../../etc/passwd", "sub/dir.md", "..", ".hidden"])
+def test_a_hostile_reference_name_is_refused(store, served_with_reference, hostile):
+    """The index is remote input; a name with a separator would write anywhere."""
+    result = install("decision-memo", store=store, entries=[_entry(trust="none", references=[hostile])])
+
+    assert f"refused unsafe reference name '{hostile}'" in result.reason
+    assert not (store.get("decision-memo").path.parent.parent / "passwd").exists()
+
+
+def test_a_skill_without_references_fetches_nothing_extra(store, served_with_reference):
+    _, requested = served_with_reference
+
+    install("decision-memo", store=store, entries=[_entry(trust="none")])
+
+    assert not any("references/" in url for url in requested)

--- a/tests/test_swarm_local.py
+++ b/tests/test_swarm_local.py
@@ -204,6 +204,65 @@ async def test_a_peer_chain_does_not_start_new_reactions(bus):
 
 
 @pytest.mark.asyncio
+async def test_a_peer_ping_pong_stops_at_the_root_ceiling(bus):
+    """The exact bound: everything said about one user message is counted.
+
+    The per-window bound alone let a slow loop resume every ten minutes. The
+    ledger ceiling is absolute per user message, so the exchange ends and stays
+    ended until the user says something new.
+    """
+    from kronos.group_router import MAX_AGENT_REPLIES_PER_ROOT
+
+    bus.add_agent("nexus", relevance=_keen, react=lambda agent, text: True)
+    bus.add_agent("kronos", relevance=lambda agent, text: 1, react=lambda agent, text: True)
+
+    facts = (await bus.user_says("что с метриками?"))[0]["reply_facts"]
+    for _ in range(20):
+        sent = await bus.run_round(facts)
+        if not sent:
+            break
+        facts = sent[0]["reply_facts"]
+    else:
+        pytest.fail("the exchange never ended")
+
+    replies = bus.store.count_replies_to_root(chat_id=bus.chat_id, topic_id=bus.topic_id, root_msg_id=1001)
+    assert replies == MAX_AGENT_REPLIES_PER_ROOT
+    # And it stays ended: a further round adds nothing.
+    assert await bus.run_round(facts) == []
+
+
+@pytest.mark.asyncio
+async def test_every_hop_is_attributed_to_the_user_message(bus):
+    """Without this the ceiling cannot bind: each hop would be its own root."""
+    bus.add_agent("nexus", relevance=_keen, react=lambda agent, text: True)
+    bus.add_agent("kronos", relevance=lambda agent, text: 1, react=lambda agent, text: True)
+
+    first = await bus.user_says("что с метриками?")
+    reaction = await bus.run_round(first[0]["reply_facts"])
+    chain = await bus.run_round(reaction[0]["reply_facts"])
+
+    assert chain, "the exchange should still be within budget here"
+    # Three agent replies, one root: the user's message.
+    assert bus.store.count_replies_to_root(chat_id=bus.chat_id, topic_id=bus.topic_id, root_msg_id=1001) == 3
+
+
+@pytest.mark.asyncio
+async def test_a_new_user_message_gets_a_fresh_budget(bus):
+    """The ceiling bounds one exchange, it does not silence the swarm."""
+    bus.add_agent("nexus", relevance=_keen, react=lambda agent, text: True)
+    bus.add_agent("kronos", relevance=lambda agent, text: 1, react=lambda agent, text: True)
+
+    facts = (await bus.user_says("первый вопрос"))[0]["reply_facts"]
+    for _ in range(20):
+        sent = await bus.run_round(facts)
+        if not sent:
+            break
+        facts = sent[0]["reply_facts"]
+
+    assert await bus.user_says("второй вопрос"), "a new question must still be answered"
+
+
+@pytest.mark.asyncio
 async def test_a_peer_ping_pong_runs_out_of_budget(bus):
     """Found by this bus: Tier 1 bypasses every cap, so two agents looped forever.
 

--- a/tests/test_swarm_store.py
+++ b/tests/test_swarm_store.py
@@ -587,3 +587,86 @@ class TestSchemaMigration:
 
         _db._instances.clear()
         ss._singleton = None
+
+
+# --- exchange attribution (moat 11.5 follow-up) --------------------------------
+
+
+def test_resolve_user_root_walks_the_reply_chain(swarm):
+    """An agent↔agent chain leads back to the user message it descends from."""
+    swarm.record_inbound_message(
+        chat_id=-1,
+        topic_id=0,
+        msg_id=100,
+        reply_to_msg_id=None,
+        sender_id=42,
+        sender_type="user",
+        agent_name=None,
+        text="вопрос",
+    )
+    swarm.record_outbound_message(
+        chat_id=-1,
+        topic_id=0,
+        msg_id=101,
+        reply_to_msg_id=100,
+        agent_name="nexus",
+        text="ответ",
+    )
+    swarm.record_outbound_message(
+        chat_id=-1,
+        topic_id=0,
+        msg_id=102,
+        reply_to_msg_id=101,
+        agent_name="kronos",
+        text="возражение",
+    )
+
+    assert swarm.resolve_user_root(chat_id=-1, topic_id=0, msg_id=102) == 100
+    assert swarm.resolve_user_root(chat_id=-1, topic_id=0, msg_id=100) == 100
+
+
+def test_an_unknown_message_is_its_own_root(swarm):
+    """The conservative reading: nothing known, nothing to attribute it to."""
+    assert swarm.resolve_user_root(chat_id=-1, topic_id=0, msg_id=999) == 999
+
+
+def test_a_cycle_cannot_loop_forever(swarm):
+    """A malformed chain must terminate, not spin."""
+    swarm.record_outbound_message(chat_id=-1, topic_id=0, msg_id=1, reply_to_msg_id=2, agent_name="a", text="x")
+    swarm.record_outbound_message(chat_id=-1, topic_id=0, msg_id=2, reply_to_msg_id=1, agent_name="b", text="y")
+
+    assert swarm.resolve_user_root(chat_id=-1, topic_id=0, msg_id=1, max_hops=4) in (1, 2)
+
+
+def test_count_replies_to_root_counts_every_tier(swarm):
+    """Unlike the implicit cap, the exchange ceiling counts tier 1 as well."""
+    for msg_id, tier in ((10, 1), (11, 2), (12, 3)):
+        swarm.claim_reply(
+            chat_id=-1,
+            topic_id=0,
+            root_msg_id=100,
+            trigger_msg_id=msg_id,
+            agent_name=f"agent{msg_id}",
+            tier=tier,
+            eta_ts=0.0,
+        )
+        swarm.mark_sent(chat_id=-1, topic_id=0, trigger_msg_id=msg_id, agent_name=f"agent{msg_id}", reply_msg_id=None)
+
+    assert swarm.count_replies_to_root(chat_id=-1, topic_id=0, root_msg_id=100) == 3
+    assert swarm.count_replies_to_root(chat_id=-1, topic_id=0, root_msg_id=999) == 0
+
+
+def test_a_cancelled_claim_does_not_spend_the_exchange(swarm):
+    """Standing down must not count against the budget."""
+    swarm.claim_reply(
+        chat_id=-1,
+        topic_id=0,
+        root_msg_id=100,
+        trigger_msg_id=10,
+        agent_name="nexus",
+        tier=2,
+        eta_ts=0.0,
+    )
+    swarm.cancel_claim(chat_id=-1, topic_id=0, trigger_msg_id=10, agent_name="nexus")
+
+    assert swarm.count_replies_to_root(chat_id=-1, topic_id=0, root_msg_id=100) == 0


### PR DESCRIPTION
The two debts recorded when Phases 11 and 12 landed.

## 1. A peer exchange is now bounded exactly, not just per window

The window bound stopped the agent↔agent ping-pong from being *unbounded*. It did not stop it from resuming every ten minutes.

The reason no per-root budget could bind: peer-sourced claims used the peer's own message as their root, so every hop of an exchange looked like a fresh conversation to the ledger. `resolve_user_root` now walks the reply links in `swarm_messages` back to the user message the chain descends from (bounded hops, terminates on a malformed cycle), and both the bridge and the local bus claim peer replies against that root. `MAX_AGENT_REPLIES_PER_ROOT` then caps everything the swarm says about one user message — across agents, across restarts, until the user says something new.

Both bounds stay and they are not redundant: ledger reads fail open on purpose (a locked database must not mute an agent), so without the per-process window a ledger outage would restore the unbounded loop.

Measured on the bus: the loop that ran twelve hops and counting now ends after five, with exactly six agent replies attributed to the user's message; a new question gets a fresh budget.

`GroupRouter` takes an explicit `swarm` instead of reaching for the process singleton — the bus holds its own store, and a router silently reading a different database would report an empty exchange and never reach its ceiling. Same singleton trap that made `kaos demo --swarm` find no escalation earlier.

## 2. A skill's reference files are installed

`import_skill` fetches one file, so a skill published with `references/` arrived without them. The SKILL.md pointed at files that were not there — and, the part that matters more, **the skill could never verify**: the checksum covers reference files, so every published skill with references failed its own checksum on arrival.

The index declares them (`"references": ["template", "checklist"]`) and the installer fetches exactly those. Declared rather than discovered, because raw HTTP has no directory listing and guessing means either missing files or probing a publisher's host.

Order is now explicit: references land **before** verification, or the fix would not fix the checksum. A reference that cannot be fetched keeps the skill a draft — a skill missing part of itself is not ready to activate, whatever else checks out. Path separators, leading dots and `..` in a name are refused rather than fetched; the index is remote input.

## Verification

- `KAOS_ENV_FILE=/dev/null pytest -m "not integration" -q` → 1368 passed (17 new)
- `pytest tests/test_durable_kill.py -m integration` → 5 passed
- The ping-pong measured end to end on the local bus, before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)