### PR TITLE
fix(bridge): owner-topic replies were generated then dropped

### DIFF
--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -1094,6 +1094,11 @@ async def run_bridge(agent: KronosAgent) -> None:
                     0.0,
                     1,
                     f"topic-owner:{topic_route.label}",
+                    topic=topic_route.label,
+                    # Ownership is already resolved above by `_agent_owns_topic`,
+                    # which also accepts a comma-separated list of owners — so
+                    # the owner of this decision is this agent, not the raw config.
+                    topic_owner=settings.agent_name,
                 )
                 if swarm is not None:
                     swarm.claim_reply(

--- a/kronos/bridge_topics.py
+++ b/kronos/bridge_topics.py
@@ -23,13 +23,22 @@ class TopicRoute:
 
 @dataclass(frozen=True)
 class TopicDecision:
-    """Small decision object compatible with group_router.RoutingDecision."""
+    """Small decision object compatible with group_router.RoutingDecision.
+
+    The compatibility is load-bearing: ``bridge.handle_message`` reads the same
+    attributes off whichever decision it holds. Every field ``RoutingDecision``
+    carries must exist here too, or the owner-topic path raises AttributeError
+    after the answer is already generated — and the reply is silently lost.
+    """
 
     should_respond: bool
     delay: float
     tier: int
     reason: str
     addressing: object | None = None
+    topic: str = ""
+    topic_owner: str = ""
+    owner_sla_minutes: int = 0
 
 
 def _normalize_telegram_chat_id(chat_id: int | None) -> int | None:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -157,6 +157,23 @@ def test_topic_owner_can_allow_multiple_agents(monkeypatch):
     assert bridge._agent_owns_topic(route) is False
 
 
+def test_topic_decision_carries_every_routing_decision_field():
+    """The two decision types are read interchangeably by handle_message.
+
+    A field present only on RoutingDecision raises AttributeError on the
+    owner-topic path — after the answer is generated, so the reply is lost
+    instead of sent. Keep the contract enforced here, not in production.
+    """
+    from dataclasses import fields
+
+    from kronos.group_router import RoutingDecision
+
+    routing = {field.name for field in fields(RoutingDecision)}
+    topic = {field.name for field in fields(bridge.TopicDecision)}
+
+    assert routing <= topic, f"TopicDecision is missing: {sorted(routing - topic)}"
+
+
 def test_topic_route_falls_back_outside_configured_chat(monkeypatch):
     _clear_topic_alias_env(monkeypatch)
     monkeypatch.setattr(bridge.settings, "telegram_swarm_chat_id", 3642435967)


### PR DESCRIPTION
## Problem

Every message in an **owner-mode forum topic** crashed `handle_message` — after the LLM had already generated an answer and after the reply claim was taken. Nothing reached the chat; the agent looked dead in exactly the topics it owns.

```
File "kronos/bridge.py", line 1469, in handle_message
    if not is_dm and decision is not None and reply and decision.topic_owner == settings.agent_name:
AttributeError: 'TopicDecision' object has no attribute 'topic_owner'
```

`TopicDecision` documents itself as "compatible with group_router.RoutingDecision", but that compatibility was never enforced: `RoutingDecision` grew `topic`, `topic_owner` and `owner_sla_minutes`, `TopicDecision` did not. `handle_message` reads those attributes off whichever decision it holds, so the owner-topic path raised.

Introduced in #37 (Swarm 3.0), where the dissent gate started reading `decision.topic_owner`.

## Fix

- `TopicDecision` gets the missing fields, with a docstring saying why the contract is load-bearing.
- The owner-topic path populates them. Ownership is already resolved by `_agent_owns_topic` (which accepts a comma-separated owner list), so the decision's owner is this agent rather than the raw config value.
- A structural test asserts every `RoutingDecision` field exists on `TopicDecision` — the next added field cannot silently reopen this hole.

The dissent gate itself is a no-op unless a profile sets `dissent: require`, so this restores replies without changing behaviour for anyone not opted in.

## Verification

- `pytest tests/test_bridge.py tests/test_swarm_ownership.py` — 30 passed
- Full suite: 820 passed (`test_mcp_smoke.py` fails locally on a missing MCP server, unrelated and pre-existing)
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)