### PR TITLE
Plans: work that outlives a turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Kronos Agent OS are documented here.
 
 ### Added
 
+- **Plans — work that outlives a turn** — a durable turn protects minutes; "ask
+  three landlords and compare what comes back" is days, mostly spent waiting. A
+  plan is a goal plus steps, where a step holds a prompt, what it depends on, and
+  what it waits for: a time, you resuming it, you replying, a page starting or
+  stopping to match a pattern, or a number on a page crossing a threshold. The
+  poller runs each ready step as an ordinary agent turn, so durable turns, the
+  effects ledger, approvals and the cost guardian apply unchanged. Conditions are
+  validated in the turn that writes them — a bad regex or a forbidden host is
+  refused with the reason, not discovered next Tuesday. A dependency counts as
+  satisfied when it *finished*, not when it succeeded, so one silent landlord does
+  not turn two answers into none. Steps are silent unless marked `notify`; what
+  always arrives is one closing summary. `plan_start` / `plan_add_step` /
+  `plan_status` / `plan_cancel`, `kaos plans list/show/resume/cancel`, a dashboard
+  page, and bounds on everything that could otherwise wait forever. Docs:
+  [Plans](docs/PLANS.md).
+
 - **Site accounts — acting as the owner, without holding the keys** — an account
   says which sites the agent may work on as you, which domains that session may
   be used on, and what it may do there (`read` / `message` / `full`, with

--- a/dashboard-ui/src/App.tsx
+++ b/dashboard-ui/src/App.tsx
@@ -25,6 +25,7 @@ const TurnsPage = lazy(() => import('./pages/TurnsPage'));
 const AnomaliesPage = lazy(() => import('./pages/AnomaliesPage'));
 const SandboxPage = lazy(() => import('./pages/SandboxPage'));
 const AccountsPage = lazy(() => import('./pages/AccountsPage'));
+const PlansPage = lazy(() => import('./pages/PlansPage'));
 
 /* ── Login ── */
 
@@ -115,6 +116,7 @@ const NAV_SECTIONS: NavSection[] = [
       { path: '/analytics', label: 'Analytics', icon: 'N' },
       { path: '/audit', label: 'Audit Trail', icon: 'T' },
       { path: '/turns', label: 'Durable Turns', icon: 'D' },
+      { path: '/plans', label: 'Plans', icon: 'B' },
       { path: '/sandbox', label: 'Sandbox', icon: 'X' },
     ],
   },
@@ -135,7 +137,7 @@ const NAV_SECTIONS: NavSection[] = [
 
 const ICON_COLORS: Record<string, string> = {
   '~': '#f97316', F: '#22d3ee', A: '#3b82f6', M: '#8b5cf6', L: '#4ade80',
-  J: '#0ea5e9', P: '#f59e0b', N: '#06b6d4', T: '#ec4899',
+  J: '#0ea5e9', P: '#f59e0b', N: '#06b6d4', T: '#ec4899', B: '#84cc16',
   X: '#f97316',
   '!': '#ef4444', S: '#6366f1', K: '#14b8a6', G: '#a78bfa', Q: '#22c55e', U: '#eab308', W: '#f472b6', C: '#64748b',
 };
@@ -346,6 +348,7 @@ export default function App() {
           <Route path="/analytics" element={<AnalyticsPage />} />
           <Route path="/audit" element={<AuditTrailPage />} />
           <Route path="/turns" element={<TurnsPage />} />
+          <Route path="/plans" element={<PlansPage />} />
           <Route path="/sandbox" element={<SandboxPage />} />
           <Route path="/anomalies" element={<AnomaliesPage />} />
           <Route path="/mcp" element={<McpPage />} />

--- a/dashboard-ui/src/pages/PlansPage.tsx
+++ b/dashboard-ui/src/pages/PlansPage.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react';
+import { api } from '../api/client';
+
+/**
+ * Long-lived plans: work that spends most of its life waiting.
+ *
+ * A waiting plan is invisible everywhere else — no log line, no turn in flight,
+ * nothing on /health. This page exists so "still watching that price, checked 41
+ * times" is something a person can see, and so a plan that parked itself waiting
+ * for the owner can be released without editing SQLite.
+ */
+
+interface Step {
+  id: number;
+  seq: number;
+  title: string;
+  prompt: string;
+  state: string;
+  depends_on: number[];
+  waiting_for: string;
+  wake_at: number;
+  checks: number;
+  attempts: number;
+  notify: boolean;
+  result: string;
+  updated_at: number;
+}
+
+interface Plan {
+  id: number;
+  goal: string;
+  state: string;
+  summary: string;
+  created_at: number;
+  updated_at: number;
+  expires_at: number;
+  step_count: number;
+  done_count: number;
+  failed_count: number;
+  waiting_count: number;
+  steps?: Step[];
+}
+
+const STATE_COLOR: Record<string, string> = {
+  active: '#22d3ee',
+  done: '#22c55e',
+  failed: '#ef4444',
+  cancelled: '#64748b',
+  pending: '#94a3b8',
+  waiting: '#f59e0b',
+  running: '#22d3ee',
+};
+
+const card: React.CSSProperties = {
+  background: '#111', border: '1px solid #1a1a1a', borderRadius: 12, padding: '1.1rem',
+};
+const ghost: React.CSSProperties = {
+  padding: '0.35rem 0.75rem', borderRadius: 8, border: '1px solid #222', cursor: 'pointer',
+  background: 'transparent', color: '#999', fontSize: '0.76rem',
+};
+
+function when(ts: number): string {
+  if (!ts) return '';
+  const diff = Math.floor(Date.now() / 1000 - ts);
+  if (Math.abs(diff) < 60) return 'just now';
+  const ahead = diff < 0;
+  const mins = Math.floor(Math.abs(diff) / 60);
+  const text = mins < 60 ? `${mins}m` : mins < 1440 ? `${Math.floor(mins / 60)}h` : `${Math.floor(mins / 1440)}d`;
+  return ahead ? `in ${text}` : `${text} ago`;
+}
+
+export default function PlansPage() {
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [showAll, setShowAll] = useState(false);
+  const [open, setOpen] = useState<number | null>(null);
+  const [error, setError] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const load = (all = showAll) =>
+    api<{ plans: Plan[] }>(`/api/plans?all=${all}`)
+      .then(r => setPlans(r.plans))
+      .catch(e => setError(String(e)));
+
+  useEffect(() => { load(); }, [showAll]);
+
+  const act = async (fn: () => Promise<unknown>) => {
+    setBusy(true);
+    setError('');
+    try {
+      await fn();
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message.replace(/^\d+:\s*/, '') : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.25rem' }}>
+        <div>
+          <h1 style={{ fontSize: '1.5rem', fontWeight: 600, marginBottom: '0.2rem' }}>Plans</h1>
+          <p style={{ fontSize: '0.82rem', color: '#666' }}>
+            Work that outlives a conversation — mostly spent waiting, which is the point.
+          </p>
+        </div>
+        <button style={ghost} onClick={() => setShowAll(!showAll)}>
+          {showAll ? 'Running only' : 'Include finished'}
+        </button>
+      </div>
+
+      {error && (
+        <div style={{ ...card, borderColor: '#ef444455', color: '#fca5a5', marginBottom: '1rem', fontSize: '0.85rem' }}>
+          {error}
+        </div>
+      )}
+
+      {plans.length === 0 && (
+        <div style={{ ...card, color: '#666', fontSize: '0.85rem' }}>
+          {showAll ? 'No plans yet.' : 'Nothing running. Finished plans are behind “Include finished”.'}
+        </div>
+      )}
+
+      <div style={{ display: 'grid', gap: '0.75rem' }}>
+        {plans.map(plan => (
+          <div key={plan.id} style={card}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem', alignItems: 'flex-start' }}>
+              <div style={{ minWidth: 0 }}>
+                <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', marginBottom: '0.3rem' }}>
+                  <span style={{ color: '#555', fontSize: '0.8rem' }}>#{plan.id}</span>
+                  <span style={{ fontSize: '0.98rem', fontWeight: 600 }}>{plan.goal}</span>
+                  <span style={{ fontSize: '0.68rem', color: STATE_COLOR[plan.state] || '#666' }}>● {plan.state}</span>
+                </div>
+                <div style={{ fontSize: '0.75rem', color: '#666' }}>
+                  {plan.done_count}/{plan.step_count} steps done
+                  {plan.failed_count > 0 && ` · ${plan.failed_count} failed`}
+                  {plan.waiting_count > 0 && ` · ${plan.waiting_count} waiting`}
+                  {' · touched '}{when(plan.updated_at)}
+                  {plan.state === 'active' && plan.expires_at ? ` · expires ${when(plan.expires_at)}` : ''}
+                </div>
+                {plan.summary && (
+                  <div style={{ marginTop: '0.6rem', fontSize: '0.82rem', color: '#bbb', whiteSpace: 'pre-wrap' }}>
+                    {plan.summary}
+                  </div>
+                )}
+              </div>
+              <div style={{ display: 'flex', gap: '0.4rem', flexShrink: 0 }}>
+                <button style={ghost} onClick={() => setOpen(open === plan.id ? null : plan.id)}>
+                  {open === plan.id ? 'Hide steps' : 'Steps'}
+                </button>
+                {plan.waiting_count > 0 && (
+                  <button
+                    style={{ ...ghost, color: '#f59e0b' }}
+                    disabled={busy}
+                    onClick={() => act(() => api(`/api/plans/${plan.id}/resume`, { method: 'POST' }))}
+                  >Resume</button>
+                )}
+                {plan.state === 'active' && (
+                  <button
+                    style={{ ...ghost, color: '#ef4444' }}
+                    disabled={busy}
+                    onClick={() => { if (confirm(`Stop plan #${plan.id}?`)) act(() => api(`/api/plans/${plan.id}`, { method: 'DELETE' })); }}
+                  >Stop</button>
+                )}
+              </div>
+            </div>
+
+            {open === plan.id && (
+              <div style={{ marginTop: '0.9rem', paddingTop: '0.9rem', borderTop: '1px solid #1a1a1a', display: 'grid', gap: '0.6rem' }}>
+                {(plan.steps || []).map(step => (
+                  <div key={step.id} style={{ fontSize: '0.8rem' }}>
+                    <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'baseline' }}>
+                      <span style={{ color: '#555' }}>#{step.id}</span>
+                      <span style={{ color: '#ddd', fontWeight: 500 }}>{step.title || `step ${step.seq}`}</span>
+                      <span style={{ color: STATE_COLOR[step.state] || '#666', fontSize: '0.7rem' }}>{step.state}</span>
+                      {step.notify && <span style={{ color: '#8b5cf6', fontSize: '0.68rem' }}>notifies</span>}
+                    </div>
+                    <div style={{ color: '#777', marginTop: '0.15rem' }}>{step.prompt}</div>
+                    {step.waiting_for && (
+                      <div style={{ color: '#f59e0b', marginTop: '0.15rem', fontSize: '0.75rem' }}>
+                        waits {step.waiting_for}
+                        {step.checks > 0 && ` · checked ${step.checks}×`}
+                        {step.wake_at ? ` · next look ${when(step.wake_at)}` : ''}
+                      </div>
+                    )}
+                    {step.depends_on.length > 0 && (
+                      <div style={{ color: '#555', marginTop: '0.15rem', fontSize: '0.72rem' }}>
+                        after {step.depends_on.map(d => `#${d}`).join(', ')}
+                      </div>
+                    )}
+                    {step.result && (
+                      <div style={{ color: '#9ca3af', marginTop: '0.3rem', whiteSpace: 'pre-wrap', fontSize: '0.78rem' }}>
+                        → {step.result}
+                      </div>
+                    )}
+                    {step.state === 'waiting' && (
+                      <button
+                        style={{ ...ghost, marginTop: '0.35rem', fontSize: '0.7rem' }}
+                        disabled={busy}
+                        onClick={() => act(() => api(`/api/plans/${plan.id}/resume?step=${step.id}`, { method: 'POST' }))}
+                      >Release this step</button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/api/plans.py
+++ b/dashboard/api/plans.py
@@ -1,0 +1,110 @@
+"""Plans API — what the agent is still working on, days later.
+
+A plan spends most of its life waiting, which makes it invisible: no log line,
+no turn in flight, nothing on /health. The control room is where "still watching
+that price, checked 41 times" becomes something a person can see — and where a
+plan that parked itself waiting for the owner can be released.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from dashboard.auth import verify_token
+from kronos import plan_conditions, plans
+from kronos.config import settings
+
+router = APIRouter(prefix="/api/plans", tags=["plans"], dependencies=[Depends(verify_token)])
+log = logging.getLogger("kronos.dashboard.plans")
+
+
+def _step_view(step: dict) -> dict:
+    spec = plans.wait_spec(step)
+    return {
+        "id": step["id"],
+        "seq": step["seq"],
+        "title": step["title"],
+        "prompt": step["prompt"],
+        "state": step["state"],
+        "depends_on": plans.dependency_ids(step),
+        "waiting_for": plan_conditions.describe(spec) if spec else "",
+        "wake_at": step["wake_at"],
+        "checks": step["checks"],
+        "attempts": step["attempts"],
+        "notify": bool(step["notify"]),
+        "result": step["result"],
+        "updated_at": step["updated_at"],
+    }
+
+
+def _plan_view(plan: dict, *, with_steps: bool = True) -> dict:
+    steps = plans.steps_of(plan["id"])
+    view = {
+        "id": plan["id"],
+        "goal": plan["goal"],
+        "state": plan["state"],
+        "summary": plan["summary"],
+        "created_at": plan["created_at"],
+        "updated_at": plan["updated_at"],
+        "expires_at": plan["expires_at"],
+        "step_count": len(steps),
+        "done_count": sum(1 for step in steps if step["state"] == plans.STEP_DONE),
+        "failed_count": sum(1 for step in steps if step["state"] == plans.STEP_FAILED),
+        "waiting_count": sum(1 for step in steps if step["state"] == plans.STEP_WAITING),
+    }
+    if with_steps:
+        view["steps"] = [_step_view(step) for step in steps]
+    return view
+
+
+@router.get("")
+async def list_plans(
+    include_finished: bool = Query(False, alias="all"),
+    limit: int = Query(50, ge=1, le=200),
+) -> dict:
+    rows = list(plans.list_plans(settings.agent_name, limit=limit))
+    if include_finished:
+        seen = {plan["id"] for plan in rows}
+        for state in plans.PLAN_TERMINAL:
+            rows += [p for p in plans.list_plans(settings.agent_name, state=state, limit=limit) if p["id"] not in seen]
+    rows.sort(key=lambda plan: plan["id"], reverse=True)
+    return {
+        "plans": [_plan_view(plan) for plan in rows],
+        "states": [plans.PLAN_ACTIVE, *plans.PLAN_TERMINAL],
+    }
+
+
+@router.get("/{plan_id}")
+async def get_plan(plan_id: int) -> dict:
+    plan = plans.get_plan(plan_id)
+    if not plan:
+        raise HTTPException(status_code=404, detail=f"no plan #{plan_id}")
+    return _plan_view(plan)
+
+
+@router.post("/{plan_id}/resume")
+async def resume_plan(plan_id: int, step: int = Query(0, description="one step, or 0 for every waiting step")) -> dict:
+    """Release steps that were waiting for the owner. The poller takes it from there."""
+    plan = plans.get_plan(plan_id)
+    if not plan:
+        raise HTTPException(status_code=404, detail=f"no plan #{plan_id}")
+    if plan["state"] != plans.PLAN_ACTIVE:
+        raise HTTPException(status_code=409, detail=f"plan #{plan_id} is {plan['state']}")
+
+    waiting = [s for s in plans.steps_of(plan_id) if s["state"] == plans.STEP_WAITING]
+    if step:
+        waiting = [s for s in waiting if s["id"] == step]
+    if not waiting:
+        raise HTTPException(status_code=404, detail="nothing is waiting on this plan")
+
+    for parked in waiting:
+        plans.release_step(parked["id"])
+    log.info("Plan #%s: released %d step(s) from the dashboard", plan_id, len(waiting))
+    return {"released": [s["id"] for s in waiting], "plan": _plan_view(plans.get_plan(plan_id))}
+
+
+@router.delete("/{plan_id}")
+async def cancel_plan(plan_id: int) -> dict:
+    if not plans.cancel_plan(plan_id, settings.agent_name):
+        raise HTTPException(status_code=404, detail=f"no active plan #{plan_id}")
+    return _plan_view(plans.get_plan(plan_id))

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -29,6 +29,7 @@ from dashboard.api.monitoring import set_scheduler
 from dashboard.api.overview import router as overview_router
 from dashboard.api.performance import router as performance_router
 from dashboard.api.persona import router as persona_router
+from dashboard.api.plans import router as plans_router
 from dashboard.api.sandbox import router as sandbox_router
 from dashboard.api.skills import router as skills_router
 from dashboard.api.swarm import router as swarm_router
@@ -84,6 +85,7 @@ def create_app(scheduler=None, agent=None) -> FastAPI:
     app.include_router(audit_trail_router)
     app.include_router(turns_router)
     app.include_router(accounts_router)
+    app.include_router(plans_router)
     app.include_router(anomalies_router)
     app.include_router(persona_router)
     app.include_router(monitoring_router)

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -1,0 +1,107 @@
+# Plans
+
+A durable turn protects minutes of work: up to twenty-five model steps, resumable
+after a crash. Some requests do not fit in that shape at all.
+
+> Find me a flat on Airbnb and Booking, ask the landlords about the deposit and
+> the minimum term, and tell me which one is worth taking.
+
+That is days, and most of it is waiting. A plan is the object for it: a goal, a
+set of steps, and for each step what it waits for. The poller runs each step as
+an ordinary agent turn when its time comes, so durable turns, the effects ledger,
+approvals and the cost guardian all apply — nothing about plans re-implements
+them.
+
+```
+plan   → goal, state (active | done | failed | cancelled), expiry, summary
+ step  → prompt, depends_on, waiting condition, state, result
+```
+
+## What a step waits for
+
+| Condition | Fires when | For |
+|---|---|---|
+| `{"kind":"at","seconds":86400}` | the time comes | check back tomorrow |
+| `{"kind":"manual","note":"after the viewing"}` | you release it | only you know when |
+| `{"kind":"reply"}` | you write in the chat the plan came from | the plan needs your answer |
+| `{"kind":"page_matches","url":…,"pattern":"in stock","absent":false}` | the page starts (or stops) matching | back in stock, listing gone |
+| `{"kind":"page_number","url":…,"pattern":"Rp ([0-9.]+)","op":"below","value":9000000}` | the number crosses the threshold | watch a price |
+
+Page conditions take `every_seconds` — minimum 300, default 3600. None of these
+call a model: a condition that cost a model call every few minutes would make
+waiting the expensive part, when waiting is meant to be the cheap part.
+
+Conditions are validated when the step is written, not when it wakes. A bad
+regex, a missing `op`, a host the egress allowlist forbids — all refused in the
+turn that asked, with the reason, so the agent fixes it immediately instead of
+the plan looking fine and never firing.
+
+## What the agent does
+
+| Tool | Does |
+|---|---|
+| `plan_start(goal, first_step)` | opens a plan and queues its first step |
+| `plan_add_step(plan_id, task, after_steps, wait, notify)` | appends a step, optionally parked and/or dependent |
+| `plan_status(plan_id)` | what is running and what it waits for |
+| `plan_cancel(plan_id)` | stop it |
+
+Steps run in the plan's own thread (`plan:<id>`), not your chat: a dozen machine
+turns do not belong in a conversation, and it is what lets a `reply` condition
+tell you speaking from the agent's own work.
+
+## What you see
+
+```bash
+kaos plans list            # running plans, and what each waits for
+kaos plans list --all      # including finished ones
+kaos plans show 7          # steps, results, how many times a condition was checked
+kaos plans resume 7        # release steps that were waiting for you
+kaos plans resume 7 --step 12
+kaos plans cancel 7
+```
+
+The dashboard has the same under **Plans**, including a per-step release button.
+
+## What reaches you, and when
+
+A step is silent unless it was created with `notify`. What always arrives is the
+plan closing: one message, written by the agent from the step results — that is
+the thing you waited days for, and the raw results are a log, not an answer.
+
+The reason for the default is arithmetic. A week-long price watch that messaged
+every hour would be muted by day two, and then nothing would reach you at all.
+
+## Bounds
+
+Every one of these exists because its absence is a way for a plan to cost money
+forever, or to look alive when it is not:
+
+| Bound | Value | Why |
+|---|---|---|
+| Steps per plan | 50 | a plan that keeps adding steps is a loop |
+| Attempts per step | 3 | a transient failure must not end a week-long plan; a permanent one must not retry forever |
+| Checks per condition | 5000 | a page that stopped existing, a threshold nothing will reach |
+| Plan expiry | 90 days | "still waiting" must eventually become "this did not work" |
+| Step runs per cycle | 3 | each is a model call, and a minute is not a reason to run everything ready |
+| Summaries per cycle | 2 | leftovers are picked up next cycle; a finished plan is owed one until it has one |
+| Condition checks per cycle | 20 | a page fetch takes seconds |
+
+A plan that expires is closed and reported, not silently dropped: silence would
+leave you believing it was still watching.
+
+## Honest limits
+
+- **A dependency counts as satisfied when it finished, not when it succeeded.**
+  Three landlords asked, one never replies: the comparison step still runs, with
+  two answers and one stated absence. This is deliberate — cascading skips would
+  turn one silent landlord into no answer at all.
+- **`reply` means you wrote in that chat**, not that a particular question was
+  answered. Waiting on a reply *inside a site's own inbox* needs an inbox for
+  that site, which does not exist yet; use `manual` or `at` for those.
+- **A page condition is a small crawler.** Five-minute floor, one URL per step,
+  and a site that blocks the fetch reads as "check did not happen" — never as a
+  fired condition. Whether watching a given site is acceptable is your call, not
+  something the code decides.
+- **Steps do not share a conversation with your chat.** A step only knows the
+  goal, its own prompt, and the results of the steps it depends on. Write step
+  prompts that carry what they need.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Start here if you want to understand or contribute to Kronos Agent OS.
 | [Skills](SKILLS.md) | Workspace-local reusable procedures |
 | [MCP & Tools](MCP.md) | Static MCP, tool gateway, dynamic tool gates |
 | [Site Accounts](SITE-ACCOUNTS.md) | Acting as the owner on a site: sessions, permissions, the password vault |
+| [Plans](PLANS.md) | Work that outlives a turn: steps, waiting conditions, what reaches you |
 | [Automations](AUTOMATIONS.md) | Scheduler, jobs, notifications, audit trail |
 | [Sub-Agents & Swarm](SWARM.md) | Optional multi-agent coordination |
 | [Skill Registry](REGISTRY.md) | Publishing, signing, installing and measuring skills |

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -1527,6 +1527,128 @@ def run_audit_verify(as_json: bool) -> int:
     return 0
 
 
+def _plan_row(plan: dict) -> dict:
+    from kronos import plan_conditions, plans
+
+    steps = plans.steps_of(plan["id"])
+    return {
+        "id": plan["id"],
+        "goal": plan["goal"],
+        "state": plan["state"],
+        "steps": len(steps),
+        "done": sum(1 for s in steps if s["state"] == plans.STEP_DONE),
+        "waiting": [
+            {"step": s["id"], "for": plan_conditions.describe(plans.wait_spec(s))}
+            for s in steps
+            if s["state"] == plans.STEP_WAITING
+        ],
+        "summary": plan["summary"],
+    }
+
+
+def run_plans_list(show_all: bool, as_json: bool) -> int:
+    """Plans that are still running, or every plan there has been."""
+    from kronos import plans
+
+    rows = []
+    states = ("", *plans.PLAN_TERMINAL) if show_all else ("",)
+    seen = set()
+    for state in states:
+        for plan in plans.list_plans(settings.agent_name, state=state):
+            if plan["id"] in seen:
+                continue
+            seen.add(plan["id"])
+            rows.append(_plan_row(plan))
+    rows.sort(key=lambda row: row["id"], reverse=True)
+
+    if as_json:
+        print(json.dumps(rows, ensure_ascii=False, indent=2))
+        return 0
+    if not rows:
+        print("No plans." if show_all else "No plans running. `kaos plans list --all` for finished ones.")
+        return 0
+    for row in rows:
+        print(f"#{row['id']} [{row['state']}] {row['goal']}  ({row['done']}/{row['steps']} steps)")
+        for waiting in row["waiting"]:
+            print(f"    step #{waiting['step']} waits {waiting['for']}")
+    return 0
+
+
+def run_plans_show(plan_id: int, as_json: bool) -> int:
+    from kronos import plan_conditions, plans
+
+    plan = plans.get_plan(plan_id)
+    if not plan:
+        print(f"No plan #{plan_id}")
+        return 1
+
+    steps = plans.steps_of(plan_id)
+    if as_json:
+        print(json.dumps({"plan": plan, "steps": steps}, ensure_ascii=False, indent=2, default=str))
+        return 0
+
+    print(f"#{plan['id']} [{plan['state']}] {plan['goal']}")
+    if plan["summary"]:
+        print(f"\n{plan['summary']}\n")
+    for step in steps:
+        label = step["title"] or f"step {step['seq']}"
+        line = f"  #{step['id']} {label}: {step['state']}"
+        spec = plans.wait_spec(step)
+        if spec:
+            line += f" — waits {plan_conditions.describe(spec)} (checked {step['checks']}x)"
+        deps = plans.dependency_ids(step)
+        if deps:
+            line += f" — after {', '.join(f'#{d}' for d in deps)}"
+        print(line)
+        if step["result"]:
+            print(f"      {step['result'][:500]}")
+    return 0
+
+
+def run_plans_resume(plan_id: int, step_id: int) -> int:
+    """Release waiting steps so the next poller cycle runs them.
+
+    This is the other half of a `manual` condition: the plan parked itself
+    because only the owner knows when to carry on.
+    """
+    from kronos import plans
+
+    plan = plans.get_plan(plan_id)
+    if not plan:
+        print(f"No plan #{plan_id}")
+        return 1
+    if plan["state"] != plans.PLAN_ACTIVE:
+        print(f"Plan #{plan_id} is {plan['state']} — nothing to resume.")
+        return 1
+
+    waiting = [s for s in plans.steps_of(plan_id) if s["state"] == plans.STEP_WAITING]
+    if step_id:
+        waiting = [s for s in waiting if s["id"] == step_id]
+        if not waiting:
+            print(f"Step #{step_id} of plan #{plan_id} is not waiting.")
+            return 1
+    if not waiting:
+        print(f"Plan #{plan_id} has no waiting steps.")
+        return 1
+
+    for step in waiting:
+        plans.release_step(step["id"])
+        label = step["title"] or f"step {step['seq']}"
+        print(f"Released step #{step['id']} ({label})")
+    print("The next poller cycle picks them up.")
+    return 0
+
+
+def run_plans_cancel(plan_id: int) -> int:
+    from kronos import plans
+
+    if not plans.cancel_plan(plan_id, settings.agent_name):
+        print(f"No active plan #{plan_id} for {settings.agent_name}")
+        return 1
+    print(f"Plan #{plan_id} cancelled.")
+    return 0
+
+
 def run_vault_init(overwrite: bool) -> int:
     """Create the key that encrypts stored site passwords."""
     from kronos import vault
@@ -1965,6 +2087,20 @@ def build_parser() -> argparse.ArgumentParser:
     audit_verify = audit_sub.add_parser("verify", help="verify the audit log hash chain")
     audit_verify.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
 
+    plans_cmd = sub.add_parser("plans", help="long-lived plans: what is running and what it waits for")
+    plans_sub = plans_cmd.add_subparsers(dest="plans_command")
+    plans_list = plans_sub.add_parser("list", help="plans still running")
+    plans_list.add_argument("--all", dest="show_all", action="store_true", help="include finished plans")
+    plans_list.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
+    plans_show = plans_sub.add_parser("show", help="one plan with its steps and results")
+    plans_show.add_argument("plan_id", type=int)
+    plans_show.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
+    plans_resume = plans_sub.add_parser("resume", help="release steps that were waiting for you")
+    plans_resume.add_argument("plan_id", type=int)
+    plans_resume.add_argument("--step", dest="step_id", type=int, default=0, help="release only this step")
+    plans_cancel = plans_sub.add_parser("cancel", help="stop a plan")
+    plans_cancel.add_argument("plan_id", type=int)
+
     vault_cmd = sub.add_parser("vault", help="the key that encrypts stored site passwords")
     vault_sub = vault_cmd.add_subparsers(dest="vault_command")
     vault_init = vault_sub.add_parser("init", help="create the vault key")
@@ -2155,6 +2291,17 @@ def main(argv: list[str] | None = None) -> int:
         if args.audit_command == "verify":
             return run_audit_verify(args.as_json)
         parser.parse_args(["audit", "--help"])
+        return 0
+    if args.command == "plans":
+        if args.plans_command == "list":
+            return run_plans_list(args.show_all, args.as_json)
+        if args.plans_command == "show":
+            return run_plans_show(args.plan_id, args.as_json)
+        if args.plans_command == "resume":
+            return run_plans_resume(args.plan_id, args.step_id)
+        if args.plans_command == "cancel":
+            return run_plans_cancel(args.plan_id)
+        parser.parse_args(["plans", "--help"])
         return 0
     if args.command == "vault":
         if args.vault_command == "init":

--- a/kronos/cron/plans.py
+++ b/kronos/cron/plans.py
@@ -1,0 +1,266 @@
+"""The poller that makes a plan move.
+
+Once a minute: retire plans that ran out of time, ask each parked step's
+condition whether it is time, and run the steps that are ready. A step runs as
+an ordinary agent turn, so durable turns, the effects ledger, approvals and the
+cost guardian all apply without knowing plans exist.
+
+Three things keep the loop honest:
+
+* **Steps run in the plan's own thread** (``plan:<id>``), not the owner's chat.
+  A dozen machine turns do not belong in a person's conversation, and it means a
+  "wait for my reply" condition cannot mistake the agent's own work for the
+  owner speaking.
+* **One step per plan per cycle, a few steps in total.** Each step is a model
+  call. Without the cap, one plan with forty ready steps would spend a day's
+  budget in a minute and starve every other plan.
+* **Nothing is delivered unless it was asked for.** A step notifies only when it
+  was created with ``notify``; what always arrives is the plan finishing. A
+  week-long watch that sent a message every hour would be turned off in a day.
+"""
+
+import asyncio
+import logging
+
+from kronos import plan_conditions, plans
+from kronos.config import settings
+from kronos.cron.notify import send_webhook
+
+log = logging.getLogger("kronos.cron.plans")
+
+# Step runs per cycle, across all plans. A minute of wall clock is not a reason
+# to run everything that happens to be ready.
+MAX_STEPS_PER_CYCLE = 3
+# Closing summaries per cycle. Counted separately from steps because a plan that
+# finished is what the owner is actually waiting for, and it must not be crowded
+# out by steps of other plans. Leftovers are picked up next cycle — a plan is
+# owed a summary until it has one.
+MAX_SUMMARIES_PER_CYCLE = 2
+# Condition checks per cycle. Page conditions fetch, and a fetch can take
+# seconds — twenty is already most of a minute.
+MAX_CHECKS_PER_CYCLE = 20
+MAX_RESULT_CHARS_IN_PROMPT = 1200
+
+
+def plan_thread_id(plan_id: int) -> str:
+    return f"plan:{plan_id}"
+
+
+def _short(text: str, limit: int = MAX_RESULT_CHARS_IN_PROMPT) -> str:
+    text = (text or "").strip()
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def step_prompt(plan: dict, step: dict, observation: str = "") -> str:
+    """What the agent is asked when a step wakes.
+
+    Carries the goal, what earlier steps produced (including what failed, plainly
+    said), and the observation that woke this one — a condition already fetched
+    the page, and making the step fetch it again to find out why it woke would be
+    both slower and a chance to see something different.
+    """
+    lines = [
+        "Ты выполняешь шаг долгоживущего плана.",
+        "",
+        f"Цель плана: {plan['goal']}",
+        f"Шаг {step['seq']}" + (f": {step['title']}" if step["title"] else ""),
+    ]
+    if observation:
+        lines += ["", f"Что произошло: {observation}"]
+
+    done = plans.dependency_results(step)
+    if done:
+        lines += ["", "Результаты шагов, от которых зависит этот:"]
+        for dep in done:
+            label = dep["title"] or f"шаг {dep['seq']}"
+            if dep["state"] == plans.STEP_FAILED:
+                lines.append(f"- {label}: НЕ УДАЛОСЬ — {_short(dep['result'], 300)}")
+            else:
+                lines.append(f"- {label}: {_short(dep['result'])}")
+
+    lines += [
+        "",
+        f"Задача: {step['prompt']}",
+        "",
+        "Ответь результатом шага — кратко и по делу, это будет сохранено в план. "
+        "Если работа продолжается позже, добавь следующий шаг через plan_add_step "
+        f"(plan_id={plan['id']}) с условием ожидания.",
+    ]
+    return "\n".join(lines)
+
+
+async def _run_step(plan: dict, step: dict, observation: str) -> None:
+    """Run one step as a turn. Its reply is the step's result."""
+    from kronos.bridge import get_agent
+
+    agent = get_agent()
+    if agent is None:
+        log.warning("Plan step #%s skipped: agent not ready", step["id"])
+        return
+
+    plans.mark_running(step["id"])
+    try:
+        result = await agent.ainvoke(
+            message=step_prompt(plan, step, observation),
+            thread_id=plan_thread_id(plan["id"]),
+            user_id="plan",
+            session_id=str(plan["chat_id"] or plan["id"]),
+            source_kind="user",
+            persist_user_turn=True,
+        )
+    except Exception as e:
+        log.error("Plan step #%s failed: %s", step["id"], e)
+        plans.fail_step(step["id"], str(e))
+        return
+
+    text = (result or "").strip()
+    if not text:
+        # An empty reply is not a result. Retrying is the right reading: the
+        # model was cut off, the provider hiccuped, the turn was blocked.
+        plans.fail_step(step["id"], "the agent returned nothing")
+        return
+
+    plans.finish_step(step["id"], text)
+    if step["notify"]:
+        await _deliver(plan, text)
+
+
+async def _deliver(plan: dict, text: str) -> None:
+    if not plan.get("chat_id"):
+        return
+    await asyncio.to_thread(send_webhook, text, plan["chat_id"], None, plan.get("topic_id"))
+
+
+async def _summarize(plan: dict, state: str) -> None:
+    """Say how it went, once, when the plan closes.
+
+    This is the message the owner actually waited days for, so it is worth a
+    model call: the raw step results are a log, not an answer.
+    """
+    steps = plans.steps_of(plan["id"])
+    rendered = []
+    for step in steps:
+        label = step["title"] or f"шаг {step['seq']}"
+        mark = "не удалось" if step["state"] == plans.STEP_FAILED else "готово"
+        rendered.append(f"- {label} ({mark}): {_short(step['result'], 600)}")
+
+    from kronos.bridge import get_agent
+
+    agent = get_agent()
+    fallback = f"План «{plan['goal']}» — {state}.\n\n" + "\n".join(rendered)
+    if agent is None:
+        plans.set_summary(plan["id"], fallback)
+        await _deliver(plan, fallback)
+        return
+
+    prompt = (
+        f"Долгоживущий план завершён ({state}).\n\n"
+        f"Цель: {plan['goal']}\n\n"
+        f"Что вышло по шагам:\n" + "\n".join(rendered) + "\n\n"
+        "Напиши пользователю итог: что удалось, что нет, что делать дальше. "
+        "Без пересказа процесса — только результат и следующий шаг."
+    )
+    try:
+        summary = await agent.ainvoke(
+            message=prompt,
+            thread_id=plan_thread_id(plan["id"]),
+            user_id="plan",
+            session_id=str(plan["chat_id"] or plan["id"]),
+            source_kind="user",
+            persist_user_turn=False,
+        )
+    except Exception as e:
+        log.error("Plan #%s summary failed: %s", plan["id"], e)
+        summary = ""
+
+    text = (summary or "").strip() or fallback
+    plans.set_summary(plan["id"], text)
+    await _deliver(plan, text)
+
+
+async def _check_condition(plan: dict, step: dict) -> tuple[bool, str]:
+    """Ask a parked step's condition. Returns (may run, what was observed)."""
+    spec = plans.wait_spec(step)
+    if not spec:
+        return True, ""
+
+    verdict = await plan_conditions.evaluate(spec, step=step, plan=plan)
+    if verdict.notes:
+        log.info("Step #%s condition notes: %s", step["id"], "; ".join(verdict.notes))
+
+    if verdict.fired:
+        plans.release_step(step["id"])
+        return True, verdict.detail
+
+    plans.note_check(step["id"], verdict.next_check_at)
+    return False, ""
+
+
+async def _retire_expired() -> None:
+    """Mark plans that ran out of time. The summary pass reports them."""
+    for plan in plans.expired_plans(settings.agent_name):
+        plans.expire_plan(plan["id"])
+
+
+async def _deliver_pending_summaries(limit: int) -> int:
+    """Close out plans that finished but have not said so yet. Returns how many.
+
+    A plan owes the owner a summary until it has one, which is also what makes
+    this crash-safe: the marker is the empty summary on a finished plan, not a
+    variable in a loop that just died.
+    """
+    if limit <= 0:
+        return 0
+    pending = plans.plans_awaiting_summary(settings.agent_name, limit=limit)
+    for plan in pending:
+        await _summarize(plan, "выполнен" if plan["state"] == plans.PLAN_DONE else "не удался")
+    return len(pending)
+
+
+async def run_due_plan_steps() -> None:
+    """One cycle: retire what timed out, report what closed, run what is ready."""
+    await _retire_expired()
+    # Last cycle's leftovers first: a finished plan is what the owner is waiting
+    # for, and it should not queue behind other plans' steps.
+    summaries = MAX_SUMMARIES_PER_CYCLE - await _deliver_pending_summaries(MAX_SUMMARIES_PER_CYCLE)
+
+    ready = plans.ready_steps(settings.agent_name)
+    if not ready:
+        return
+
+    ran = 0
+    checks = 0
+    seen_plans: set[int] = set()
+    touched_plans: set[int] = set()
+
+    for step in ready:
+        plan_id = step["plan_id"]
+        if plan_id in seen_plans:
+            continue  # one step per plan per cycle keeps plans from starving each other
+        if ran >= MAX_STEPS_PER_CYCLE:
+            break
+
+        plan = plans.get_plan(plan_id)
+        if not plan or plan["state"] != plans.PLAN_ACTIVE:
+            continue
+
+        if plans.wait_spec(step):
+            if checks >= MAX_CHECKS_PER_CYCLE:
+                break
+            checks += 1
+            may_run, observation = await _check_condition(plan, step)
+            if not may_run:
+                continue
+        else:
+            observation = ""
+
+        seen_plans.add(plan_id)
+        touched_plans.add(plan_id)
+        await _run_step(plan, plans.get_step(step["id"]), observation)
+        ran += 1
+
+    for plan_id in touched_plans:
+        plans.settle_plan(plan_id)
+    # Anything that just closed gets its summary now rather than a minute later;
+    # what does not fit in the cycle's budget is still owed one.
+    await _deliver_pending_summaries(summaries)

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -194,6 +194,6 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
         nexus_jobs_registered = 4
 
     total = (
-        21 + nexus_jobs_registered
-    )  # +reminders +handoff/council/memory intake +sla-escalation +swarm-weekly-report +persona-evolution; signal-jobs, travel insights, people-scout and group-digest paused
+        22 + nexus_jobs_registered
+    )  # +reminders +plan-steps +handoff/council/memory intake +sla-escalation +swarm-weekly-report +persona-evolution; signal-jobs, travel insights, people-scout and group-digest paused
     log.info("%d cron jobs registered for agent '%s'", total, me)

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -40,6 +40,7 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     from kronos.cron.news_monitor import run_news_monitor
     from kronos.cron.persona_evolve import run_persona_evolution
     from kronos.cron.personal_observer import run_daily_scope, run_personal_observer
+    from kronos.cron.plans import run_due_plan_steps
     from kronos.cron.reminders import run_due_reminders
     from kronos.cron.self_improve import run_self_improve
     from kronos.cron.signal_ideas import run_ideas_digest
@@ -66,6 +67,10 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
 
     # User-scheduled reminders / tasks — poll every minute (roadmap 4.2)
     scheduler.add_periodic("user-reminders", run_due_reminders, interval_seconds=60)
+
+    # Long-lived plans — poll every minute. Cheap when nothing is due: a cycle
+    # with no ready step is one indexed query.
+    scheduler.add_periodic("plan-steps", run_due_plan_steps, interval_seconds=60)
 
     # Cross-agent hand-off intake — poll every 30s (roadmap 5.1)
     scheduler.add_periodic("handoff-intake", run_handoff_intake, interval_seconds=30)

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -112,6 +112,12 @@ class KronosAgent:
 
         self._tools.extend(ACCOUNT_TOOLS)
 
+        # Work that will not finish in this conversation: a goal, steps, and what
+        # each step waits for. The cron poller is what actually runs them.
+        from kronos.tools.plans_tools import PLAN_TOOLS
+
+        self._tools.extend(PLAN_TOOLS)
+
         # Browser tools (stateful session; the acquire tools cover one-off reads)
         from kronos.tools.browser.tools import get_browser_tools
 

--- a/kronos/plan_conditions.py
+++ b/kronos/plan_conditions.py
@@ -1,0 +1,340 @@
+"""What a step can wait for, and how the poller finds out.
+
+Each condition is a small deterministic question asked on a schedule: has the
+time come, does this page still say that, has the number on it dropped below
+what I care about, has the owner said anything. Nothing here calls a model — a
+condition that costs a model call every few minutes would make waiting the
+expensive part, when waiting is supposed to be the cheap part.
+
+The verdict carries a `detail` string, and that string reaches the woken step's
+prompt. It is deliberately the *observation* ("price is now 8 750 000, below
+9 000 000") rather than a bare "fired": the step's whole job is usually to react
+to what changed, and re-deriving it would mean fetching the page twice.
+
+Conditions are validated when the step is parked, not when it wakes. A bad regex
+or a URL the egress policy forbids should be a refusal the agent can see and fix
+in the same turn, not a failure discovered next Tuesday.
+"""
+
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+
+log = logging.getLogger("kronos.plan_conditions")
+
+KIND_AT = "at"
+KIND_MANUAL = "manual"
+KIND_PAGE_MATCHES = "page_matches"
+KIND_PAGE_NUMBER = "page_number"
+KIND_REPLY = "reply"
+KINDS = (KIND_AT, KIND_MANUAL, KIND_PAGE_MATCHES, KIND_PAGE_NUMBER, KIND_REPLY)
+
+# A page condition that re-fetched every minute would be a small crawler pointed
+# at one site for weeks. Five minutes is the floor, an hour the default.
+MIN_INTERVAL_SECONDS = 300
+DEFAULT_INTERVAL_SECONDS = 3600
+# The cheap conditions read the local database, so they can look more often.
+CHEAP_INTERVAL_SECONDS = 300
+# Long enough that a manually released step never wakes on its own; the plan's
+# own expiry is what ends it.
+NEVER_SECONDS = 400 * 86400
+
+MAX_PATTERN_LENGTH = 200
+MAX_DETAIL_CHARS = 400
+
+OP_BELOW = "below"
+OP_ABOVE = "above"
+OPS = (OP_BELOW, OP_ABOVE)
+
+
+class ConditionError(Exception):
+    """Raised when a condition is malformed — while it can still be corrected."""
+
+
+@dataclass
+class Verdict:
+    fired: bool
+    detail: str = ""
+    next_check_at: float = 0.0
+    notes: list[str] = field(default_factory=list)
+
+
+def _interval(spec: dict, *, floor: int, default: int) -> int:
+    raw = spec.get("every_seconds", default)
+    try:
+        seconds = int(float(raw))
+    except (TypeError, ValueError) as e:
+        raise ConditionError(f"every_seconds must be a number, got {raw!r}") from e
+    return max(floor, seconds)
+
+
+def _url(spec: dict, *, tool: str) -> str:
+    from kronos.security.egress import check_url
+
+    url = str(spec.get("url") or "").strip()
+    if not url.startswith(("http://", "https://")):
+        raise ConditionError(f"{tool} needs a url starting with http:// or https://")
+    # The same allowlist the fetch tools obey. Checked here so a forbidden host
+    # is refused while the agent is still in the turn that asked for it.
+    check_url(url, tool=tool)
+    return url
+
+
+def _pattern(spec: dict, *, want_group: bool) -> re.Pattern:
+    raw = str(spec.get("pattern") or "")
+    if not raw:
+        raise ConditionError("this condition needs a pattern")
+    if len(raw) > MAX_PATTERN_LENGTH:
+        raise ConditionError(f"pattern is longer than {MAX_PATTERN_LENGTH} characters")
+    try:
+        compiled = re.compile(raw, re.IGNORECASE)
+    except re.error as e:
+        raise ConditionError(f"pattern is not a valid regular expression: {e}") from e
+    if want_group and compiled.groups < 1:
+        raise ConditionError("pattern must capture the number in a group, e.g. r'Rp ([\\d.,]+)'")
+    return compiled
+
+
+def normalize(spec: dict, *, now: float | None = None) -> tuple[dict, float]:
+    """Validate a condition and say when it should first be looked at.
+
+    Returns the cleaned spec and the initial wake time. Page conditions get
+    wake time 0 — checked on the next cycle — because a price that is *already*
+    below the threshold should not have to drop twice.
+    """
+    stamp = time.time() if now is None else now
+    if not isinstance(spec, dict):
+        raise ConditionError("a condition must be an object")
+    kind = str(spec.get("kind") or "").strip().lower()
+    if kind not in KINDS:
+        raise ConditionError(f"unknown condition '{kind}' (expected one of {', '.join(KINDS)})")
+
+    if kind == KIND_AT:
+        if "timestamp" in spec:
+            try:
+                when = float(spec["timestamp"])
+            except (TypeError, ValueError) as e:
+                raise ConditionError("timestamp must be a unix time") from e
+        else:
+            try:
+                seconds = float(spec.get("seconds", 0))
+            except (TypeError, ValueError) as e:
+                raise ConditionError("seconds must be a number") from e
+            if seconds <= 0:
+                raise ConditionError("'at' needs seconds > 0, or an absolute timestamp")
+            when = stamp + seconds
+        return {"kind": KIND_AT, "timestamp": when}, when
+
+    if kind == KIND_MANUAL:
+        return {"kind": KIND_MANUAL, "note": str(spec.get("note") or "")[:200]}, stamp + NEVER_SECONDS
+
+    if kind == KIND_REPLY:
+        interval = _interval(spec, floor=CHEAP_INTERVAL_SECONDS, default=CHEAP_INTERVAL_SECONDS)
+        return {"kind": KIND_REPLY, "every_seconds": interval}, 0.0
+
+    if kind == KIND_PAGE_MATCHES:
+        url = _url(spec, tool="plan_wait_page_matches")
+        pattern = _pattern(spec, want_group=False)
+        return {
+            "kind": KIND_PAGE_MATCHES,
+            "url": url,
+            "pattern": pattern.pattern,
+            "absent": bool(spec.get("absent", False)),
+            "every_seconds": _interval(spec, floor=MIN_INTERVAL_SECONDS, default=DEFAULT_INTERVAL_SECONDS),
+        }, 0.0
+
+    url = _url(spec, tool="plan_wait_page_number")
+    pattern = _pattern(spec, want_group=True)
+    op = str(spec.get("op") or "").strip().lower()
+    if op not in OPS:
+        raise ConditionError(f"op must be one of {', '.join(OPS)}")
+    try:
+        value = float(spec["value"])
+    except (KeyError, TypeError, ValueError) as e:
+        raise ConditionError("page_number needs a numeric value to compare against") from e
+    return {
+        "kind": KIND_PAGE_NUMBER,
+        "url": url,
+        "pattern": pattern.pattern,
+        "op": op,
+        "value": value,
+        "every_seconds": _interval(spec, floor=MIN_INTERVAL_SECONDS, default=DEFAULT_INTERVAL_SECONDS),
+    }, 0.0
+
+
+def describe(spec: dict) -> str:
+    """One line an owner can read in a list of plans."""
+    kind = spec.get("kind")
+    if kind == KIND_AT:
+        return f"until {time.strftime('%Y-%m-%d %H:%M', time.localtime(spec.get('timestamp', 0)))}"
+    if kind == KIND_MANUAL:
+        note = spec.get("note")
+        return f"for you to resume it{f' ({note})' if note else ''}"
+    if kind == KIND_REPLY:
+        return "for your reply"
+    if kind == KIND_PAGE_MATCHES:
+        verb = "stops matching" if spec.get("absent") else "matches"
+        return f"until {spec.get('url', '')} {verb} /{spec.get('pattern', '')}/"
+    if kind == KIND_PAGE_NUMBER:
+        return f"until the number on {spec.get('url', '')} is {spec.get('op')} {format_number(spec.get('value', 0))}"
+    return "for something unrecognised"
+
+
+def parse_number(text: str) -> float | None:
+    """Read a price the way a page writes one.
+
+    Handles 1.234.567 / 1,234,567 / 8750000 / 1 234,56 — thousands separators and
+    a decimal comma are both normal on the sites this exists for, and a wrong
+    reading here is a notification that never comes or one that comes falsely.
+    """
+    cleaned = re.sub(r"[^\d.,]", "", text or "")
+    if not cleaned:
+        return None
+    # The last separator is a decimal point only when 1–2 digits follow it.
+    match = re.search(r"[.,](\d{1,2})$", cleaned)
+    if match and len(re.sub(r"\D", "", cleaned)) > len(match.group(1)):
+        whole = re.sub(r"\D", "", cleaned[: match.start()])
+        try:
+            return float(f"{whole}.{match.group(1)}")
+        except ValueError:
+            return None
+    digits = re.sub(r"\D", "", cleaned)
+    try:
+        return float(digits) if digits else None
+    except ValueError:
+        return None
+
+
+def format_number(value: float) -> str:
+    """A price a person can read. `%g` would turn 8750000 into 8.75e+06."""
+    if float(value).is_integer():
+        return f"{int(value):,}"
+    return f"{value:,.2f}"
+
+
+async def _page_text(url: str, *, tool: str) -> tuple[str, list[str]]:
+    from kronos.security.egress import check_url
+    from kronos.tools.acquire import fetch_tiered, html_to_text
+
+    # Re-checked at wake time: the allowlist can be tightened while a plan waits,
+    # and a plan is not a way around the policy that is in force now.
+    check_url(url, tool=tool)
+    _, raw, notes = await fetch_tiered(url)
+    text = html_to_text(raw) if "<" in raw[:2000] else raw
+    return text, notes
+
+
+async def _owner_spoke_since(plan: dict, since: float) -> bool:
+    """Whether a turn started in the owner's own thread after the step parked.
+
+    Plan steps run in their own thread (``plan:<id>``), so the agent's own work
+    cannot be mistaken for the owner speaking.
+    """
+    thread_id = str(plan.get("thread_id") or "")
+    if not thread_id:
+        return False
+
+    from kronos.config import settings
+    from kronos.session import SessionStore
+
+    store = SessionStore(settings.db_path, agent_name=settings.agent_name)
+    turns = await store.list_turns(thread_id=thread_id, limit=5)
+    for turn in turns:
+        started = turn.get("started_at")
+        if started and _as_epoch(started) > since:
+            return True
+    return False
+
+
+def _as_epoch(value) -> float:
+    """SQLite CURRENT_TIMESTAMP is a UTC string; turn it into seconds."""
+    if isinstance(value, int | float):
+        return float(value)
+    from datetime import UTC, datetime
+
+    for fmt in ("%Y-%m-%d %H:%M:%S.%f", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(str(value), fmt).replace(tzinfo=UTC).timestamp()
+        except ValueError:
+            continue
+    log.debug("Cannot read turn timestamp %r", value)
+    return 0.0
+
+
+async def evaluate(spec: dict, *, step: dict, plan: dict, now: float | None = None) -> Verdict:
+    """Ask the condition whether it is time. Never raises for a network failure.
+
+    A page that cannot be fetched is *not* a fired condition and not a failure
+    either — it is a check that did not happen, and the next one may work. That
+    distinction is the difference between "the price dropped" and "the site was
+    down", which must never be confused.
+    """
+    stamp = time.time() if now is None else now
+    kind = spec.get("kind")
+
+    if kind == KIND_AT:
+        when = float(spec.get("timestamp") or 0)
+        if stamp >= when:
+            return Verdict(True, "the time you set has come")
+        return Verdict(False, next_check_at=when)
+
+    if kind == KIND_MANUAL:
+        return Verdict(False, next_check_at=stamp + NEVER_SECONDS)
+
+    if kind == KIND_REPLY:
+        interval = int(spec.get("every_seconds") or CHEAP_INTERVAL_SECONDS)
+        try:
+            spoke = await _owner_spoke_since(plan, float(step.get("parked_at") or 0))
+        except Exception as e:
+            log.warning("Reply check failed for step %s: %s", step.get("id"), e)
+            return Verdict(False, next_check_at=stamp + interval, notes=[f"could not check for a reply: {e}"])
+        if spoke:
+            return Verdict(True, "you replied in the chat this plan came from")
+        return Verdict(False, next_check_at=stamp + interval)
+
+    if kind in (KIND_PAGE_MATCHES, KIND_PAGE_NUMBER):
+        interval = int(spec.get("every_seconds") or DEFAULT_INTERVAL_SECONDS)
+        url = str(spec.get("url") or "")
+        try:
+            text, notes = await _page_text(url, tool=f"plan_{kind}")
+        except Exception as e:
+            log.info("Condition check for step %s could not read %s: %s", step.get("id"), url, e)
+            return Verdict(False, next_check_at=stamp + interval, notes=[f"could not read {url}: {e}"])
+
+        pattern = re.compile(str(spec.get("pattern") or ""), re.IGNORECASE)
+        match = pattern.search(text)
+
+        if kind == KIND_PAGE_MATCHES:
+            present = match is not None
+            want_absent = bool(spec.get("absent"))
+            if present != want_absent:
+                seen = match.group(0)[:MAX_DETAIL_CHARS] if match else ""
+                detail = f"{url} no longer matches /{pattern.pattern}/" if want_absent else f"{url} now shows: {seen}"
+                return Verdict(True, detail, notes=notes)
+            return Verdict(False, next_check_at=stamp + interval, notes=notes)
+
+        if match is None:
+            # The pattern is how the number is found; without it there is nothing
+            # to compare, and guessing would be worse than waiting.
+            return Verdict(
+                False,
+                next_check_at=stamp + interval,
+                notes=notes + [f"pattern /{pattern.pattern}/ did not match {url}"],
+            )
+        number = parse_number(match.group(1))
+        if number is None:
+            return Verdict(
+                False,
+                next_check_at=stamp + interval,
+                notes=notes + [f"could not read a number from {match.group(1)!r}"],
+            )
+        target = float(spec.get("value") or 0)
+        fired = number < target if spec.get("op") == OP_BELOW else number > target
+        if fired:
+            detail = f"the number on {url} is {format_number(number)}, {spec.get('op')} {format_number(target)}"
+            return Verdict(True, detail, notes=notes)
+        return Verdict(False, next_check_at=stamp + interval, notes=notes)
+
+    log.warning("Step %s waits on an unrecognised condition %r", step.get("id"), kind)
+    return Verdict(False, next_check_at=stamp + NEVER_SECONDS, notes=[f"unrecognised condition {kind!r}"])

--- a/kronos/plans.py
+++ b/kronos/plans.py
@@ -428,6 +428,25 @@ def cancel_plan(plan_id: int, agent_name: str, now: float | None = None) -> bool
     return cursor.rowcount > 0
 
 
+def plans_awaiting_summary(agent_name: str, *, limit: int = 5) -> list[dict]:
+    """Finished plans that have not told the owner how it went yet.
+
+    The marker is the state plus an empty summary, not a variable in the poller's
+    loop — so a crash between finishing and reporting loses nothing, and a plan
+    stays owed its summary until it has one. Cancelled plans are not owed one:
+    the owner did that on purpose.
+    """
+    rows = _db().read(
+        """
+        SELECT * FROM plans
+        WHERE agent_name = ? AND state IN (?, ?) AND summary = ''
+        ORDER BY updated_at LIMIT ?
+        """,
+        (agent_name, PLAN_DONE, PLAN_FAILED, limit),
+    )
+    return [dict(row) for row in rows]
+
+
 def expired_plans(agent_name: str, now: float | None = None) -> list[dict]:
     rows = _db().read(
         "SELECT * FROM plans WHERE agent_name = ? AND state = ? AND expires_at <= ?",

--- a/kronos/plans.py
+++ b/kronos/plans.py
@@ -1,0 +1,451 @@
+"""Plans: work that outlives a turn.
+
+The durable machinery elsewhere in this codebase protects a **turn** — minutes,
+at most twenty-five model steps, resumable after a crash. Some work does not fit
+in that shape at all: *ask three landlords, wait for their answers, compare what
+comes back*. That is days, mostly spent waiting, and the waiting is the point.
+
+A plan is a goal plus steps. A step holds a prompt, what it depends on, and
+optionally a condition it waits for. The poller (`kronos.cron.plans`) picks up
+steps whose dependencies are settled and whose condition has fired, and runs each
+one as an ordinary agent turn — so durable turns, the effects ledger, approvals
+and the cost guardian all apply unchanged. Nothing here re-implements them.
+
+Two decisions worth knowing:
+
+* **A dependency is satisfied when it is finished, not when it succeeded.** Three
+  landlords were asked; one never replies and that step fails. The comparison
+  step still runs, with two answers and one stated absence. Cascading skips would
+  turn one silent landlord into no answer at all.
+* **A plan has an expiry.** A condition that never fires would otherwise leave a
+  step in the poller forever, costing a little on every cycle and never
+  admitting it failed. Expiry is what makes "still waiting" eventually become
+  "this did not work".
+"""
+
+import json
+import logging
+import time
+
+from kronos.db import get_db
+
+log = logging.getLogger("kronos.plans")
+
+PLAN_ACTIVE = "active"
+PLAN_DONE = "done"
+PLAN_FAILED = "failed"
+PLAN_CANCELLED = "cancelled"
+PLAN_TERMINAL = (PLAN_DONE, PLAN_FAILED, PLAN_CANCELLED)
+
+STEP_PENDING = "pending"
+STEP_WAITING = "waiting"
+STEP_RUNNING = "running"
+STEP_DONE = "done"
+STEP_FAILED = "failed"
+# Terminal for dependency purposes: a dependent step may proceed once every step
+# it names has stopped moving, whatever the outcome.
+STEP_TERMINAL = (STEP_DONE, STEP_FAILED)
+
+# Bounds. Every one of these exists because its absence is a way for a plan to
+# quietly cost money forever.
+MAX_STEPS_PER_PLAN = 50
+MAX_STEP_ATTEMPTS = 3
+MAX_CONDITION_CHECKS = 5000
+DEFAULT_TTL_SECONDS = 90 * 86400
+
+
+class PlanError(Exception):
+    """Raised when a plan or step is missing, or a bound was reached."""
+
+
+def _init_schema(conn) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS plans (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_name  TEXT    NOT NULL,
+            goal        TEXT    NOT NULL,
+            state       TEXT    NOT NULL DEFAULT 'active',
+            chat_id     INTEGER NOT NULL DEFAULT 0,
+            topic_id    INTEGER,
+            thread_id   TEXT    NOT NULL DEFAULT '',
+            summary     TEXT    NOT NULL DEFAULT '',
+            created_at  REAL    NOT NULL,
+            updated_at  REAL    NOT NULL,
+            expires_at  REAL    NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS plan_steps (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            plan_id     INTEGER NOT NULL,
+            seq         INTEGER NOT NULL,
+            title       TEXT    NOT NULL DEFAULT '',
+            prompt      TEXT    NOT NULL,
+            state       TEXT    NOT NULL DEFAULT 'pending',
+            -- Comma-separated step ids. Several, because "wait for all three
+            -- landlords" is the shape this exists for.
+            depends_on  TEXT    NOT NULL DEFAULT '',
+            wait_json   TEXT    NOT NULL DEFAULT '',
+            wake_at     REAL    NOT NULL DEFAULT 0,
+            parked_at   REAL    NOT NULL DEFAULT 0,
+            checks      INTEGER NOT NULL DEFAULT 0,
+            attempts    INTEGER NOT NULL DEFAULT 0,
+            notify      INTEGER NOT NULL DEFAULT 0,
+            result      TEXT    NOT NULL DEFAULT '',
+            created_at  REAL    NOT NULL,
+            updated_at  REAL    NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_plan_steps_plan ON plan_steps(plan_id, seq);
+        CREATE INDEX IF NOT EXISTS idx_plan_steps_open ON plan_steps(state, wake_at);
+        CREATE INDEX IF NOT EXISTS idx_plans_open ON plans(agent_name, state);
+        """
+    )
+
+
+def _db():
+    db = get_db("plans")
+    db.init_schema(_init_schema)
+    return db
+
+
+def _now(now: float | None = None) -> float:
+    return time.time() if now is None else now
+
+
+def _row(row) -> dict:
+    return dict(row) if row is not None else {}
+
+
+def dependency_ids(step: dict) -> list[int]:
+    return [int(part) for part in str(step.get("depends_on") or "").split(",") if part.strip()]
+
+
+def wait_spec(step: dict) -> dict:
+    """The step's parked condition, or {} when it simply waits its turn."""
+    raw = step.get("wait_json") or ""
+    if not raw:
+        return {}
+    try:
+        spec = json.loads(raw)
+    except json.JSONDecodeError:
+        log.warning("Step %s has an unreadable condition: %r", step.get("id"), raw)
+        return {}
+    return spec if isinstance(spec, dict) else {}
+
+
+# --- creating -----------------------------------------------------------------
+
+
+def create_plan(
+    *,
+    agent_name: str,
+    goal: str,
+    chat_id: int = 0,
+    topic_id: int | None = None,
+    thread_id: str = "",
+    ttl_seconds: float = DEFAULT_TTL_SECONDS,
+    now: float | None = None,
+) -> int:
+    goal = goal.strip()
+    if not goal:
+        raise PlanError("a plan needs a goal")
+    stamp = _now(now)
+    cursor = _db().write(
+        """
+        INSERT INTO plans (agent_name, goal, state, chat_id, topic_id, thread_id,
+                           created_at, updated_at, expires_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (agent_name, goal, PLAN_ACTIVE, chat_id, topic_id, thread_id, stamp, stamp, stamp + ttl_seconds),
+    )
+    plan_id = int(cursor.lastrowid)
+    log.info("Plan #%s created: %s", plan_id, goal[:80])
+    return plan_id
+
+
+def add_step(
+    plan_id: int,
+    prompt: str,
+    *,
+    title: str = "",
+    depends_on: list[int] | None = None,
+    wait: dict | None = None,
+    notify: bool = False,
+    now: float | None = None,
+) -> int:
+    """Append a step. ``wait`` parks it until a condition fires.
+
+    The condition is stored opaquely — this module does not know what
+    ``page_number`` means, only when to hand the step to whoever does.
+    """
+    plan = get_plan(plan_id)
+    if not plan:
+        raise PlanError(f"no plan #{plan_id}")
+    if plan["state"] != PLAN_ACTIVE:
+        raise PlanError(f"plan #{plan_id} is {plan['state']}, not active")
+
+    existing = steps_of(plan_id)
+    if len(existing) >= MAX_STEPS_PER_PLAN:
+        raise PlanError(f"plan #{plan_id} already has {MAX_STEPS_PER_PLAN} steps")
+
+    known = {step["id"] for step in existing}
+    deps = [int(d) for d in (depends_on or [])]
+    unknown = [d for d in deps if d not in known]
+    if unknown:
+        raise PlanError(f"step depends on {unknown}, which is not part of plan #{plan_id}")
+
+    stamp = _now(now)
+    state = STEP_WAITING if wait else STEP_PENDING
+    cursor = _db().write(
+        """
+        INSERT INTO plan_steps (plan_id, seq, title, prompt, state, depends_on, wait_json,
+                                wake_at, parked_at, notify, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            plan_id,
+            len(existing) + 1,
+            title.strip(),
+            prompt.strip(),
+            state,
+            ",".join(str(d) for d in deps),
+            json.dumps(wait, ensure_ascii=False) if wait else "",
+            0.0,
+            stamp if wait else 0.0,
+            1 if notify else 0,
+            stamp,
+            stamp,
+        ),
+    )
+    _touch_plan(plan_id, stamp)
+    return int(cursor.lastrowid)
+
+
+# --- reading ------------------------------------------------------------------
+
+
+def get_plan(plan_id: int) -> dict:
+    return _row(_db().read_one("SELECT * FROM plans WHERE id = ?", (plan_id,)))
+
+
+def get_step(step_id: int) -> dict:
+    return _row(_db().read_one("SELECT * FROM plan_steps WHERE id = ?", (step_id,)))
+
+
+def steps_of(plan_id: int) -> list[dict]:
+    return [dict(row) for row in _db().read("SELECT * FROM plan_steps WHERE plan_id = ? ORDER BY seq", (plan_id,))]
+
+
+def list_plans(agent_name: str, *, state: str = "", limit: int = 50) -> list[dict]:
+    """Plans newest first. Empty ``state`` means the open ones."""
+    if state:
+        rows = _db().read(
+            "SELECT * FROM plans WHERE agent_name = ? AND state = ? ORDER BY id DESC LIMIT ?",
+            (agent_name, state, limit),
+        )
+    else:
+        rows = _db().read(
+            "SELECT * FROM plans WHERE agent_name = ? AND state = ? ORDER BY id DESC LIMIT ?",
+            (agent_name, PLAN_ACTIVE, limit),
+        )
+    return [dict(row) for row in rows]
+
+
+def dependency_results(step: dict) -> list[dict]:
+    """What the steps this one waited for actually produced."""
+    ids = dependency_ids(step)
+    if not ids:
+        return []
+    placeholders = ",".join("?" for _ in ids)
+    rows = _db().read(f"SELECT * FROM plan_steps WHERE id IN ({placeholders}) ORDER BY seq", tuple(ids))
+    return [dict(row) for row in rows]
+
+
+def open_steps(agent_name: str) -> list[dict]:
+    """Every step of an active plan that has not finished, soonest wake first."""
+    rows = _db().read(
+        """
+        SELECT s.* FROM plan_steps s
+        JOIN plans p ON p.id = s.plan_id
+        WHERE p.agent_name = ? AND p.state = ? AND s.state IN (?, ?)
+        ORDER BY s.wake_at, s.seq
+        """,
+        (agent_name, PLAN_ACTIVE, STEP_PENDING, STEP_WAITING),
+    )
+    return [dict(row) for row in rows]
+
+
+def ready_steps(agent_name: str, now: float | None = None) -> list[dict]:
+    """Steps whose dependencies are settled and whose wake time has come.
+
+    A parked step is returned so its condition can be evaluated — whether it may
+    actually run is that condition's answer, not this function's.
+    """
+    stamp = _now(now)
+    ready = []
+    for step in open_steps(agent_name):
+        if step["wake_at"] and step["wake_at"] > stamp:
+            continue
+        if not _dependencies_settled(step):
+            continue
+        ready.append(step)
+    return ready
+
+
+def _dependencies_settled(step: dict) -> bool:
+    return all(dep.get("state") in STEP_TERMINAL for dep in dependency_results(step))
+
+
+# --- moving a step along ------------------------------------------------------
+
+
+def mark_running(step_id: int, now: float | None = None) -> None:
+    stamp = _now(now)
+    _db().write(
+        "UPDATE plan_steps SET state = ?, attempts = attempts + 1, updated_at = ? WHERE id = ?",
+        (STEP_RUNNING, stamp, step_id),
+    )
+
+
+def finish_step(step_id: int, result: str, now: float | None = None) -> None:
+    stamp = _now(now)
+    _db().write(
+        "UPDATE plan_steps SET state = ?, result = ?, updated_at = ? WHERE id = ?",
+        (STEP_DONE, result, stamp, step_id),
+    )
+    step = get_step(step_id)
+    if step:
+        _touch_plan(step["plan_id"], stamp)
+
+
+def fail_step(step_id: int, error: str, now: float | None = None) -> bool:
+    """Record a failed attempt. Returns whether the step is now given up on.
+
+    Below the attempt limit the step goes back to pending and the next cycle
+    retries it — a transient network failure should not end a week-long plan.
+    """
+    stamp = _now(now)
+    step = get_step(step_id)
+    if not step:
+        raise PlanError(f"no step #{step_id}")
+
+    if step["attempts"] >= MAX_STEP_ATTEMPTS:
+        _db().write(
+            "UPDATE plan_steps SET state = ?, result = ?, updated_at = ? WHERE id = ?",
+            (STEP_FAILED, f"failed after {step['attempts']} attempts: {error}", stamp, step_id),
+        )
+        _touch_plan(step["plan_id"], stamp)
+        return True
+
+    _db().write(
+        "UPDATE plan_steps SET state = ?, result = ?, wake_at = ?, updated_at = ? WHERE id = ?",
+        (STEP_PENDING, f"attempt {step['attempts']} failed: {error}", stamp + 60, stamp, step_id),
+    )
+    _touch_plan(step["plan_id"], stamp)
+    return False
+
+
+def park_step(step_id: int, wait: dict, *, wake_at: float = 0.0, now: float | None = None) -> None:
+    """Put a step back to waiting on a condition."""
+    stamp = _now(now)
+    _db().write(
+        """
+        UPDATE plan_steps
+        SET state = ?, wait_json = ?, wake_at = ?, parked_at = ?, updated_at = ?
+        WHERE id = ?
+        """,
+        (STEP_WAITING, json.dumps(wait, ensure_ascii=False), wake_at, stamp, stamp, step_id),
+    )
+
+
+def note_check(step_id: int, next_check_at: float, now: float | None = None) -> bool:
+    """A condition was evaluated and had not fired. Returns whether to give up.
+
+    Counting checks bounds a condition that can never fire — a page that stopped
+    existing, a threshold nothing will reach.
+    """
+    stamp = _now(now)
+    step = get_step(step_id)
+    if not step:
+        raise PlanError(f"no step #{step_id}")
+    checks = step["checks"] + 1
+    if checks >= MAX_CONDITION_CHECKS:
+        _db().write(
+            "UPDATE plan_steps SET state = ?, checks = ?, result = ?, updated_at = ? WHERE id = ?",
+            (STEP_FAILED, checks, f"condition never fired in {checks} checks", stamp, step_id),
+        )
+        _touch_plan(step["plan_id"], stamp)
+        return True
+    _db().write(
+        "UPDATE plan_steps SET checks = ?, wake_at = ?, state = ?, updated_at = ? WHERE id = ?",
+        (checks, next_check_at, STEP_WAITING, stamp, step_id),
+    )
+    return False
+
+
+def release_step(step_id: int, now: float | None = None) -> None:
+    """The condition fired: the step is now merely pending."""
+    stamp = _now(now)
+    _db().write(
+        "UPDATE plan_steps SET state = ?, wait_json = '', wake_at = 0, updated_at = ? WHERE id = ?",
+        (STEP_PENDING, stamp, step_id),
+    )
+
+
+# --- moving a plan along ------------------------------------------------------
+
+
+def _touch_plan(plan_id: int, stamp: float) -> None:
+    _db().write("UPDATE plans SET updated_at = ? WHERE id = ?", (stamp, plan_id))
+
+
+def set_summary(plan_id: int, summary: str, now: float | None = None) -> None:
+    _db().write(
+        "UPDATE plans SET summary = ?, updated_at = ? WHERE id = ?",
+        (summary.strip(), _now(now), plan_id),
+    )
+
+
+def settle_plan(plan_id: int, now: float | None = None) -> str:
+    """Close a plan whose steps have all stopped moving. Returns its state.
+
+    A plan with no step that reached ``done`` is a failure; anything else is a
+    plan that got somewhere, and its summary says what did not work.
+    """
+    steps = steps_of(plan_id)
+    if not steps or any(step["state"] not in STEP_TERMINAL for step in steps):
+        return PLAN_ACTIVE
+    state = PLAN_DONE if any(step["state"] == STEP_DONE for step in steps) else PLAN_FAILED
+    _db().write("UPDATE plans SET state = ?, updated_at = ? WHERE id = ?", (state, _now(now), plan_id))
+    log.info("Plan #%s %s", plan_id, state)
+    return state
+
+
+def cancel_plan(plan_id: int, agent_name: str, now: float | None = None) -> bool:
+    cursor = _db().write(
+        "UPDATE plans SET state = ?, updated_at = ? WHERE id = ? AND agent_name = ? AND state = ?",
+        (PLAN_CANCELLED, _now(now), plan_id, agent_name, PLAN_ACTIVE),
+    )
+    return cursor.rowcount > 0
+
+
+def expired_plans(agent_name: str, now: float | None = None) -> list[dict]:
+    rows = _db().read(
+        "SELECT * FROM plans WHERE agent_name = ? AND state = ? AND expires_at <= ?",
+        (agent_name, PLAN_ACTIVE, _now(now)),
+    )
+    return [dict(row) for row in rows]
+
+
+def expire_plan(plan_id: int, now: float | None = None) -> None:
+    """Give up on a plan that ran out of time, saying so rather than vanishing."""
+    stamp = _now(now)
+    _db().write_many(
+        [
+            (
+                "UPDATE plan_steps SET state = ?, result = ?, updated_at = ? WHERE plan_id = ? AND state IN (?, ?)",
+                (STEP_FAILED, "plan expired before this step could run", stamp, plan_id, STEP_PENDING, STEP_WAITING),
+            ),
+            ("UPDATE plans SET state = ?, updated_at = ? WHERE id = ?", (PLAN_FAILED, stamp, plan_id)),
+        ]
+    )
+    log.info("Plan #%s expired", plan_id)

--- a/kronos/tools/plans_tools.py
+++ b/kronos/tools/plans_tools.py
@@ -1,0 +1,219 @@
+"""Letting the agent declare work that will not finish today.
+
+The turn the plan is written in is short; the plan is not. So these tools only
+*declare* — a goal, steps, and what each step waits for. The poller
+(`kronos.cron.plans`) is what runs them, one at a time, for as long as it takes.
+
+Waiting conditions are passed as JSON because they are structured and vary by
+kind, and a malformed one is refused with the reason attached — an agent that
+gets "op must be one of below, above" can fix it in the same turn, which is the
+whole reason validation happens here rather than next Tuesday.
+"""
+
+import json
+import logging
+
+from langchain_core.tools import tool
+
+from kronos import plan_conditions, plans
+from kronos.audit import get_tool_audit_context
+from kronos.config import settings
+from kronos.security.effects import mark_side_effect
+
+log = logging.getLogger("kronos.tools.plans")
+
+MAX_LISTED_STEPS = 20
+
+
+def _chat_context() -> tuple[int, str, int | None]:
+    """(chat_id, thread_id, topic_id) of the request, so results can come back."""
+    ctx = get_tool_audit_context()
+    chat_raw = ctx.get("session_id", "")
+    thread_id = ctx.get("thread_id", "")
+    topic_id = None
+    _, sep, tail = thread_id.partition(":")
+    if sep and tail.isdigit():
+        topic_id = int(tail)
+    try:
+        chat_id = int(chat_raw)
+    except (TypeError, ValueError):
+        chat_id = 0
+    return chat_id, thread_id, topic_id
+
+
+def _parse_wait(raw: str) -> tuple[dict | None, str]:
+    """(condition, error). Empty input means the step simply waits its turn."""
+    raw = (raw or "").strip()
+    if not raw:
+        return None, ""
+    try:
+        spec = json.loads(raw)
+    except json.JSONDecodeError as e:
+        return None, f"wait должен быть JSON-объектом: {e}"
+    try:
+        normalized, _ = plan_conditions.normalize(spec)
+    except plan_conditions.ConditionError as e:
+        return None, f"Условие ожидания не годится: {e}"
+    except Exception as e:  # egress policy, mostly
+        return None, f"Условие ожидания отклонено: {e}"
+    return normalized, ""
+
+
+def _parse_after(raw: str) -> tuple[list[int], str]:
+    ids = []
+    for part in (raw or "").replace(" ", "").split(","):
+        if not part:
+            continue
+        if not part.lstrip("-").isdigit():
+            return [], f"after_steps должен быть списком номеров шагов, а не '{part}'"
+        ids.append(int(part))
+    return ids, ""
+
+
+def _render_plan(plan: dict, *, with_steps: bool = True) -> str:
+    lines = [f"План #{plan['id']} ({plan['state']}): {plan['goal']}"]
+    if plan.get("summary"):
+        lines.append(f"Итог: {plan['summary']}")
+    if not with_steps:
+        return "\n".join(lines)
+
+    for step in plans.steps_of(plan["id"])[:MAX_LISTED_STEPS]:
+        label = step["title"] or f"шаг {step['seq']}"
+        line = f"  #{step['id']} {label} — {step['state']}"
+        spec = plans.wait_spec(step)
+        if spec:
+            line += f", ждёт {plan_conditions.describe(spec)}"
+        deps = plans.dependency_ids(step)
+        if deps:
+            line += f", после {', '.join(f'#{d}' for d in deps)}"
+        if step["result"]:
+            line += f"\n     → {step['result'][:300]}"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+@tool
+def plan_start(goal: str, first_step: str, title: str = "") -> str:
+    """Start a plan: work that will take days and mostly consist of waiting.
+
+    Use this when the answer cannot be reached in this conversation — waiting for
+    replies, watching a price, checking back after an event. Do NOT use it for
+    work you can simply do now, or for a plain reminder (use schedule_task).
+
+    Add the remaining steps with plan_add_step. Each step runs later, on its own,
+    and its result is kept for the steps that depend on it.
+
+    Args:
+        goal: what the plan is for, in one sentence — the owner reads this.
+        first_step: what to do first, as an instruction to yourself.
+        title: optional short label for that first step.
+    """
+    chat_id, thread_id, topic_id = _chat_context()
+    try:
+        plan_id = plans.create_plan(
+            agent_name=settings.agent_name,
+            goal=goal,
+            chat_id=chat_id,
+            topic_id=topic_id,
+            thread_id=thread_id,
+        )
+        step_id = plans.add_step(plan_id, first_step, title=title)
+    except plans.PlanError as e:
+        return f"[ERROR] {e}"
+
+    return (
+        f"План #{plan_id} создан, шаг #{step_id} поставлен в очередь. "
+        f"Добавляй следующие шаги через plan_add_step(plan_id={plan_id}). "
+        f"Скажи пользователю, что вернёшься с результатом сам."
+    )
+
+
+@tool
+def plan_add_step(
+    plan_id: int,
+    task: str,
+    title: str = "",
+    after_steps: str = "",
+    wait: str = "",
+    notify: bool = False,
+) -> str:
+    """Add a step to a plan, optionally parked until something happens.
+
+    Args:
+        plan_id: which plan.
+        task: what to do, as an instruction to yourself when it wakes.
+        title: optional short label.
+        after_steps: step numbers this one needs first, e.g. "12,13". A step runs
+            once they have all finished — including any that failed, whose result
+            says so.
+        wait: JSON condition to wait for. One of:
+            {"kind":"at","seconds":86400} — or {"kind":"at","timestamp":<unix>}
+            {"kind":"manual","note":"after I view the flat"} — until the owner resumes it
+            {"kind":"reply"} — until the owner writes in the chat this plan came from
+            {"kind":"page_matches","url":"https://...","pattern":"in stock","absent":false}
+            {"kind":"page_number","url":"https://...","pattern":"Rp ([0-9.]+)","op":"below","value":9000000}
+            Page conditions accept "every_seconds" (minimum 300, default 3600).
+        notify: send this step's result to the owner as soon as it is done. Leave
+            false unless it is worth interrupting them for — the plan's closing
+            summary always reaches them anyway.
+    """
+    condition, error = _parse_wait(wait)
+    if error:
+        return f"[ERROR] {error}"
+    deps, error = _parse_after(after_steps)
+    if error:
+        return f"[ERROR] {error}"
+
+    try:
+        step_id = plans.add_step(
+            plan_id,
+            task,
+            title=title,
+            depends_on=deps,
+            wait=condition,
+            notify=notify,
+        )
+    except plans.PlanError as e:
+        return f"[ERROR] {e}"
+
+    waiting = f", ждёт {plan_conditions.describe(condition)}" if condition else ""
+    return f"Шаг #{step_id} добавлен в план #{plan_id}{waiting}."
+
+
+@tool
+def plan_status(plan_id: int = 0) -> str:
+    """Show your plans: what is running, what is waiting and for what.
+
+    Args:
+        plan_id: one plan, or 0 for every plan still running.
+    """
+    if plan_id:
+        plan = plans.get_plan(plan_id)
+        if not plan:
+            return f"[ERROR] Плана #{plan_id} нет."
+        return _render_plan(plan)
+
+    active = plans.list_plans(settings.agent_name)
+    if not active:
+        return "Активных планов нет."
+    return "\n\n".join(_render_plan(plan) for plan in active)
+
+
+@tool
+def plan_cancel(plan_id: int, reason: str = "") -> str:
+    """Stop a plan. Its waiting steps are dropped and nothing else runs.
+
+    Args:
+        plan_id: which plan.
+        reason: why, for the record.
+    """
+    if not plans.cancel_plan(plan_id, settings.agent_name):
+        return f"[ERROR] План #{plan_id} не найден или уже закрыт."
+    log.info("Plan #%s cancelled: %s", plan_id, reason or "no reason given")
+    return f"План #{plan_id} остановлен."
+
+
+# Declaring a plan schedules future model calls and future page fetches, which is
+# an effect outside this turn — durable resume must not replay it and create the
+# plan twice.
+PLAN_TOOLS = mark_side_effect([plan_start, plan_add_step, plan_cancel], reason="plans") + [plan_status]

--- a/tests/test_dashboard_plans.py
+++ b/tests/test_dashboard_plans.py
@@ -1,0 +1,133 @@
+"""The plans API — the only place a waiting plan is visible.
+
+Resume is the interesting endpoint: it is how a plan that parked itself for the
+owner gets going again, and the failure modes are silent ones (releasing a step
+of a cancelled plan, releasing a step that was not waiting).
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from kronos import plans
+from kronos.config import settings
+
+AGENT = "kronos"
+
+
+@pytest.fixture(autouse=True)
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
+    monkeypatch.setattr(settings, "agent_name", AGENT)
+    import kronos.db as _db
+
+    _db._instances.clear()
+    yield
+    _db._instances.clear()
+
+
+@pytest.fixture
+def client():
+    from dashboard.server import create_app
+
+    app = create_app()
+    # Auth is covered by test_dashboard_auth; here we exercise the endpoints.
+    from dashboard import auth
+
+    app.dependency_overrides[auth.verify_token] = lambda: True
+    return TestClient(app)
+
+
+def _plan(goal="найти жильё") -> int:
+    return plans.create_plan(agent_name=AGENT, goal=goal, chat_id=1, thread_id="1")
+
+
+def test_listing_counts_progress_and_waiting(client):
+    plan_id = _plan()
+    done = plans.add_step(plan_id, "поискал")
+    plans.finish_step(done, "нашёл")
+    plans.add_step(plan_id, "жду", wait={"kind": "manual"})
+
+    body = client.get("/api/plans").json()
+
+    assert body["plans"][0]["id"] == plan_id
+    assert body["plans"][0]["done_count"] == 1
+    assert body["plans"][0]["waiting_count"] == 1
+    assert body["plans"][0]["step_count"] == 2
+
+
+def test_finished_plans_are_hidden_until_asked_for(client):
+    plan_id = _plan("законченный")
+    step = plans.add_step(plan_id, "шаг")
+    plans.finish_step(step, "готово")
+    plans.settle_plan(plan_id)
+
+    assert client.get("/api/plans").json()["plans"] == []
+    assert client.get("/api/plans?all=true").json()["plans"][0]["id"] == plan_id
+
+
+def test_a_step_says_what_it_waits_for_in_words(client):
+    plan_id = _plan()
+    plans.add_step(
+        plan_id,
+        "скажи мне",
+        wait={
+            "kind": "page_number",
+            "url": "https://x.test/a",
+            "pattern": r"Rp ([\d.]+)",
+            "op": "below",
+            "value": 9_000_000,
+        },
+    )
+
+    step = client.get(f"/api/plans/{plan_id}").json()["steps"][0]
+
+    assert "below" in step["waiting_for"]
+    assert "9,000,000" in step["waiting_for"]
+
+
+def test_a_missing_plan_is_a_404(client):
+    assert client.get("/api/plans/4242").status_code == 404
+
+
+def test_resume_releases_every_waiting_step(client):
+    plan_id = _plan()
+    parked = plans.add_step(plan_id, "продолжай", wait={"kind": "manual"})
+
+    body = client.post(f"/api/plans/{plan_id}/resume").json()
+
+    assert body["released"] == [parked]
+    assert plans.get_step(parked)["state"] == plans.STEP_PENDING
+
+
+def test_resume_can_target_one_step(client):
+    plan_id = _plan()
+    first = plans.add_step(plan_id, "один", wait={"kind": "manual"})
+    second = plans.add_step(plan_id, "два", wait={"kind": "manual"})
+
+    client.post(f"/api/plans/{plan_id}/resume?step={second}")
+
+    assert plans.get_step(first)["state"] == plans.STEP_WAITING
+    assert plans.get_step(second)["state"] == plans.STEP_PENDING
+
+
+def test_resume_with_nothing_waiting_is_a_404(client):
+    plan_id = _plan()
+    plans.add_step(plan_id, "уже в очереди")
+
+    assert client.post(f"/api/plans/{plan_id}/resume").status_code == 404
+
+
+def test_resume_of_a_closed_plan_is_a_conflict(client):
+    plan_id = _plan()
+    plans.add_step(plan_id, "шаг", wait={"kind": "manual"})
+    plans.cancel_plan(plan_id, AGENT)
+
+    assert client.post(f"/api/plans/{plan_id}/resume").status_code == 409
+
+
+def test_cancelling_returns_the_closed_plan_and_then_404s(client):
+    plan_id = _plan()
+
+    assert client.delete(f"/api/plans/{plan_id}").json()["state"] == plans.PLAN_CANCELLED
+    assert client.delete(f"/api/plans/{plan_id}").status_code == 404

--- a/tests/test_plan_conditions.py
+++ b/tests/test_plan_conditions.py
@@ -1,0 +1,340 @@
+"""Conditions decide when weeks of waiting end, so their edges are the feature.
+
+The distinctions worth testing: a site being down is not a price drop; a pattern
+that stops matching is not a number that fell; and a price written 8.750.000 is
+not eight point seven five. Each of those, read wrong, is either a notification
+that never comes or one that comes falsely.
+"""
+
+import pytest
+
+from kronos import plan_conditions as pc
+
+
+@pytest.fixture(autouse=True)
+def allow_egress(monkeypatch):
+    """The allowlist is tested elsewhere; here it must not be the thing failing."""
+    monkeypatch.setattr("kronos.security.egress.check_url", lambda url, tool="": None)
+    yield
+
+
+NOW = 1_000_000.0
+
+
+# --- validation, while it can still be fixed -----------------------------------
+
+
+def test_an_unknown_condition_is_refused():
+    with pytest.raises(pc.ConditionError, match="unknown condition"):
+        pc.normalize({"kind": "vibes"})
+
+
+def test_at_needs_a_future():
+    with pytest.raises(pc.ConditionError, match="seconds > 0"):
+        pc.normalize({"kind": "at", "seconds": 0})
+
+
+def test_at_turns_a_delay_into_a_moment():
+    spec, wake = pc.normalize({"kind": "at", "seconds": 3600}, now=NOW)
+
+    assert spec == {"kind": "at", "timestamp": NOW + 3600}
+    assert wake == NOW + 3600
+
+
+def test_at_accepts_an_absolute_time():
+    spec, wake = pc.normalize({"kind": "at", "timestamp": NOW + 10}, now=NOW)
+
+    assert wake == NOW + 10
+    assert spec["timestamp"] == NOW + 10
+
+
+def test_a_manual_wait_is_never_woken_by_the_clock():
+    """It ends when the owner says so, or when the plan expires — not on a timer."""
+    _, wake = pc.normalize({"kind": "manual", "note": "after I view the flat"}, now=NOW)
+
+    assert wake > NOW + 86400 * 300
+
+
+def test_a_page_condition_is_checked_at_once():
+    """A price already below the threshold should not have to drop a second time."""
+    _, wake = pc.normalize({"kind": "page_matches", "url": "https://x.test/a", "pattern": "sold"}, now=NOW)
+
+    assert wake == 0.0
+
+
+def test_a_page_condition_needs_a_real_url():
+    with pytest.raises(pc.ConditionError, match="http"):
+        pc.normalize({"kind": "page_matches", "url": "x.test/a", "pattern": "sold"})
+
+
+def test_a_forbidden_host_is_refused_when_the_step_is_written(monkeypatch):
+    def blocked(url, tool=""):
+        raise RuntimeError("host not on the allowlist")
+
+    monkeypatch.setattr("kronos.security.egress.check_url", blocked)
+
+    with pytest.raises(RuntimeError, match="allowlist"):
+        pc.normalize({"kind": "page_matches", "url": "https://x.test/a", "pattern": "sold"})
+
+
+def test_a_broken_regex_is_refused():
+    with pytest.raises(pc.ConditionError, match="not a valid regular expression"):
+        pc.normalize({"kind": "page_matches", "url": "https://x.test/a", "pattern": "([unclosed"})
+
+
+def test_a_number_condition_needs_a_capture_group():
+    with pytest.raises(pc.ConditionError, match="capture the number"):
+        pc.normalize(
+            {"kind": "page_number", "url": "https://x.test/a", "pattern": r"Rp [\d.]+", "op": "below", "value": 1}
+        )
+
+
+def test_a_number_condition_needs_a_direction_and_a_threshold():
+    base = {"kind": "page_number", "url": "https://x.test/a", "pattern": r"Rp ([\d.]+)"}
+
+    with pytest.raises(pc.ConditionError, match="op must be"):
+        pc.normalize({**base, "value": 1})
+    with pytest.raises(pc.ConditionError, match="numeric value"):
+        pc.normalize({**base, "op": "below"})
+
+
+def test_the_check_interval_has_a_floor():
+    """A minute-by-minute condition is a crawler pointed at one site for weeks."""
+    spec, _ = pc.normalize({"kind": "page_matches", "url": "https://x.test/a", "pattern": "x", "every_seconds": 5})
+
+    assert spec["every_seconds"] == pc.MIN_INTERVAL_SECONDS
+
+
+# --- reading numbers off a page ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("8750000", 8750000),
+        ("8.750.000", 8750000),
+        ("8,750,000", 8750000),
+        ("Rp 8.750.000", 8750000),
+        ("1 234,56", 1234.56),
+        ("1,234.56", 1234.56),
+        ("99", 99),
+        ("12.5", 12.5),
+        ("", None),
+        ("free", None),
+    ],
+)
+def test_prices_are_read_the_way_pages_write_them(text, expected):
+    assert pc.parse_number(text) == expected
+
+
+# --- evaluating ---------------------------------------------------------------
+
+
+async def test_a_time_condition_fires_when_the_time_comes():
+    spec = {"kind": "at", "timestamp": NOW}
+
+    assert (await pc.evaluate(spec, step={}, plan={}, now=NOW + 1)).fired is True
+
+    early = await pc.evaluate(spec, step={}, plan={}, now=NOW - 60)
+    assert early.fired is False
+    assert early.next_check_at == NOW
+
+
+async def test_a_manual_condition_never_fires_on_its_own():
+    verdict = await pc.evaluate({"kind": "manual"}, step={}, plan={}, now=NOW)
+
+    assert verdict.fired is False
+
+
+async def test_a_page_that_now_says_the_thing_fires(monkeypatch):
+    _page(monkeypatch, "This listing is no longer available")
+
+    verdict = await pc.evaluate(
+        {"kind": "page_matches", "url": "https://x.test/a", "pattern": "no longer available"},
+        step={},
+        plan={},
+        now=NOW,
+    )
+
+    assert verdict.fired is True
+    assert "no longer available" in verdict.detail
+
+
+async def test_absent_waits_for_the_text_to_go_away(monkeypatch):
+    spec = {"kind": "page_matches", "url": "https://x.test/a", "pattern": "sold out", "absent": True}
+
+    _page(monkeypatch, "sold out")
+    assert (await pc.evaluate(spec, step={}, plan={}, now=NOW)).fired is False
+
+    _page(monkeypatch, "add to cart")
+    assert (await pc.evaluate(spec, step={}, plan={}, now=NOW)).fired is True
+
+
+async def test_a_price_below_the_threshold_fires_with_what_it_saw(monkeypatch):
+    _page(monkeypatch, "Best price Rp 8.750.000 today")
+
+    verdict = await pc.evaluate(
+        {
+            "kind": "page_number",
+            "url": "https://x.test/a",
+            "pattern": r"Rp ([\d.]+)",
+            "op": "below",
+            "value": 9_000_000,
+        },
+        step={},
+        plan={},
+        now=NOW,
+    )
+
+    assert verdict.fired is True
+    assert "8,750,000" in verdict.detail, "a price a person can read, not 8.75e+06"
+
+
+async def test_a_price_still_above_the_threshold_waits(monkeypatch):
+    _page(monkeypatch, "Best price Rp 9.500.000 today")
+
+    verdict = await pc.evaluate(
+        {
+            "kind": "page_number",
+            "url": "https://x.test/a",
+            "pattern": r"Rp ([\d.]+)",
+            "op": "below",
+            "value": 9_000_000,
+            "every_seconds": 3600,
+        },
+        step={},
+        plan={},
+        now=NOW,
+    )
+
+    assert verdict.fired is False
+    assert verdict.next_check_at == NOW + 3600
+
+
+async def test_a_site_that_is_down_is_not_a_price_drop(monkeypatch):
+    """The one confusion that must never happen."""
+
+    async def broken(url):
+        raise RuntimeError("503 from the marketplace")
+
+    monkeypatch.setattr("kronos.tools.acquire.fetch_tiered", broken)
+
+    verdict = await pc.evaluate(
+        {"kind": "page_number", "url": "https://x.test/a", "pattern": r"Rp ([\d.]+)", "op": "below", "value": 1},
+        step={},
+        plan={},
+        now=NOW,
+    )
+
+    assert verdict.fired is False
+    assert verdict.next_check_at > NOW
+    assert any("could not read" in note for note in verdict.notes)
+
+
+async def test_a_pattern_that_stopped_matching_is_not_a_number_that_fell(monkeypatch):
+    """A redesigned page must not read as a price of zero."""
+    _page(monkeypatch, "Harga: hubungi penjual")
+
+    verdict = await pc.evaluate(
+        {"kind": "page_number", "url": "https://x.test/a", "pattern": r"Rp ([\d.]+)", "op": "below", "value": 1},
+        step={},
+        plan={},
+        now=NOW,
+    )
+
+    assert verdict.fired is False
+    assert any("did not match" in note for note in verdict.notes)
+
+
+async def test_an_unrecognisable_number_does_not_fire(monkeypatch):
+    _page(monkeypatch, "Price: Rp lots")
+
+    verdict = await pc.evaluate(
+        {"kind": "page_number", "url": "https://x.test/a", "pattern": r"Rp (\w+)", "op": "below", "value": 1},
+        step={},
+        plan={},
+        now=NOW,
+    )
+
+    assert verdict.fired is False
+    assert any("could not read a number" in note for note in verdict.notes)
+
+
+async def test_an_unrecognised_condition_parks_rather_than_spins(monkeypatch):
+    verdict = await pc.evaluate({"kind": "from-the-future"}, step={"id": 1}, plan={}, now=NOW)
+
+    assert verdict.fired is False
+    assert verdict.next_check_at > NOW + 86400
+
+
+# --- waiting for the owner ----------------------------------------------------
+
+
+async def test_a_reply_after_parking_fires(monkeypatch):
+    _turns(monkeypatch, [{"started_at": "2026-01-01 12:00:00"}])
+
+    verdict = await pc.evaluate(
+        {"kind": "reply"},
+        step={"parked_at": _epoch("2026-01-01 11:00:00")},
+        plan={"thread_id": "42"},
+        now=NOW,
+    )
+
+    assert verdict.fired is True
+
+
+async def test_a_reply_from_before_parking_does_not_count(monkeypatch):
+    _turns(monkeypatch, [{"started_at": "2026-01-01 10:00:00"}])
+
+    verdict = await pc.evaluate(
+        {"kind": "reply"},
+        step={"parked_at": _epoch("2026-01-01 11:00:00")},
+        plan={"thread_id": "42"},
+        now=NOW,
+    )
+
+    assert verdict.fired is False
+
+
+async def test_a_plan_with_no_chat_behind_it_never_waits_for_a_reply(monkeypatch):
+    _turns(monkeypatch, [{"started_at": "2026-01-01 12:00:00"}])
+
+    verdict = await pc.evaluate({"kind": "reply"}, step={"parked_at": 0}, plan={}, now=NOW)
+
+    assert verdict.fired is False
+
+
+# --- describing ---------------------------------------------------------------
+
+
+def test_every_condition_can_be_read_by_a_human():
+    specs = [
+        {"kind": "at", "timestamp": NOW},
+        {"kind": "manual", "note": "after the viewing"},
+        {"kind": "reply"},
+        {"kind": "page_matches", "url": "https://x.test/a", "pattern": "sold"},
+        {"kind": "page_number", "url": "https://x.test/a", "pattern": r"Rp ([\d.]+)", "op": "below", "value": 9},
+    ]
+
+    for spec in specs:
+        assert pc.describe(spec) and "unrecognised" not in pc.describe(spec), spec
+
+
+def _page(monkeypatch, text: str) -> None:
+    async def fake_fetch(url):
+        return "plain", text, []
+
+    monkeypatch.setattr("kronos.tools.acquire.fetch_tiered", fake_fetch)
+
+
+def _turns(monkeypatch, rows: list[dict]) -> None:
+    async def fake_list(self, *, thread_id: str = "", limit: int = 5, status: str = ""):
+        return rows
+
+    monkeypatch.setattr("kronos.session.SessionStore.list_turns", fake_list)
+
+
+def _epoch(stamp: str) -> float:
+    from datetime import UTC, datetime
+
+    return datetime.strptime(stamp, "%Y-%m-%d %H:%M:%S").replace(tzinfo=UTC).timestamp()

--- a/tests/test_plan_poller.py
+++ b/tests/test_plan_poller.py
@@ -1,0 +1,316 @@
+"""The poller: what runs, what waits, and what reaches the owner.
+
+The expensive mistakes here are all about volume. Running every ready step in
+one cycle spends a day's budget in a minute; letting one plan take every slot
+starves the rest; delivering each step's result turns a week-long watch into a
+reason to switch notifications off. Each has a test.
+"""
+
+import pytest
+
+from kronos import plans
+from kronos.config import settings
+from kronos.cron import plans as poller
+
+AGENT = "kronos"
+
+
+@pytest.fixture(autouse=True)
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
+    monkeypatch.setattr(settings, "agent_name", AGENT)
+    import kronos.db as _db
+
+    _db._instances.clear()
+    yield
+    _db._instances.clear()
+
+
+class FakeAgent:
+    def __init__(self, reply="сделано"):
+        self.reply = reply
+        self.calls: list[dict] = []
+
+    async def ainvoke(self, **kwargs):
+        self.calls.append(kwargs)
+        if isinstance(self.reply, Exception):
+            raise self.reply
+        return self.reply
+
+
+@pytest.fixture
+def agent(monkeypatch):
+    """The live agent, plus a record of everything delivered to the owner."""
+    sent: list[tuple[str, int]] = []
+
+    def install(reply="сделано") -> tuple[FakeAgent, list]:
+        fake = FakeAgent(reply)
+        monkeypatch.setattr("kronos.bridge.get_agent", lambda: fake)
+        monkeypatch.setattr(
+            poller,
+            "send_webhook",
+            lambda text, chat_id=None, parse_mode=None, topic_id=None: sent.append((text, chat_id)) or True,
+        )
+        return fake, sent
+
+    return install
+
+
+def _plan(goal="найти жильё", **kwargs) -> int:
+    return plans.create_plan(agent_name=AGENT, goal=goal, chat_id=77, thread_id="77", **kwargs)
+
+
+# --- running a step -----------------------------------------------------------
+
+
+async def test_a_ready_step_runs_and_keeps_its_result(agent):
+    fake, _ = agent("нашёл три варианта")
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "поищи на airbnb")
+
+    await poller.run_due_plan_steps()
+
+    assert plans.get_step(step_id)["state"] == plans.STEP_DONE
+    assert plans.get_step(step_id)["result"] == "нашёл три варианта"
+    assert fake.calls[0]["thread_id"] == f"plan:{plan_id}", "plan turns belong in the plan's own thread"
+
+
+async def test_the_prompt_carries_the_goal_and_earlier_results(agent):
+    fake, _ = agent()
+    plan_id = _plan("найти жильё на Бали")
+    first = plans.add_step(plan_id, "спроси у арендодателя про депозит", title="аренда 1")
+    plans.finish_step(first, "депозит два месяца")
+    plans.add_step(plan_id, "сравни условия", depends_on=[first])
+
+    await poller.run_due_plan_steps()
+
+    prompt = fake.calls[0]["message"]  # calls[-1] is the closing summary
+    assert "найти жильё на Бали" in prompt
+    assert "депозит два месяца" in prompt
+    assert "сравни условия" in prompt
+
+
+async def test_a_failed_dependency_is_stated_plainly_in_the_prompt(agent):
+    fake, _ = agent()
+    plan_id = _plan()
+    asked = plans.add_step(plan_id, "спроси", title="аренда 2")
+    for _ in range(plans.MAX_STEP_ATTEMPTS):
+        plans.mark_running(asked)
+        plans.fail_step(asked, "не ответил")
+    plans.add_step(plan_id, "сравни", depends_on=[asked])
+
+    await poller.run_due_plan_steps()
+
+    assert "НЕ УДАЛОСЬ" in fake.calls[0]["message"]
+
+
+async def test_an_agent_that_is_not_up_yet_costs_the_step_nothing(monkeypatch):
+    monkeypatch.setattr("kronos.bridge.get_agent", lambda: None)
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "поищи")
+
+    await poller.run_due_plan_steps()
+
+    step = plans.get_step(step_id)
+    assert step["attempts"] == 0, "a restart window must not burn the retry budget"
+    assert step["state"] == plans.STEP_PENDING
+
+
+async def test_a_step_whose_turn_raised_is_retried(agent):
+    agent(RuntimeError("provider down"))
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "поищи")
+
+    await poller.run_due_plan_steps()
+
+    step = plans.get_step(step_id)
+    assert step["state"] == plans.STEP_PENDING
+    assert "provider down" in step["result"]
+
+
+async def test_an_empty_reply_is_not_a_result(agent):
+    agent("   ")
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "поищи")
+
+    await poller.run_due_plan_steps()
+
+    assert plans.get_step(step_id)["state"] == plans.STEP_PENDING
+    assert "nothing" in plans.get_step(step_id)["result"]
+
+
+# --- volume -------------------------------------------------------------------
+
+
+async def test_only_a_few_steps_run_per_cycle(agent):
+    """Forty ready steps in one minute would be a day's budget in a minute."""
+    fake, _ = agent()
+    for i in range(10):
+        plans.add_step(_plan(f"план {i}"), "работай")
+
+    await poller.run_due_plan_steps()
+
+    steps_run = [c for c in fake.calls if "Ты выполняешь шаг" in c["message"]]
+    assert len(steps_run) == poller.MAX_STEPS_PER_CYCLE
+
+
+async def test_one_plan_does_not_take_every_slot(agent):
+    fake, _ = agent()
+    busy = _plan("занятой план")
+    for i in range(5):
+        plans.add_step(busy, f"работа {i}")
+    other = _plan("другой план")
+    plans.add_step(other, "тоже работа")
+
+    await poller.run_due_plan_steps()
+
+    threads = [call["thread_id"] for call in fake.calls]
+    assert threads.count(f"plan:{busy}") == 1
+    assert f"plan:{other}" in threads
+
+
+# --- waiting ------------------------------------------------------------------
+
+
+async def test_a_step_whose_condition_has_not_fired_is_not_run(agent, monkeypatch):
+    fake, _ = agent()
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "действуй по падению цены", wait={"kind": "page_number"})
+    _condition(monkeypatch, fired=False, next_check_at=999.0)
+
+    await poller.run_due_plan_steps()
+
+    step = plans.get_step(step_id)
+    assert fake.calls == []
+    assert step["state"] == plans.STEP_WAITING
+    assert step["checks"] == 1
+    assert step["wake_at"] == 999.0
+
+
+async def test_a_condition_that_fired_runs_the_step_with_what_was_seen(agent, monkeypatch):
+    fake, _ = agent()
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "купи", wait={"kind": "page_number"})
+    _condition(monkeypatch, fired=True, detail="цена теперь 8 750 000, ниже 9 000 000")
+
+    await poller.run_due_plan_steps()
+
+    assert "8 750 000" in fake.calls[0]["message"]
+    assert plans.get_step(step_id)["state"] == plans.STEP_DONE
+
+
+async def test_condition_checks_are_capped_per_cycle(agent, monkeypatch):
+    """Page conditions fetch, and twenty fetches is already most of a minute."""
+    agent()
+    for i in range(poller.MAX_CHECKS_PER_CYCLE + 5):
+        plans.add_step(_plan(f"наблюдение {i}"), "смотри", wait={"kind": "page_number"})
+    checked = _condition(monkeypatch, fired=False, next_check_at=999.0)
+
+    await poller.run_due_plan_steps()
+
+    assert len(checked) == poller.MAX_CHECKS_PER_CYCLE
+
+
+# --- what reaches the owner ---------------------------------------------------
+
+
+async def test_a_step_stays_quiet_unless_it_was_asked_to_speak(agent):
+    _, sent = agent("промежуточный результат")
+    plan_id = _plan()
+    plans.add_step(plan_id, "шаг 1")
+    plans.add_step(plan_id, "шаг 2")
+
+    await poller.run_due_plan_steps()
+
+    assert sent == [], "an hourly watch that messages every cycle gets muted"
+
+
+async def test_a_step_marked_notify_reaches_the_owner(agent):
+    _, sent = agent("цена упала")
+    plan_id = _plan()
+    plans.add_step(plan_id, "скажи мне", notify=True)
+    plans.add_step(plan_id, "и ещё поработай")
+
+    await poller.run_due_plan_steps()
+
+    assert sent[0] == ("цена упала", 77)
+
+
+async def test_a_finished_plan_is_summarised_once(agent):
+    fake, sent = agent("итог: два варианта подходят")
+    plan_id = _plan()
+    plans.add_step(plan_id, "единственный шаг")
+
+    await poller.run_due_plan_steps()
+
+    assert plans.get_plan(plan_id)["state"] == plans.PLAN_DONE
+    assert plans.get_plan(plan_id)["summary"] == "итог: два варианта подходят"
+    assert len(sent) == 1
+    assert fake.calls[-1]["persist_user_turn"] is False, "the summary is for the owner, not the history"
+
+
+async def test_a_plan_still_working_is_not_summarised(agent):
+    _, sent = agent()
+    plan_id = _plan()
+    plans.add_step(plan_id, "шаг 1")
+    plans.add_step(plan_id, "шаг 2", wait={"kind": "manual"})
+
+    await poller.run_due_plan_steps()
+
+    assert plans.get_plan(plan_id)["state"] == plans.PLAN_ACTIVE
+    assert sent == []
+
+
+async def test_an_expired_plan_is_retired_and_reported(agent):
+    """Silence would leave the owner believing it is still watching."""
+    _, sent = agent("план истёк, ничего не нашлось")
+    plan_id = _plan(ttl_seconds=-1)
+    plans.add_step(plan_id, "наблюдай", wait={"kind": "manual"})
+
+    await poller.run_due_plan_steps()
+
+    assert plans.get_plan(plan_id)["state"] == plans.PLAN_FAILED
+    assert len(sent) == 1
+
+
+async def test_a_summary_survives_the_agent_being_down(monkeypatch):
+    """The step results are a worse message than a written summary, but not no message."""
+    sent: list = []
+    monkeypatch.setattr("kronos.bridge.get_agent", lambda: None)
+    monkeypatch.setattr(
+        poller, "send_webhook", lambda text, chat_id=None, parse_mode=None, topic_id=None: sent.append(text) or True
+    )
+    plan_id = _plan("найти жильё")
+    step_id = plans.add_step(plan_id, "шаг")
+    plans.finish_step(step_id, "нашёл вариант")
+
+    await poller._summarize(plans.get_plan(plan_id), "выполнен")
+
+    assert "найти жильё" in sent[0]
+    assert "нашёл вариант" in sent[0]
+
+
+async def test_a_plan_with_no_chat_behind_it_delivers_nothing(agent):
+    _, sent = agent()
+    plan_id = plans.create_plan(agent_name=AGENT, goal="фоновая работа")
+    plans.add_step(plan_id, "шаг", notify=True)
+
+    await poller.run_due_plan_steps()
+
+    assert sent == []
+    assert plans.get_plan(plan_id)["summary"], "the summary is still recorded, just not sent"
+
+
+def _condition(monkeypatch, *, fired: bool, detail: str = "", next_check_at: float = 0.0) -> list:
+    """Replace condition evaluation; returns the list of steps it was asked about."""
+    checked: list = []
+
+    async def fake_evaluate(spec, *, step, plan, now=None):
+        checked.append(step["id"])
+        from kronos.plan_conditions import Verdict
+
+        return Verdict(fired, detail, next_check_at)
+
+    monkeypatch.setattr("kronos.plan_conditions.evaluate", fake_evaluate)
+    return checked

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1,0 +1,320 @@
+"""A plan is mostly a state machine, and its interesting states are the stuck ones.
+
+What these check: a dependency that failed still lets the next step run (one
+silent landlord must not mean no answer at all), a retry does not end a
+week-long plan, and every way a plan could wait forever has a bound that ends it
+with a stated failure instead.
+"""
+
+import pytest
+
+from kronos import plans
+from kronos.config import settings
+
+AGENT = "kronos"
+
+
+@pytest.fixture(autouse=True)
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
+    import kronos.db as _db
+
+    _db._instances.clear()
+    yield
+    _db._instances.clear()
+
+
+def _plan(goal: str = "find a flat in Bali") -> int:
+    return plans.create_plan(agent_name=AGENT, goal=goal, chat_id=1, thread_id="1")
+
+
+# --- shape --------------------------------------------------------------------
+
+
+def test_a_plan_holds_its_goal_and_stays_active():
+    plan_id = _plan()
+
+    plan = plans.get_plan(plan_id)
+
+    assert plan["goal"] == "find a flat in Bali"
+    assert plan["state"] == plans.PLAN_ACTIVE
+    assert plan["expires_at"] > plan["created_at"]
+
+
+def test_a_plan_needs_a_goal():
+    with pytest.raises(plans.PlanError, match="needs a goal"):
+        plans.create_plan(agent_name=AGENT, goal="   ")
+
+
+def test_steps_keep_their_order():
+    plan_id = _plan()
+
+    first = plans.add_step(plan_id, "search airbnb")
+    second = plans.add_step(plan_id, "search booking")
+
+    assert [s["id"] for s in plans.steps_of(plan_id)] == [first, second]
+    assert [s["seq"] for s in plans.steps_of(plan_id)] == [1, 2]
+
+
+def test_a_parked_step_starts_out_waiting():
+    plan_id = _plan()
+
+    step_id = plans.add_step(plan_id, "check the price", wait={"kind": "at", "seconds": 3600})
+
+    step = plans.get_step(step_id)
+    assert step["state"] == plans.STEP_WAITING
+    assert plans.wait_spec(step) == {"kind": "at", "seconds": 3600}
+
+
+def test_a_step_cannot_depend_on_a_step_of_another_plan():
+    other = plans.add_step(_plan("other"), "something")
+    plan_id = _plan()
+
+    with pytest.raises(plans.PlanError, match="not part of plan"):
+        plans.add_step(plan_id, "compare", depends_on=[other])
+
+
+def test_steps_are_capped():
+    plan_id = _plan()
+    for i in range(plans.MAX_STEPS_PER_PLAN):
+        plans.add_step(plan_id, f"step {i}")
+
+    with pytest.raises(plans.PlanError, match="already has"):
+        plans.add_step(plan_id, "one too many")
+
+
+def test_a_closed_plan_takes_no_new_steps():
+    plan_id = _plan()
+    plans.cancel_plan(plan_id, AGENT)
+
+    with pytest.raises(plans.PlanError, match="not active"):
+        plans.add_step(plan_id, "too late")
+
+
+def test_an_unreadable_condition_reads_as_no_condition():
+    """Corrupt JSON must not crash the poller for every other plan."""
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "x", wait={"kind": "at"})
+    plans._db().write("UPDATE plan_steps SET wait_json = '{oops' WHERE id = ?", (step_id,))
+
+    assert plans.wait_spec(plans.get_step(step_id)) == {}
+
+
+# --- what is ready to run -----------------------------------------------------
+
+
+def test_a_fresh_step_is_ready():
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "search airbnb")
+
+    assert [s["id"] for s in plans.ready_steps(AGENT)] == [step_id]
+
+
+def test_a_step_waits_for_what_it_depends_on():
+    plan_id = _plan()
+    first = plans.add_step(plan_id, "ask the landlord")
+    second = plans.add_step(plan_id, "compare", depends_on=[first])
+
+    assert [s["id"] for s in plans.ready_steps(AGENT)] == [first]
+
+    plans.finish_step(first, "asked")
+
+    assert [s["id"] for s in plans.ready_steps(AGENT)] == [second]
+
+
+def test_a_failed_dependency_still_lets_the_next_step_run():
+    """Two landlords answered and one went silent — that is an answer, not a dead end."""
+    plan_id = _plan()
+    asks = [plans.add_step(plan_id, f"ask landlord {i}") for i in range(3)]
+    compare = plans.add_step(plan_id, "compare the answers", depends_on=asks)
+
+    plans.finish_step(asks[0], "answered: 800/mo")
+    plans.finish_step(asks[1], "answered: 950/mo")
+    for _ in range(plans.MAX_STEP_ATTEMPTS + 1):
+        plans.mark_running(asks[2])
+        given_up = plans.fail_step(asks[2], "no reply")
+
+    assert given_up is True
+    assert [s["id"] for s in plans.ready_steps(AGENT)] == [compare]
+
+
+def test_the_next_step_can_read_what_the_previous_ones_produced():
+    plan_id = _plan()
+    first = plans.add_step(plan_id, "ask")
+    second = plans.add_step(plan_id, "compare", depends_on=[first])
+    plans.finish_step(first, "800 per month, deposit two months")
+
+    results = plans.dependency_results(plans.get_step(second))
+
+    assert [r["result"] for r in results] == ["800 per month, deposit two months"]
+
+
+def test_a_step_parked_in_the_future_is_not_ready():
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "check the price", wait={"kind": "at"})
+    plans.park_step(step_id, {"kind": "at"}, wake_at=_soon())
+
+    assert plans.ready_steps(AGENT) == []
+
+
+def test_a_parked_step_becomes_ready_when_its_wake_time_passes():
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "check the price", wait={"kind": "at"})
+    plans.park_step(step_id, {"kind": "at"}, wake_at=1.0)
+
+    assert [s["id"] for s in plans.ready_steps(AGENT)] == [step_id]
+
+
+def test_steps_of_a_cancelled_plan_are_never_ready():
+    plan_id = _plan()
+    plans.add_step(plan_id, "search")
+    plans.cancel_plan(plan_id, AGENT)
+
+    assert plans.ready_steps(AGENT) == []
+
+
+def test_another_agents_plan_is_none_of_our_business():
+    other = plans.create_plan(agent_name="nexus", goal="theirs")
+    plans.add_step(other, "their step")
+
+    assert plans.ready_steps(AGENT) == []
+
+
+# --- retries and give-up ------------------------------------------------------
+
+
+def test_a_transient_failure_is_retried_rather_than_ending_the_plan():
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "fetch the listing")
+
+    plans.mark_running(step_id)
+    given_up = plans.fail_step(step_id, "connection reset")
+
+    step = plans.get_step(step_id)
+    assert given_up is False
+    assert step["state"] == plans.STEP_PENDING
+    assert step["wake_at"] > 0, "a retry should not hammer the same failure immediately"
+    assert plans.get_plan(plan_id)["state"] == plans.PLAN_ACTIVE
+
+
+def test_a_step_that_keeps_failing_is_given_up_on():
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "fetch the listing")
+
+    for _ in range(plans.MAX_STEP_ATTEMPTS):
+        plans.mark_running(step_id)
+        given_up = plans.fail_step(step_id, "connection reset")
+
+    assert given_up is True
+    assert plans.get_step(step_id)["state"] == plans.STEP_FAILED
+    assert "attempts" in plans.get_step(step_id)["result"]
+
+
+def test_a_condition_that_never_fires_eventually_gives_up():
+    """Otherwise the poller pays for it on every cycle until the heat death."""
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "wait for a price drop", wait={"kind": "page_number"})
+    plans._db().write("UPDATE plan_steps SET checks = ? WHERE id = ?", (plans.MAX_CONDITION_CHECKS - 1, step_id))
+
+    assert plans.note_check(step_id, next_check_at=1.0) is True
+    assert plans.get_step(step_id)["state"] == plans.STEP_FAILED
+    assert "never fired" in plans.get_step(step_id)["result"]
+
+
+def test_a_check_that_did_not_fire_just_schedules_the_next_one():
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "wait", wait={"kind": "page_number"})
+
+    assert plans.note_check(step_id, next_check_at=1234.0) is False
+
+    step = plans.get_step(step_id)
+    assert step["checks"] == 1
+    assert step["wake_at"] == 1234.0
+    assert step["state"] == plans.STEP_WAITING
+
+
+def test_releasing_a_step_clears_the_condition():
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "act on the drop", wait={"kind": "at"})
+
+    plans.release_step(step_id)
+
+    step = plans.get_step(step_id)
+    assert step["state"] == plans.STEP_PENDING
+    assert plans.wait_spec(step) == {}
+
+
+# --- closing ------------------------------------------------------------------
+
+
+def test_a_plan_stays_active_until_every_step_stops_moving():
+    plan_id = _plan()
+    first = plans.add_step(plan_id, "one")
+    plans.add_step(plan_id, "two")
+    plans.finish_step(first, "done")
+
+    assert plans.settle_plan(plan_id) == plans.PLAN_ACTIVE
+
+
+def test_a_plan_with_no_steps_is_not_finished():
+    """An empty plan is one being written, not one that succeeded."""
+    assert plans.settle_plan(_plan()) == plans.PLAN_ACTIVE
+
+
+def test_a_plan_that_got_somewhere_is_done_even_with_a_failed_step():
+    plan_id = _plan()
+    good = plans.add_step(plan_id, "one")
+    bad = plans.add_step(plan_id, "two")
+    plans.finish_step(good, "found three flats")
+    for _ in range(plans.MAX_STEP_ATTEMPTS):
+        plans.mark_running(bad)
+        plans.fail_step(bad, "site down")
+
+    assert plans.settle_plan(plan_id) == plans.PLAN_DONE
+
+
+def test_a_plan_where_nothing_worked_is_failed():
+    plan_id = _plan()
+    step_id = plans.add_step(plan_id, "one")
+    for _ in range(plans.MAX_STEP_ATTEMPTS):
+        plans.mark_running(step_id)
+        plans.fail_step(step_id, "site down")
+
+    assert plans.settle_plan(plan_id) == plans.PLAN_FAILED
+
+
+def test_cancelling_is_idempotent_and_scoped_to_the_agent():
+    plan_id = _plan()
+
+    assert plans.cancel_plan(plan_id, "nexus") is False, "another agent's plan is not ours to cancel"
+    assert plans.cancel_plan(plan_id, AGENT) is True
+    assert plans.cancel_plan(plan_id, AGENT) is False
+
+
+def test_an_expired_plan_says_so_instead_of_waiting_forever():
+    plan_id = plans.create_plan(agent_name=AGENT, goal="watch a price", ttl_seconds=-1)
+    step_id = plans.add_step(plan_id, "keep watching", wait={"kind": "page_number"})
+
+    expired = plans.expired_plans(AGENT)
+    assert [p["id"] for p in expired] == [plan_id]
+
+    plans.expire_plan(plan_id)
+
+    assert plans.get_plan(plan_id)["state"] == plans.PLAN_FAILED
+    assert "expired" in plans.get_step(step_id)["result"]
+    assert plans.ready_steps(AGENT) == []
+
+
+def test_a_summary_is_kept_on_the_plan():
+    plan_id = _plan()
+
+    plans.set_summary(plan_id, "  three flats, two landlords answered  ")
+
+    assert plans.get_plan(plan_id)["summary"] == "three flats, two landlords answered"
+
+
+def _soon() -> float:
+    import time
+
+    return time.time() + 3600

--- a/tests/test_plans_cli.py
+++ b/tests/test_plans_cli.py
@@ -1,0 +1,139 @@
+"""`kaos plans` — seeing what is waiting, and being the thing it waits for.
+
+`resume` is the other half of a `manual` condition: the plan parked because only
+the owner knows when to carry on. If that command were wrong, those plans would
+be unreachable except by editing SQLite.
+"""
+
+import json
+
+import pytest
+
+from kronos import plans
+from kronos.cli import main
+from kronos.config import settings
+
+AGENT = "kronos"
+
+
+@pytest.fixture(autouse=True)
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
+    monkeypatch.setattr(settings, "agent_name", AGENT)
+    import kronos.db as _db
+
+    _db._instances.clear()
+    yield
+    _db._instances.clear()
+
+
+def _plan(goal="найти жильё") -> int:
+    return plans.create_plan(agent_name=AGENT, goal=goal, chat_id=1, thread_id="1")
+
+
+def test_list_with_nothing_running_points_at_the_finished_ones(capsys):
+    assert main(["plans", "list"]) == 0
+
+    assert "--all" in capsys.readouterr().out
+
+
+def test_list_shows_progress_and_what_is_waited_for(capsys):
+    plan_id = _plan()
+    done = plans.add_step(plan_id, "поискал")
+    plans.finish_step(done, "нашёл")
+    plans.add_step(plan_id, "жду тебя", title="после просмотра", wait={"kind": "manual"})
+
+    assert main(["plans", "list"]) == 0
+
+    out = capsys.readouterr().out
+    assert f"#{plan_id}" in out
+    assert "1/2 steps" in out
+    assert "waits for you to resume it" in out
+
+
+def test_list_all_includes_what_is_over(capsys):
+    finished = _plan("сделано")
+    step = plans.add_step(finished, "шаг")
+    plans.finish_step(step, "готово")
+    plans.settle_plan(finished)
+
+    assert main(["plans", "list"]) == 0
+    assert f"#{finished}" not in capsys.readouterr().out
+
+    assert main(["plans", "list", "--all"]) == 0
+    assert f"#{finished}" in capsys.readouterr().out
+
+
+def test_list_json_is_machine_readable(capsys):
+    plan_id = _plan()
+    plans.add_step(plan_id, "шаг", wait={"kind": "at", "timestamp": 1})
+
+    assert main(["plans", "list", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["id"] == plan_id
+    assert payload[0]["waiting"][0]["for"].startswith("until ")
+
+
+def test_show_prints_the_steps_and_their_results(capsys):
+    plan_id = _plan()
+    step = plans.add_step(plan_id, "спроси", title="аренда 1")
+    plans.finish_step(step, "депозит два месяца")
+
+    assert main(["plans", "show", str(plan_id)]) == 0
+
+    out = capsys.readouterr().out
+    assert "аренда 1" in out
+    assert "депозит два месяца" in out
+
+
+def test_show_of_a_missing_plan_fails(capsys):
+    assert main(["plans", "show", "4242"]) == 1
+    assert "No plan #4242" in capsys.readouterr().out
+
+
+def test_resume_releases_what_was_waiting_for_the_owner(capsys):
+    plan_id = _plan()
+    parked = plans.add_step(plan_id, "продолжай", wait={"kind": "manual"})
+
+    assert main(["plans", "resume", str(plan_id)]) == 0
+
+    assert plans.get_step(parked)["state"] == plans.STEP_PENDING
+    assert "Released step" in capsys.readouterr().out
+
+
+def test_resume_can_target_one_step(capsys):
+    plan_id = _plan()
+    first = plans.add_step(plan_id, "один", wait={"kind": "manual"})
+    second = plans.add_step(plan_id, "два", wait={"kind": "manual"})
+
+    assert main(["plans", "resume", str(plan_id), "--step", str(second)]) == 0
+
+    assert plans.get_step(first)["state"] == plans.STEP_WAITING
+    assert plans.get_step(second)["state"] == plans.STEP_PENDING
+
+
+def test_resume_says_when_there_is_nothing_waiting(capsys):
+    plan_id = _plan()
+    plans.add_step(plan_id, "уже в очереди")
+
+    assert main(["plans", "resume", str(plan_id)]) == 1
+    assert "no waiting steps" in capsys.readouterr().out
+
+
+def test_resume_of_a_closed_plan_does_nothing(capsys):
+    plan_id = _plan()
+    plans.add_step(plan_id, "шаг", wait={"kind": "manual"})
+    plans.cancel_plan(plan_id, AGENT)
+
+    assert main(["plans", "resume", str(plan_id)]) == 1
+    assert "cancelled" in capsys.readouterr().out
+
+
+def test_cancel_stops_it_once(capsys):
+    plan_id = _plan()
+
+    assert main(["plans", "cancel", str(plan_id)]) == 0
+    assert plans.get_plan(plan_id)["state"] == plans.PLAN_CANCELLED
+    assert main(["plans", "cancel", str(plan_id)]) == 1

--- a/tests/test_plans_tools.py
+++ b/tests/test_plans_tools.py
@@ -1,0 +1,224 @@
+"""What the agent can declare, and what it is told when it declares it wrong.
+
+A condition is refused here, in the turn that wrote it, with the reason
+attached — an agent that reads "op must be one of below, above" fixes it now.
+The alternative is a plan that looks fine and quietly never wakes.
+"""
+
+import json
+
+import pytest
+
+from kronos import plans
+from kronos.audit import reset_tool_audit_context, set_tool_audit_context
+from kronos.config import settings
+from kronos.tools.plans_tools import PLAN_TOOLS, plan_add_step, plan_cancel, plan_start, plan_status
+
+AGENT = "kronos"
+
+
+@pytest.fixture(autouse=True)
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
+    monkeypatch.setattr(settings, "agent_name", AGENT)
+    monkeypatch.setattr("kronos.security.egress.check_url", lambda url, tool="": None)
+    import kronos.db as _db
+
+    _db._instances.clear()
+    token = set_tool_audit_context(session_id="77", thread_id="77:3", agent=AGENT)
+    yield
+    reset_tool_audit_context(token)
+    _db._instances.clear()
+
+
+def _start(goal="найти жильё на Бали", step="поищи на airbnb") -> int:
+    plan_start.invoke({"goal": goal, "first_step": step})
+    return plans.list_plans(AGENT)[0]["id"]
+
+
+# --- declaring ----------------------------------------------------------------
+
+
+def test_starting_a_plan_records_where_to_report_back():
+    plan_id = _start()
+
+    plan = plans.get_plan(plan_id)
+    assert plan["goal"] == "найти жильё на Бали"
+    assert plan["chat_id"] == 77
+    assert plan["topic_id"] == 3, "a plan started in a topic must answer in that topic"
+    assert len(plans.steps_of(plan_id)) == 1
+
+
+def test_starting_a_plan_tells_the_agent_how_to_continue():
+    out = plan_start.invoke({"goal": "цель", "first_step": "шаг"})
+
+    assert "plan_add_step" in out
+    assert "plan_id=" in out
+
+
+def test_a_plan_without_a_goal_is_refused():
+    assert plan_start.invoke({"goal": " ", "first_step": "шаг"}).startswith("[ERROR]")
+
+
+def test_a_step_can_wait_for_a_price_to_fall():
+    plan_id = _start()
+    wait = json.dumps(
+        {
+            "kind": "page_number",
+            "url": "https://tokopedia.test/rog-ally",
+            "pattern": r"Rp ([\d.]+)",
+            "op": "below",
+            "value": 9_000_000,
+        }
+    )
+
+    out = plan_add_step.invoke({"plan_id": plan_id, "task": "скажи мне", "wait": wait, "notify": True})
+
+    step = plans.steps_of(plan_id)[-1]
+    assert "ждёт" in out
+    assert step["state"] == plans.STEP_WAITING
+    assert step["notify"] == 1
+    assert plans.wait_spec(step)["value"] == 9_000_000
+
+
+def test_a_page_condition_gets_a_sane_check_interval_even_if_none_was_given():
+    plan_id = _start()
+    plan_add_step.invoke(
+        {
+            "plan_id": plan_id,
+            "task": "смотри",
+            "wait": json.dumps({"kind": "page_matches", "url": "https://x.test/a", "pattern": "in stock"}),
+        }
+    )
+
+    assert plans.wait_spec(plans.steps_of(plan_id)[-1])["every_seconds"] >= 300
+
+
+def test_steps_can_fan_in_on_several_earlier_steps():
+    plan_id = _start()
+    second = plans.add_step(plan_id, "спроси второго")
+    first = plans.steps_of(plan_id)[0]["id"]
+
+    plan_add_step.invoke({"plan_id": plan_id, "task": "сравни", "after_steps": f"{first}, {second}"})
+
+    assert plans.dependency_ids(plans.steps_of(plan_id)[-1]) == [first, second]
+
+
+# --- refusals the agent can act on --------------------------------------------
+
+
+def test_a_condition_that_is_not_json_says_so():
+    plan_id = _start()
+
+    out = plan_add_step.invoke({"plan_id": plan_id, "task": "x", "wait": "через неделю"})
+
+    assert out.startswith("[ERROR]")
+    assert "JSON" in out
+
+
+def test_an_unknown_condition_lists_the_ones_that_exist():
+    plan_id = _start()
+
+    out = plan_add_step.invoke({"plan_id": plan_id, "task": "x", "wait": json.dumps({"kind": "vibes"})})
+
+    assert "page_number" in out, "the error should be enough to fix the call"
+
+
+def test_a_number_condition_without_a_direction_is_refused():
+    plan_id = _start()
+    wait = json.dumps({"kind": "page_number", "url": "https://x.test/a", "pattern": r"([\d]+)", "value": 1})
+
+    out = plan_add_step.invoke({"plan_id": plan_id, "task": "x", "wait": wait})
+
+    assert "op" in out
+
+
+def test_a_host_the_policy_forbids_is_refused_at_declaration(monkeypatch):
+    def blocked(url, tool=""):
+        raise RuntimeError("not on the egress allowlist")
+
+    monkeypatch.setattr("kronos.security.egress.check_url", blocked)
+    plan_id = _start()
+    wait = json.dumps({"kind": "page_matches", "url": "https://blocked.test/a", "pattern": "x"})
+
+    out = plan_add_step.invoke({"plan_id": plan_id, "task": "x", "wait": wait})
+
+    assert out.startswith("[ERROR]")
+    assert "allowlist" in out
+
+
+def test_a_bad_dependency_list_is_refused():
+    plan_id = _start()
+
+    out = plan_add_step.invoke({"plan_id": plan_id, "task": "x", "after_steps": "первый шаг"})
+
+    assert out.startswith("[ERROR]")
+    assert "after_steps" in out
+
+
+def test_adding_to_a_plan_that_does_not_exist_says_so():
+    assert plan_add_step.invoke({"plan_id": 999, "task": "x"}).startswith("[ERROR]")
+
+
+# --- reading and stopping -----------------------------------------------------
+
+
+def test_status_shows_what_each_step_is_waiting_for():
+    plan_id = _start()
+    plan_add_step.invoke(
+        {"plan_id": plan_id, "task": "потом", "title": "после просмотра", "wait": json.dumps({"kind": "manual"})}
+    )
+
+    out = plan_status.invoke({})
+
+    assert f"План #{plan_id}" in out
+    assert "после просмотра" in out
+    assert "resume" in out or "возоб" in out or "ждёт" in out
+
+
+def test_status_of_one_plan_includes_its_step_results():
+    plan_id = _start()
+    plans.finish_step(plans.steps_of(plan_id)[0]["id"], "нашёл три варианта")
+
+    assert "нашёл три варианта" in plan_status.invoke({"plan_id": plan_id})
+
+
+def test_status_with_no_plans_says_so():
+    assert "нет" in plan_status.invoke({}).lower()
+
+
+def test_status_of_a_missing_plan_is_an_error():
+    assert plan_status.invoke({"plan_id": 4242}).startswith("[ERROR]")
+
+
+def test_cancelling_stops_the_plan_and_is_not_repeatable():
+    plan_id = _start()
+
+    assert "остановлен" in plan_cancel.invoke({"plan_id": plan_id, "reason": "передумал"})
+    assert plans.get_plan(plan_id)["state"] == plans.PLAN_CANCELLED
+    assert plan_cancel.invoke({"plan_id": plan_id}).startswith("[ERROR]")
+
+
+# --- how the runtime must treat these ----------------------------------------
+
+
+def test_declaring_a_plan_counts_as_a_side_effect():
+    """Durable resume replays a turn; it must not create the plan a second time."""
+    by_name = {tool.name: tool for tool in PLAN_TOOLS}
+
+    for name in ("plan_start", "plan_add_step", "plan_cancel"):
+        assert (by_name[name].metadata or {}).get("side_effect") is True, name
+    assert not (by_name["plan_status"].metadata or {}).get("side_effect"), "reading is not an effect"
+
+
+def test_a_plan_started_outside_a_chat_still_works():
+    """A plan created from cron has nowhere to report, and that is not an error."""
+    token = set_tool_audit_context()  # no chat behind this call
+    try:
+        out = plan_start.invoke({"goal": "фоновая цель", "first_step": "шаг"})
+    finally:
+        reset_tool_audit_context(token)
+
+    assert not out.startswith("[ERROR]")
+    assert plans.list_plans(AGENT)[0]["chat_id"] == 0


### PR DESCRIPTION
The request that motivated this: *find me a flat on Airbnb and Booking, ask the landlords about the deposit and the minimum term, tell me which is worth taking*. That is days of work, and almost all of it is waiting.

A durable turn protects minutes — twenty-five model steps, resumable after a crash. Nothing here re-implements that. A plan is a goal plus steps; the poller runs each ready step as an **ordinary agent turn**, so durable turns, the effects ledger, approvals and the cost guardian apply without knowing plans exist.

## What a step waits for

`at` · `manual` · `reply` · `page_matches` · `page_number`. No model call anywhere: a condition that cost one every few minutes would make waiting the expensive part, when waiting is the cheap part.

Conditions are validated in the turn that writes them. A bad regex, a missing `op`, a host the egress allowlist forbids — refused with the reason, so the agent fixes it immediately. Accepted-now-broken-later is a plan that looks fine and never wakes.

## Three decisions worth arguing with

**A dependency is satisfied when it finished, not when it succeeded.** Three landlords asked, one goes silent: the comparison step still runs, with two answers and one stated absence. Cascading skips would turn one silent landlord into no answer at all.

**A site being down is not a price drop.** An unreachable page is a check that did not happen — rescheduled, never fired. Same for a pattern that stopped matching: a redesigned page must not read as a price of zero. Both have tests, because getting either wrong means a notification that never comes or one that comes falsely.

**Steps are silent unless asked to speak.** What always arrives is one closing summary, written by the agent from the step results. A week-long price watch that messaged every hour would be muted by day two, and then nothing would reach the owner at all.

## Bounds, because waiting is where money leaks

50 steps a plan · 3 attempts a step · 5000 checks a condition · 90 days a plan · 3 step runs and 2 summaries a cycle · 20 condition checks a cycle · one step per plan per cycle so a busy plan cannot starve the rest.

A plan that expires is closed **and reported**. Silence would leave the owner believing it was still watching.

A finished plan is owed a summary until it has one — the marker is the empty summary on a terminal plan, not a variable in the poller's loop, so a crash between finishing and reporting loses nothing.

## Surfaces

`plan_start` / `plan_add_step` / `plan_status` / `plan_cancel` (declaring is marked `side_effect`: resume must not create the plan twice) · `kaos plans list/show/resume/cancel` · a dashboard page with a per-step release button. `resume` is the other half of a `manual` condition — without it those plans would be reachable only by editing SQLite.

Steps run in the plan's own thread (`plan:<id>`), not the owner's chat: a dozen machine turns do not belong in a conversation, and it is what stops `reply` from mistaking the agent's own work for the owner speaking.

## Checks

1678 passed, 68 new. `tests/test_mcp_smoke.py` fails identically on a clean checkout — an external MCP server that will not start locally.

Docs: [Plans](docs/PLANS.md), including the limits — `reply` means "you wrote in that chat", a site's own inbox needs an inbox, and whether watching a given site is acceptable is the owner's call rather than something the code decides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)