### PR TITLE
Compare offers as arithmetic; make the sandbox real

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,7 +133,8 @@ EXPENSES_GMAIL_MCP_TOOLS=gmail        # cron-scoped workspace-mcp --tools (needs
 
 # === Capability Gates (public-safe defaults) ===
 ENABLE_DYNAMIC_TOOLS=false            # opt-in: agent-created Python tools
-REQUIRE_DYNAMIC_TOOL_SANDBOX=true     # fail closed unless Docker sandbox is available
+REQUIRE_DYNAMIC_TOOL_SANDBOX=true     # must stay true: there is no unsandboxed mode,
+                                      # and false simply turns dynamic tools off
 ENABLE_MCP_GATEWAY_MANAGEMENT=false   # opt-in: add/remove/reload MCP servers at runtime
 ENABLE_DYNAMIC_MCP_SERVERS=false      # opt-in: load MCP servers persisted in local registry
 ENABLE_SERVER_OPS=false               # opt-in: SSH/server diagnostics and whitelisted actions

--- a/.env.example
+++ b/.env.example
@@ -135,6 +135,7 @@ EXPENSES_GMAIL_MCP_TOOLS=gmail        # cron-scoped workspace-mcp --tools (needs
 ENABLE_DYNAMIC_TOOLS=false            # opt-in: agent-created Python tools
 REQUIRE_DYNAMIC_TOOL_SANDBOX=true     # must stay true: there is no unsandboxed mode,
                                       # and false simply turns dynamic tools off
+ENABLE_CODE_EXECUTION=false           # opt-in: run_code, one-off analysis in the Docker sandbox
 ENABLE_MCP_GATEWAY_MANAGEMENT=false   # opt-in: add/remove/reload MCP servers at runtime
 ENABLE_DYNAMIC_MCP_SERVERS=false      # opt-in: load MCP servers persisted in local registry
 ENABLE_SERVER_OPS=false               # opt-in: SSH/server diagnostics and whitelisted actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to Kronos Agent OS are documented here.
 
 ### Added
 
+- **compare_offers — totals as arithmetic, not prose** — "which flat is the
+  better deal" is adding money correctly and noticing what is missing, and both
+  are where invented numbers come from. The tool ranks on money only and says so
+  in its own output; weighing location or seller reputation stays with whoever
+  reads it. Three refusals carry the value: an offer missing a cost is set aside
+  and named rather than ranked as the cheapest, two currencies are refused
+  without a rate this has no business inventing, and one-off costs are separated
+  from recurring ones — the difference between the cheapest month and the
+  cheapest stay. No sandbox needed: a fixed comparison is a function.
+- **run_code — one-off analysis in the sandbox** — the container could previously
+  only run *persisted* dynamic tools, so ad-hoc work (normalise forty listings,
+  parse an odd export) had nowhere to go and stayed in the model's head. Opt-in
+  via `ENABLE_CODE_EXECUTION` / `capabilities.code_execution`, stdlib only, no
+  network, stdout is the answer. Each session gets one writable directory that
+  outlives the run, defaulting to the current thread — so a plan accumulates its
+  own working files and a step three days later reads what an earlier one wrote.
+  Docs: [Sandbox](docs/SANDBOX.md).
+
 - **Plans — work that outlives a turn** — a durable turn protects minutes; "ask
   three landlords and compare what comes back" is days, mostly spent waiting. A
   plan is a goal plus steps, where a step holds a prompt, what it depends on, and
@@ -137,6 +155,14 @@ All notable changes to Kronos Agent OS are documented here.
 
 ### Changed
 
+- **The sandbox now enforces what it declared.** `create_session_workspace` built
+  a directory tree that the runner never mounted, so no files went in or out;
+  the storage budget was a number in a manifest; and the dynamic-tool path
+  assembled its policy from the same request it validated, making an input
+  violation unreachable. The session directory is mounted read-write at `/work`
+  and is the working directory, a watchdog outside the container enforces the
+  disk budget while the run proceeds, and the policy comes from a new `sandbox:`
+  section in `policy.yaml`.
 - `kronos.audit.redact_secrets` is now public (was `_redact_string`'s inline
   loop) so exports and audit logs share one copy of the credential patterns.
 
@@ -153,6 +179,15 @@ All notable changes to Kronos Agent OS are documented here.
   call time instead of binding it at import time; a module-level binding
   ignored a swapped workspace, which also made an earlier test pass against
   the wrong directory.
+
+### Removed
+
+- **The unsandboxed execution path.** Two places dropped to `exec()` in the
+  agent's own process when Docker was missing, both logging "unsafe, dev only"
+  and both one environment variable away from running model-written code in
+  production. Missing Docker now means the code does not run, and
+  `REQUIRE_DYNAMIC_TOOL_SANDBOX=false` turns dynamic tools off rather than
+  running them unprotected.
 
 ## [0.2.0] - 2026-05-26
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Start here if you want to understand or contribute to Kronos Agent OS.
 | [MCP & Tools](MCP.md) | Static MCP, tool gateway, dynamic tool gates |
 | [Site Accounts](SITE-ACCOUNTS.md) | Acting as the owner on a site: sessions, permissions, the password vault |
 | [Plans](PLANS.md) | Work that outlives a turn: steps, waiting conditions, what reaches you |
+| [Sandbox](SANDBOX.md) | Running agent-written code: the container, session files, real budgets |
 | [Automations](AUTOMATIONS.md) | Scheduler, jobs, notifications, audit trail |
 | [Sub-Agents & Swarm](SWARM.md) | Optional multi-agent coordination |
 | [Skill Registry](REGISTRY.md) | Publishing, signing, installing and measuring skills |

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -1,0 +1,118 @@
+# Sandbox
+
+Two things want to run code the agent wrote: **one-off analysis** (total these
+forty listings, normalise this export) and **dynamic tools** (a named function
+the agent keeps and reuses). Both run in the same container, and only there.
+
+## What runs, and where it cannot go
+
+```
+docker run --network=none --read-only --cap-drop=ALL --user=10001:10001
+           --pids-limit=50 --memory=256m --cpus=1
+           --security-opt=no-new-privileges
+           --tmpfs=/tmp:noexec,nosuid,nodev,size=64m
+           -v <code>:/code:ro  -v <session files>:/work:rw  --workdir=/work
+```
+
+The standard library only — the image installs nothing, and packages stay
+refused unless a deployment lists them in `policy.yaml`.
+
+**There is no unsandboxed mode.** An earlier version fell back to `exec()` in the
+agent's own process when Docker was missing; it logged "unsafe, dev only" and was
+one environment variable away from production. Missing Docker now means the code
+does not run. `REQUIRE_DYNAMIC_TOOL_SANDBOX=false` turns dynamic tools **off**
+rather than running them unprotected.
+
+**There is no import blocklist.** The container is the boundary. A regex
+rejecting `import os` inside a network-less, capability-less container as a
+non-root user would refuse working code and buy nothing, while suggesting a
+protection that is not there.
+
+## `run_code`
+
+```
+run_code(code, session="", files="", timeout=30)
+```
+
+Print the answer — stdout is what comes back. Off by default:
+
+```bash
+ENABLE_CODE_EXECUTION=true          # or capabilities.code_execution in policy.yaml
+bash scripts/build-sandbox.sh       # deploy.sh does this when the image is missing
+```
+
+Errors come back separately from output, because code that printed a total and
+then crashed did not produce a total.
+
+## Files and sessions
+
+One writable directory per session, at `/work`, which is also the working
+directory — so `open("offers.csv", "w")` works and the file is still there next
+time:
+
+```
+data/<agent>/sandbox/<session>/
+  files/            ← shared by every run of the session, mounted read-write
+  <run-id>/         ← that run's manifest
+```
+
+The session name defaults to the current thread. For a plan step that is
+`plan:<id>`, so **a plan accumulates its own working files** without anyone
+naming them: a step fetches and normalises today, a step three days later reads
+the result.
+
+`files` takes a JSON object of name → text to drop in before the run. Names are
+reduced to a bare filename, so nothing can be written outside the session.
+
+## Limits, and which ones are real
+
+| Limit | Enforced by |
+|---|---|
+| Time | `asyncio.wait_for`, then the container is killed |
+| Memory, CPU, processes | Docker, at the kernel |
+| Network | `--network=none`; nothing to configure around it |
+| Disk | a watchdog **outside** the container measuring the session directory twice a second |
+
+The disk one is worth explaining: a read-write bind mount has no size of its own,
+so `storage_mb` would otherwise be a number in a manifest while a loop writing
+bytes filled the host disk. The watchdog is what makes the declared budget a
+budget.
+
+Ceilings come from `policy.yaml`:
+
+```yaml
+capabilities:
+  code_execution: false
+sandbox:
+  network_domains: []      # empty = no network, which is also what Docker enforces
+  packages: []             # empty = stdlib only
+  secret_capabilities: []
+  max_timeout_seconds: 60
+  max_storage_mb: 64
+  max_memory_mb: 256
+```
+
+A run asking for more than a ceiling is refused before the container starts, and
+the refusal is recorded.
+
+## The trail
+
+Every run and every refusal appends to `sandbox_runs.jsonl` with the policy
+decision, the resources declared, and redacted output. The dashboard's **Sandbox**
+page reads it. Secrets and PII are masked on the way in — a run's stdout is
+untrusted content like any other.
+
+## Honest limits
+
+- **Input names are not a security boundary.** They are validated for the audit
+  trail; what bounds a run is the container, the clock and the watchdog. The
+  allowlists that matter — network, packages, secret capabilities — start empty.
+- **A run can write up to its budget before the watchdog notices**, since the
+  check is periodic rather than a filesystem quota. The window is under a second
+  at default settings.
+- **`secret_capabilities` is declared and not yet implemented.** No secret is
+  ever passed into a container today; the field exists so that when one is, it
+  has to be declared first rather than injected.
+- **The image has no third-party packages.** For the arithmetic this exists for,
+  `csv`, `json` and `statistics` are enough; pandas would add hundreds of
+  megabytes to an image whose point is being small and boring.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -17,7 +17,7 @@ These defaults mean a fresh clone can run local chat/demo flows without allowing
 
 Telegram DMs are blocked until `ALLOWED_USERS` is configured, unless `ALLOW_ALL_USERS=true` is set explicitly.
 
-Dynamic tools require the local Docker sandbox image when `REQUIRE_DYNAMIC_TOOL_SANDBOX=true`. Build it with `scripts/build-sandbox.sh`; `kaos doctor` fails closed if dynamic tools are enabled but Docker or the image is missing.
+Agent-written code only ever runs in the Docker sandbox. Build the image with `scripts/build-sandbox.sh`; without it the code does not run. There is no in-process fallback — `REQUIRE_DYNAMIC_TOOL_SANDBOX=false` turns dynamic tools off rather than running them unsandboxed. `kaos doctor` fails closed if dynamic tools are enabled but Docker or the image is missing.
 
 ## Tool-Call Audit Trail
 

--- a/kronos/config.py
+++ b/kronos/config.py
@@ -81,6 +81,10 @@ class Settings(BaseSettings):
     # local deployments. Demo/fresh-clone mode should stay read-mostly.
     enable_dynamic_tools: bool = False
     require_dynamic_tool_sandbox: bool = True
+    # One-off code execution for analysis (run_code). Separate from
+    # enable_dynamic_tools on purpose: wanting to total a list of offers is not a
+    # reason to also allow the agent to author and keep new tools.
+    enable_code_execution: bool = False
     enable_mcp_gateway_management: bool = False
     enable_dynamic_mcp_servers: bool = False
     enable_server_ops: bool = False

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -106,6 +106,12 @@ class KronosAgent:
 
         self._tools.extend(ACQUIRE_TOOLS)
 
+        # Adding money up is where invented numbers come from, so it is a
+        # function rather than something the model does in its head.
+        from kronos.tools.compare import compare_offers
+
+        self._tools.append(compare_offers)
+
         # Working as the owner on configured sites. The tools hand out sessions,
         # never secrets.
         from kronos.tools.accounts_tools import ACCOUNT_TOOLS

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -112,6 +112,14 @@ class KronosAgent:
 
         self._tools.append(compare_offers)
 
+        # Running a short program beats doing arithmetic in prose. Opt-in, and
+        # only ever inside the container.
+        if settings.enable_code_execution:
+            from kronos.tools.code import CODE_TOOLS
+
+            self._tools.extend(CODE_TOOLS)
+            log.info("Code execution tool added (sandboxed)")
+
         # Working as the owner on configured sites. The tools hand out sessions,
         # never secrets.
         from kronos.tools.accounts_tools import ACCOUNT_TOOLS

--- a/kronos/policy.py
+++ b/kronos/policy.py
@@ -51,6 +51,10 @@ class CapabilityPolicy(BaseModel):
 
     dynamic_tools: bool = False
     dynamic_tool_sandbox_required: bool = True
+    # One-off sandboxed execution for analysis. Separate from dynamic_tools:
+    # totalling a list of offers is not a reason to also let the agent author and
+    # keep new tools.
+    code_execution: bool = False
     mcp_gateway_management: bool = False
     dynamic_mcp_servers: bool = False
     server_ops: bool = False
@@ -195,6 +199,32 @@ class EvolutionPolicy(BaseModel):
         return value
 
 
+class SandboxPolicy(BaseModel):
+    """What code running in the sandbox may reach and spend.
+
+    Every list is empty by default, which means refused — the sandbox has no
+    network and no extra packages unless a deployment writes them here. The
+    resource ceilings are what the watchdogs enforce, so they are the difference
+    between a declared budget and a real one.
+    """
+
+    network_domains: list[str] = Field(default_factory=list)
+    packages: list[str] = Field(default_factory=list)
+    secret_capabilities: list[str] = Field(default_factory=list)
+    max_cpu: float = 1.0
+    max_memory_mb: int = 256
+    max_timeout_seconds: int = 60
+    max_storage_mb: int = 64
+    max_process_count: int = 50
+
+    @field_validator("max_cpu", "max_memory_mb", "max_timeout_seconds", "max_storage_mb", "max_process_count")
+    @classmethod
+    def _positive(cls, value):
+        if value <= 0:
+            raise ValueError(f"sandbox limits must be positive, got {value!r}")
+        return value
+
+
 class Policy(BaseModel):
     """The whole declared posture of one deployment."""
 
@@ -209,6 +239,7 @@ class Policy(BaseModel):
     pii: PiiPolicy = Field(default_factory=PiiPolicy)
     registry: RegistryPolicy = Field(default_factory=RegistryPolicy)
     evolution: EvolutionPolicy = Field(default_factory=EvolutionPolicy)
+    sandbox: SandboxPolicy = Field(default_factory=SandboxPolicy)
 
     # Where this policy came from; "" means "no file, code defaults".
     source_path: str = ""
@@ -230,6 +261,7 @@ class Policy(BaseModel):
 _SETTINGS_MAP: tuple[tuple[str, str, str], ...] = (
     ("capabilities", "dynamic_tools", "enable_dynamic_tools"),
     ("capabilities", "dynamic_tool_sandbox_required", "require_dynamic_tool_sandbox"),
+    ("capabilities", "code_execution", "enable_code_execution"),
     ("capabilities", "mcp_gateway_management", "enable_mcp_gateway_management"),
     ("capabilities", "dynamic_mcp_servers", "enable_dynamic_mcp_servers"),
     ("capabilities", "server_ops", "enable_server_ops"),

--- a/kronos/tools/code.py
+++ b/kronos/tools/code.py
@@ -1,0 +1,213 @@
+"""Running a short program instead of doing arithmetic in prose.
+
+Forty listings, twenty product cards, a bank export in a format nobody planned
+for — the work is normalising and counting, and a model doing that in its head is
+where invented totals come from. This runs the code instead, in the same
+container as everything else here: no network, read-only root, every capability
+dropped, non-root, killed on time or on disk.
+
+Files live per session and outlive the run. A step that writes ``offers.csv``
+today and a plan step that reads it on Thursday are the same session, so the
+session name defaults to the thread — which for a plan step is ``plan:<id>``,
+meaning a plan accumulates its own working files without anyone naming them.
+
+**No import blocklist.** The container is the boundary. A regex that rejects
+``import os`` inside a network-less, capability-less container would refuse
+legitimate code and buy nothing — and pretending otherwise is the false
+confidence this module's neighbours were just cleaned of.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+from langchain_core.tools import tool
+
+from kronos.audit import get_tool_audit_context
+from kronos.config import settings
+from kronos.security.effects import mark_side_effect
+
+log = logging.getLogger("kronos.tools.code")
+
+MAX_CODE_CHARS = 20_000
+MAX_OUTPUT_CHARS = 8_000
+MAX_INPUT_FILE_CHARS = 200_000
+MAX_INPUT_FILES = 20
+MAX_TIMEOUT_SECONDS = 120
+DEFAULT_TIMEOUT_SECONDS = 30
+LISTED_FILES = 25
+
+
+def safe_filename(name: str) -> str:
+    """A file name that cannot leave the session directory. Empty if hopeless."""
+    cleaned = Path(str(name)).name.strip()
+    if cleaned in ("", ".", ".."):
+        return ""
+    return "".join(char for char in cleaned if char.isalnum() or char in "._- ")[:80].strip()
+
+
+def default_session() -> str:
+    """The thread this call belongs to, so a plan's runs share their files."""
+    context = get_tool_audit_context()
+    return context.get("thread_id") or context.get("session_id") or "default"
+
+
+def _write_inputs(files_dir: Path, raw: str) -> tuple[list[str], str]:
+    """(names written, error). Text only: this is for data the agent already has."""
+    if not raw.strip():
+        return [], ""
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as e:
+        return [], f"files must be a JSON object of name → text content: {e}"
+    if not isinstance(payload, dict):
+        return [], "files must be a JSON object of name → text content"
+    if len(payload) > MAX_INPUT_FILES:
+        return [], f"too many files ({len(payload)}; max {MAX_INPUT_FILES})"
+
+    written = []
+    for name, content in payload.items():
+        safe = safe_filename(name)
+        if not safe:
+            return [], f"{name!r} is not a usable file name"
+        text = content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
+        if len(text) > MAX_INPUT_FILE_CHARS:
+            return [], f"{safe} is larger than {MAX_INPUT_FILE_CHARS} characters"
+        (files_dir / safe).write_text(text, encoding="utf-8")
+        written.append(safe)
+    return written, ""
+
+
+def _list_files(files_dir: Path) -> list[str]:
+    entries = []
+    for path in sorted(files_dir.rglob("*")):
+        if path.is_file():
+            entries.append(f"{path.relative_to(files_dir)} ({path.stat().st_size} bytes)")
+    return entries
+
+
+def _truncate(text: str) -> str:
+    text = (text or "").strip()
+    if len(text) <= MAX_OUTPUT_CHARS:
+        return text
+    return text[:MAX_OUTPUT_CHARS] + f"\n… truncated at {MAX_OUTPUT_CHARS} characters"
+
+
+@tool
+async def run_code(code: str, session: str = "", files: str = "", timeout: int = DEFAULT_TIMEOUT_SECONDS) -> str:
+    """Run a short Python program in a locked-down container and return its output.
+
+    Use it for anything countable: totalling costs, normalising scraped rows into
+    one shape, parsing an odd export, checking dates. Print what you want back —
+    stdout is the answer.
+
+    The standard library only, no network. Files you write in the current
+    directory stay for later calls with the same session, so one run can prepare
+    data and the next can use it.
+
+    Args:
+        code: Python source. Print the result; nothing else is returned.
+        session: Name for the working directory. Defaults to this conversation,
+            so a plan's steps share their files.
+        files: Optional JSON object of name → text to place next to the code
+            before it runs, e.g. {"offers.json": "[{...}]"}.
+        timeout: Seconds to allow (max 120).
+    """
+    if not settings.enable_code_execution:
+        return (
+            "[ERROR] Code execution is off. It is opt-in: set ENABLE_CODE_EXECUTION=true "
+            "(or capabilities.code_execution in policy.yaml) and build the sandbox image."
+        )
+    if not code.strip():
+        return "[ERROR] No code given."
+    if len(code) > MAX_CODE_CHARS:
+        return f"[ERROR] Code is longer than {MAX_CODE_CHARS} characters."
+    try:
+        compile(code, "<run_code>", "exec")
+    except SyntaxError as e:
+        return f"[ERROR] The code does not parse: {e}"
+
+    from kronos.tools.sandbox import DEFAULT_MEMORY, execute_sandboxed, sandbox_ready, sandbox_unavailable_message
+    from kronos.tools.sandbox_platform import (
+        PolicyDecision,
+        SandboxRunRequest,
+        create_session_workspace,
+        evaluate_policy,
+        record_sandbox_decision,
+        sandbox_policy,
+    )
+
+    limits = sandbox_policy().max_resources
+    seconds = max(1, min(int(timeout), MAX_TIMEOUT_SECONDS, limits.timeout_seconds))
+    request = SandboxRunRequest(
+        tool_name="run_code",
+        session_id=session.strip() or default_session(),
+        # Named for the audit trail, not as a security claim: what actually
+        # bounds this run is the container, the clock and the disk watchdog.
+        input_mounts=("files",),
+        output_mounts=("files",),
+        resources=limits,
+    )
+
+    policy = sandbox_policy()
+    decision = evaluate_policy(request, policy)
+    if not decision.allowed:
+        record_sandbox_decision(request, decision, policy)
+        return f"[ERROR] Blocked by sandbox policy: {', '.join(decision.violations)}"
+
+    if not sandbox_ready():
+        record_sandbox_decision(
+            request,
+            PolicyDecision(False, "sandbox unavailable", ("execution:docker_not_ready",)),
+            policy,
+        )
+        return f"[ERROR] {sandbox_unavailable_message()}"
+
+    workspace = create_session_workspace(request)
+    files_dir = Path(workspace["files"])
+    written, error = _write_inputs(files_dir, files)
+    if error:
+        return f"[ERROR] {error}"
+
+    stdout, stderr = await execute_sandboxed(
+        code,
+        timeout=seconds,
+        memory_limit=DEFAULT_MEMORY,
+        network=False,
+        files_dir=str(files_dir),
+        storage_mb=limits.storage_mb,
+    )
+    record_sandbox_decision(
+        request,
+        decision,
+        policy,
+        stdout=stdout,
+        stderr=stderr,
+        resources_used={"timeout_seconds": seconds, "storage_mb": limits.storage_mb},
+    )
+
+    return _render(request.session_id, written, stdout, stderr, _list_files(files_dir))
+
+
+def _render(session: str, written: list[str], stdout: str, stderr: str, present: list[str]) -> str:
+    parts = [f"Ran in session '{session}'."]
+    if written:
+        parts.append(f"Placed: {', '.join(written)}")
+    if stdout:
+        parts.append("Output:\n" + _truncate(stdout))
+    if stderr:
+        # Not folded into the output: code that printed a total and then failed
+        # is not code that produced a total.
+        parts.append("Errors:\n" + _truncate(stderr))
+    if not stdout and not stderr:
+        parts.append("The program printed nothing. stdout is the only thing returned — print the result.")
+    if present:
+        shown = present[:LISTED_FILES]
+        more = f" (+{len(present) - len(shown)} more)" if len(present) > len(shown) else ""
+        parts.append(f"Files in the session now: {', '.join(shown)}{more}")
+    return "\n\n".join(parts)
+
+
+# Running code writes files that outlive the turn, so durable resume must not
+# replay it blindly — the second run would see the first run's leftovers.
+CODE_TOOLS = mark_side_effect([run_code], reason="code execution")

--- a/kronos/tools/compare.py
+++ b/kronos/tools/compare.py
@@ -1,0 +1,245 @@
+"""Comparing offers: arithmetic and completeness, not judgement.
+
+"Which flat is the better deal" and "where is this console cheaper" both come
+down to adding money up correctly and noticing what is missing. Models are bad
+at exactly those two things and good at the part that follows — weighing a
+shorter commute against a higher rent. So this module does the first part and
+refuses to do the second.
+
+What it therefore will not do: score, weight, or pick a winner on anything but
+money. A function that decided a 4.6-star seller beats a 4.9-star one because
+it saves 3% would be making the owner's tradeoff for them, silently and in
+code.
+
+Three refusals carry most of the value:
+
+* **A missing field is not zero.** A listing that never states the deposit is
+  not a listing with no deposit, and treating it as one makes the incomplete
+  offer look cheapest. Those offers are set aside, named, and never ranked.
+* **Two currencies do not add up.** Without a rate — which this module has no
+  business inventing — a total mixing Rp and USD is a wrong number that looks
+  right.
+* **A one-off cost is not a monthly one.** A deposit and a rent are both money
+  and are not the same money, so which is which has to be stated.
+"""
+
+import json
+import logging
+from dataclasses import dataclass, field
+
+from langchain_core.tools import tool
+
+from kronos.plan_conditions import format_number, parse_number
+
+log = logging.getLogger("kronos.tools.compare")
+
+MAX_OFFERS = 60
+NAME_KEYS = ("name", "title", "label", "offer", "listing")
+CURRENCY_KEYS = ("currency", "cur", "ccy")
+
+
+@dataclass
+class Comparison:
+    ranked: list[dict] = field(default_factory=list)
+    incomplete: list[dict] = field(default_factory=list)
+    currency: str = ""
+    periods: int = 1
+    one_off: list[str] = field(default_factory=list)
+    recurring: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+
+class CompareError(Exception):
+    """Raised when the offers cannot be compared at all, with the reason."""
+
+
+def _split(raw: str) -> list[str]:
+    return [part.strip() for part in (raw or "").replace(";", ",").split(",") if part.strip()]
+
+
+def _name_of(offer: dict, index: int) -> str:
+    for key in NAME_KEYS:
+        value = offer.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return f"offer {index + 1}"
+
+
+def _currency_of(offer: dict) -> str:
+    for key in CURRENCY_KEYS:
+        value = offer.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().upper()
+    return ""
+
+
+def _amount(offer: dict, key: str) -> tuple[float | None, str]:
+    """(value, why it is missing). A key that is absent and one that is unreadable
+    are both missing, but the owner should be told which."""
+    if key not in offer:
+        return None, f"{key} not stated"
+    raw = offer[key]
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        return None, f"{key} empty"
+    if isinstance(raw, int | float):
+        return float(raw), ""
+    number = parse_number(str(raw))
+    if number is None:
+        return None, f"{key} unreadable ({str(raw)[:40]!r})"
+    return number, ""
+
+
+def compare(
+    offers: list[dict],
+    *,
+    one_off: list[str] | None = None,
+    recurring: list[str] | None = None,
+    periods: int = 1,
+) -> Comparison:
+    """Total each offer and rank the complete ones. Never invents a number.
+
+    ``recurring`` fields are multiplied by ``periods``; ``one_off`` fields are
+    counted once. Anything not named in either is carried through untouched, for
+    whoever weighs it.
+    """
+    if not offers:
+        raise CompareError("no offers to compare")
+    if len(offers) > MAX_OFFERS:
+        raise CompareError(f"{len(offers)} offers is more than this compares at once (max {MAX_OFFERS})")
+    if periods < 1:
+        raise CompareError("periods must be at least 1")
+
+    one_off = one_off or []
+    recurring = recurring or []
+    if not one_off and not recurring:
+        raise CompareError("name at least one cost field, e.g. recurring='price' or one_off='shipping'")
+
+    result = Comparison(periods=periods, one_off=list(one_off), recurring=list(recurring))
+    for index, offer in enumerate(offers):
+        if not isinstance(offer, dict):
+            raise CompareError(f"offer {index + 1} is not an object")
+
+    currencies = {_currency_of(offer) for offer in offers} - {""}
+    if len(currencies) > 1:
+        raise CompareError(
+            f"offers are priced in {', '.join(sorted(currencies))} — convert them to one currency first; "
+            f"adding them up as they are would produce a wrong number that looks right"
+        )
+    result.currency = next(iter(currencies), "")
+
+    for index, offer in enumerate(offers):
+        name = _name_of(offer, index)
+        parts: dict[str, float] = {}
+        missing: list[str] = []
+        total = 0.0
+
+        for key in recurring:
+            value, why = _amount(offer, key)
+            if value is None:
+                missing.append(why)
+                continue
+            parts[key] = value * periods
+            total += value * periods
+        for key in one_off:
+            value, why = _amount(offer, key)
+            if value is None:
+                missing.append(why)
+                continue
+            parts[key] = value
+            total += value
+
+        extras = {
+            key: offer[key]
+            for key in offer
+            if key not in recurring and key not in one_off and key not in NAME_KEYS and key not in CURRENCY_KEYS
+        }
+        row = {"name": name, "total": round(total, 2), "parts": parts, "other": extras}
+        if missing:
+            # Set aside rather than ranked: a total that silently skips the
+            # deposit is what makes the least documented offer look best.
+            result.incomplete.append({**row, "missing": missing})
+        else:
+            result.ranked.append(row)
+
+    result.ranked.sort(key=lambda row: row["total"])
+    if result.ranked:
+        cheapest = result.ranked[0]["total"]
+        for row in result.ranked:
+            row["over_cheapest"] = round(row["total"] - cheapest, 2)
+    if result.incomplete:
+        result.notes.append(
+            f"{len(result.incomplete)} offer(s) are missing a cost and were not ranked — "
+            f"a missing figure is not a zero one."
+        )
+    return result
+
+
+def render(result: Comparison) -> str:
+    """The comparison as text, with the arithmetic left visible to be checked."""
+    money = f" {result.currency}" if result.currency else ""
+    span = f" over {result.periods} periods" if result.periods > 1 else ""
+    lines = [f"Total cost{span}, cheapest first{money}:"]
+
+    for position, row in enumerate(result.ranked, start=1):
+        breakdown = " + ".join(f"{key} {format_number(value)}" for key, value in row["parts"].items())
+        delta = f"  (+{format_number(row['over_cheapest'])})" if row.get("over_cheapest") else ""
+        lines.append(f"{position}. {row['name']}: {format_number(row['total'])}{delta}")
+        if breakdown:
+            lines.append(f"   = {breakdown}")
+        if row["other"]:
+            lines.append(f"   other: {_render_extras(row['other'])}")
+
+    if result.incomplete:
+        lines.append("")
+        lines.append("Not ranked — a cost is missing, and a missing figure is not a zero one:")
+        for row in result.incomplete:
+            lines.append(f"- {row['name']}: {', '.join(row['missing'])}")
+            if row["other"]:
+                lines.append(f"   other: {_render_extras(row['other'])}")
+
+    lines.append("")
+    lines.append(
+        "This is arithmetic only. Weighing the rest — location, seller, terms — is not "
+        "something this decides; do that yourself and say why."
+    )
+    return "\n".join(lines)
+
+
+def _render_extras(extras: dict) -> str:
+    return ", ".join(f"{key} {value}" for key, value in list(extras.items())[:8])
+
+
+@tool
+async def compare_offers(offers: str, recurring: str = "", one_off: str = "", periods: int = 1) -> str:
+    """Add up what each offer really costs and rank them, showing the arithmetic.
+
+    Use this instead of totalling prices yourself — that is where invented numbers
+    come from. It ranks on money only; weighing location, seller reputation or
+    terms is your job, and the result says so.
+
+    Offers missing one of the cost fields are set aside rather than ranked: a
+    listing that does not state the deposit is not a listing without one.
+
+    Args:
+        offers: JSON array of objects, one per offer. Use "name" for the label and
+            put each cost in its own field, e.g.
+            [{"name":"Villa A","currency":"USD","price":800,"deposit":1600,"utilities":90,"rating":4.8}]
+            Values may be written as on the page ("Rp 8.750.000") — they are parsed.
+        recurring: comma-separated cost fields charged every period, e.g. "price,utilities".
+        one_off: comma-separated costs charged once, e.g. "deposit,shipping,duty".
+        periods: how many periods the recurring costs are counted for (months of
+            stay, for instance). Default 1.
+    """
+    try:
+        parsed = json.loads(offers)
+    except json.JSONDecodeError as e:
+        return f"[ERROR] offers must be a JSON array: {e}"
+    if not isinstance(parsed, list):
+        return "[ERROR] offers must be a JSON array of objects"
+
+    try:
+        result = compare(parsed, one_off=_split(one_off), recurring=_split(recurring), periods=periods)
+    except CompareError as e:
+        return f"[ERROR] {e}"
+
+    return render(result)

--- a/kronos/tools/dynamic.py
+++ b/kronos/tools/dynamic.py
@@ -10,7 +10,6 @@ access, no network, no imports beyond allowlist).
 """
 
 import ast
-import inspect
 import json
 import logging
 import re
@@ -226,15 +225,6 @@ def _build_runner_code(code: str, func_name: str, args: tuple, kwargs: dict) -> 
     )
 
 
-async def _run_locally_for_dev(code: str, func_name: str, args: tuple, kwargs: dict):
-    namespace: dict = {}
-    exec(code, namespace)  # noqa: S102
-    result = namespace[func_name](*args, **kwargs)
-    if inspect.isawaitable(result):
-        return await result
-    return result
-
-
 def _build_dynamic_tool(name: str, code: str, spec: ToolFunctionSpec) -> BaseTool:
     async def _sandboxed_wrapper(*args, **kwargs):
         """Execute the dynamic tool in a Docker sandbox."""
@@ -280,17 +270,14 @@ def _build_dynamic_tool(name: str, code: str, spec: ToolFunctionSpec) -> BaseToo
             if stderr:
                 log.warning("Sandbox stderr for %s: %s", spec.name, stderr[:200])
             return stdout or stderr or "No output"
-        if settings.require_dynamic_tool_sandbox:
-            from kronos.tools.sandbox import sandbox_unavailable_message
+        from kronos.tools.sandbox import sandbox_unavailable_message
 
-            record_sandbox_decision(
-                request,
-                PolicyDecision(False, "sandbox unavailable", ("execution:docker_not_ready",)),
-                policy,
-            )
-            return f"Blocked: Docker sandbox is required for dynamic tools. {sandbox_unavailable_message()}"
-
-        return await _run_locally_for_dev(code, spec.name, args, kwargs)
+        record_sandbox_decision(
+            request,
+            PolicyDecision(False, "sandbox unavailable", ("execution:docker_not_ready",)),
+            policy,
+        )
+        return f"Blocked: the Docker sandbox is required to run this. {sandbox_unavailable_message()}"
 
     _sandboxed_wrapper.__name__ = spec.name
     _sandboxed_wrapper.__doc__ = spec.description
@@ -345,15 +332,22 @@ async def create_tool(name: str, description: str) -> tuple[BaseTool | None, str
     if spec.name != clean_name:
         return None, f"Generated code rejected: function name must match tool name '{clean_name}'"
 
-    if settings.require_dynamic_tool_sandbox:
-        from kronos.tools.sandbox import sandbox_ready, sandbox_unavailable_message
+    if not settings.require_dynamic_tool_sandbox:
+        # There is no unsandboxed mode any more. Asking not to require a sandbox
+        # is answered by not having the feature, rather than by running the code
+        # in this process.
+        return None, (
+            "Dynamic tools are unavailable while REQUIRE_DYNAMIC_TOOL_SANDBOX=false: "
+            "running agent-written code outside the sandbox is not supported."
+        )
 
-        if not sandbox_ready():
-            return None, (
-                "Docker sandbox is required before dynamic tools can be created. "
-                f"{sandbox_unavailable_message()} "
-                "Set REQUIRE_DYNAMIC_TOOL_SANDBOX=false for local development only."
-            )
+    from kronos.tools.sandbox import sandbox_ready, sandbox_unavailable_message
+
+    if not sandbox_ready():
+        return (
+            None,
+            f"The Docker sandbox must be ready before a dynamic tool can be created. {sandbox_unavailable_message()}",
+        )
 
     tool = _build_dynamic_tool(clean_name, code, spec)
 
@@ -369,12 +363,17 @@ def load_persisted_tools() -> list[BaseTool]:
     if not settings.enable_dynamic_tools:
         return []
 
-    if settings.require_dynamic_tool_sandbox:
-        from kronos.tools.sandbox import sandbox_ready, sandbox_unavailable_message
+    if not settings.require_dynamic_tool_sandbox:
+        log.warning(
+            "Skipping persisted dynamic tools: REQUIRE_DYNAMIC_TOOL_SANDBOX=false and there is no unsandboxed mode"
+        )
+        return []
 
-        if not sandbox_ready():
-            log.warning("Skipping persisted dynamic tools: %s", sandbox_unavailable_message())
-            return []
+    from kronos.tools.sandbox import sandbox_ready, sandbox_unavailable_message
+
+    if not sandbox_ready():
+        log.warning("Skipping persisted dynamic tools: %s", sandbox_unavailable_message())
+        return []
 
     if not TOOLS_DIR.exists():
         return []

--- a/kronos/tools/dynamic.py
+++ b/kronos/tools/dynamic.py
@@ -231,24 +231,22 @@ def _build_dynamic_tool(name: str, code: str, spec: ToolFunctionSpec) -> BaseToo
         from kronos.tools.sandbox import execute_sandboxed, sandbox_ready
         from kronos.tools.sandbox_platform import (
             PolicyDecision,
-            SandboxPolicy,
-            SandboxResourceLimits,
             SandboxRunRequest,
             create_session_workspace,
             evaluate_policy,
             record_sandbox_decision,
+            sandbox_policy,
         )
 
-        request_inputs = tuple([f"arg_{index}" for index, _ in enumerate(args)] + list(kwargs.keys()))
+        # The policy comes from policy.yaml, not from this call. It used to be
+        # built out of the request's own argument names, which made an input
+        # violation impossible — a check that could only ever pass.
+        policy = sandbox_policy()
         request = SandboxRunRequest(
             tool_name=spec.name,
             session_id=f"dynamic:{spec.name}",
-            input_mounts=request_inputs,
-            resources=SandboxResourceLimits(timeout_seconds=30),
-        )
-        policy = SandboxPolicy(
-            allowed_inputs=request_inputs,
-            max_resources=SandboxResourceLimits(timeout_seconds=30),
+            input_mounts=tuple([f"arg_{index}" for index, _ in enumerate(args)] + list(kwargs.keys())),
+            resources=policy.max_resources,
         )
         decision = evaluate_policy(request, policy)
         if not decision.allowed:
@@ -257,15 +255,21 @@ def _build_dynamic_tool(name: str, code: str, spec: ToolFunctionSpec) -> BaseToo
 
         if sandbox_ready():
             runner_code = _build_runner_code(code, spec.name, args, kwargs)
-            create_session_workspace(request)
-            stdout, stderr = await execute_sandboxed(runner_code, timeout=30)
+            workspace = create_session_workspace(request)
+            timeout = policy.max_resources.timeout_seconds
+            stdout, stderr = await execute_sandboxed(
+                runner_code,
+                timeout=timeout,
+                files_dir=workspace["files"],
+                storage_mb=policy.max_resources.storage_mb,
+            )
             record_sandbox_decision(
                 request,
                 decision,
                 policy,
                 stdout=stdout,
                 stderr=stderr,
-                resources_used={"timeout_seconds": 30},
+                resources_used={"timeout_seconds": timeout, "storage_mb": policy.max_resources.storage_mb},
             )
             if stderr:
                 log.warning("Sandbox stderr for %s: %s", spec.name, stderr[:200])

--- a/kronos/tools/sandbox.py
+++ b/kronos/tools/sandbox.py
@@ -73,6 +73,36 @@ def sandbox_unavailable_message() -> str:
     return f"Sandbox image {SANDBOX_IMAGE} is missing. Run `{SANDBOX_BUILD_SCRIPT}`."
 
 
+SANDBOX_UID = 10001
+
+
+def container_user() -> str:
+    """Which uid:gid the container runs as — never root, and able to use the mounts.
+
+    Bind mounts carry the host's ownership, so a container running as uid 10001
+    could neither read a 0700 temp directory nor write into a directory owned by
+    the agent's user. Running as the agent's own uid solves both without making
+    anything world-accessible; the image's baked-in 10001 stays as the answer for
+    the one case where the agent's uid would be root, and there the mounts get
+    chowned instead.
+    """
+    uid = os.getuid() if hasattr(os, "getuid") else SANDBOX_UID
+    if uid == 0:
+        return f"{SANDBOX_UID}:{SANDBOX_UID}"
+    return f"{uid}:{os.getgid()}"
+
+
+def _grant_access(path: str) -> None:
+    """Make a mounted directory usable by the container user."""
+    if not hasattr(os, "getuid") or os.getuid() != 0:
+        # Running as ourselves: the mounts are already ours.
+        return
+    try:
+        os.chown(path, SANDBOX_UID, SANDBOX_UID)
+    except OSError as e:  # pragma: no cover - only reachable as root
+        log.warning("Cannot hand %s to the sandbox user: %s", path, e)
+
+
 def build_sandbox_command(
     tmpdir: str,
     memory_limit: str = DEFAULT_MEMORY,
@@ -99,7 +129,7 @@ def build_sandbox_command(
         "--cap-drop=ALL",
         "--tmpfs=/tmp:rw,noexec,nosuid,nodev,size=64m",
         "--security-opt=no-new-privileges",
-        "--user=10001:10001",
+        f"--user={container_user()}",
         "--workdir=/work" if files_dir else "--workdir=/code",
         "-v",
         f"{tmpdir}:/code:ro",
@@ -164,6 +194,14 @@ async def execute_sandboxed(
         tmpdir = tempfile.mkdtemp(prefix="kronos-sandbox-")
         code_file = Path(tmpdir) / "tool.py"
         code_file.write_text(code, encoding="utf-8")
+        # mkdtemp is 0700. Mounted into a container running as anyone else, that
+        # is a permission denied on the very file being executed — which is how
+        # this path was silently broken until a real container was tried.
+        os.chmod(tmpdir, 0o755)
+        os.chmod(code_file, 0o644)
+        _grant_access(tmpdir)
+        if files_dir:
+            _grant_access(files_dir)
 
         cmd = build_sandbox_command(tmpdir, memory_limit=memory_limit, network=network, files_dir=files_dir)
 

--- a/kronos/tools/sandbox.py
+++ b/kronos/tools/sandbox.py
@@ -22,6 +22,8 @@ SANDBOX_IMAGE = "kronos-sandbox:latest"
 SANDBOX_BUILD_SCRIPT = "scripts/build-sandbox.sh"
 DEFAULT_TIMEOUT = 30
 DEFAULT_MEMORY = "256m"
+DEFAULT_STORAGE_MB = 64
+STORAGE_CHECK_INTERVAL_SECONDS = 0.5
 
 
 def _docker_available() -> bool:
@@ -75,10 +77,17 @@ def build_sandbox_command(
     tmpdir: str,
     memory_limit: str = DEFAULT_MEMORY,
     network: bool = False,
+    files_dir: str | None = None,
 ) -> list[str]:
-    """Build the Docker command for a single sandboxed execution."""
+    """Build the Docker command for a single sandboxed execution.
+
+    With ``files_dir`` the session's shared directory is mounted read-write at
+    /work and becomes the working directory, so ordinary relative writes
+    (``open("offers.csv", "w")``) land somewhere that outlives the container.
+    Without it nothing is writable but /tmp, which the container discards.
+    """
     network_flag = "bridge" if network else "none"
-    return [
+    command = [
         "docker",
         "run",
         "--rm",
@@ -91,13 +100,38 @@ def build_sandbox_command(
         "--tmpfs=/tmp:rw,noexec,nosuid,nodev,size=64m",
         "--security-opt=no-new-privileges",
         "--user=10001:10001",
-        "--workdir=/code",
+        "--workdir=/work" if files_dir else "--workdir=/code",
         "-v",
         f"{tmpdir}:/code:ro",
-        SANDBOX_IMAGE,
-        "python",
-        "/sandbox/runner.py",
     ]
+    if files_dir:
+        command += ["-v", f"{files_dir}:/work:rw"]
+    command += [SANDBOX_IMAGE, "python", "/sandbox/runner.py"]
+    return command
+
+
+async def _kill_over_budget(files_dir: str, limit_mb: int, proc: asyncio.subprocess.Process) -> str:
+    """Stop the run if it fills the shared directory. Returns why, or "".
+
+    A read-write bind mount has no size of its own, so the declared storage
+    budget would otherwise be a number in a manifest while a loop writing bytes
+    filled the host disk. Checking from outside is cheap and makes the declared
+    limit real.
+    """
+    from kronos.tools.sandbox_platform import directory_size_bytes
+
+    limit_bytes = max(1, limit_mb) * 1024 * 1024
+    path = Path(files_dir)
+    while proc.returncode is None:
+        await asyncio.sleep(STORAGE_CHECK_INTERVAL_SECONDS)
+        if directory_size_bytes(path) > limit_bytes:
+            log.warning("Sandbox run exceeded %d MB in %s; stopping it", limit_mb, files_dir)
+            try:
+                proc.kill()
+            except ProcessLookupError:  # pragma: no cover - it just exited
+                return ""
+            return f"Stopped: the run wrote more than {limit_mb} MB into the session directory."
+    return ""
 
 
 async def execute_sandboxed(
@@ -105,6 +139,8 @@ async def execute_sandboxed(
     timeout: int = DEFAULT_TIMEOUT,
     memory_limit: str = DEFAULT_MEMORY,
     network: bool = False,
+    files_dir: str | None = None,
+    storage_mb: int = DEFAULT_STORAGE_MB,
 ) -> tuple[str, str]:
     """Execute Python code in a Docker sandbox.
 
@@ -113,6 +149,8 @@ async def execute_sandboxed(
         timeout: Max execution time in seconds
         memory_limit: Docker memory limit (e.g. '256m')
         network: Whether to allow network access
+        files_dir: Host directory mounted read-write at /work (the session's files)
+        storage_mb: How much that directory may grow to before the run is stopped
 
     Returns:
         Tuple of (stdout, stderr)
@@ -121,12 +159,13 @@ async def execute_sandboxed(
         return "", f"Sandbox unavailable: {sandbox_unavailable_message()}"
 
     tmpdir = None
+    watchdog: asyncio.Task | None = None
     try:
         tmpdir = tempfile.mkdtemp(prefix="kronos-sandbox-")
         code_file = Path(tmpdir) / "tool.py"
         code_file.write_text(code, encoding="utf-8")
 
-        cmd = build_sandbox_command(tmpdir, memory_limit=memory_limit, network=network)
+        cmd = build_sandbox_command(tmpdir, memory_limit=memory_limit, network=network, files_dir=files_dir)
 
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -134,12 +173,21 @@ async def execute_sandboxed(
             stderr=asyncio.subprocess.PIPE,
         )
 
+        if files_dir:
+            watchdog = asyncio.create_task(_kill_over_budget(files_dir, storage_mb, proc))
+
         try:
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
         except TimeoutError:
             proc.kill()
             await proc.wait()
             return "", f"Execution timed out after {timeout}s"
+
+        if watchdog is not None:
+            over_budget = await watchdog
+            watchdog = None
+            if over_budget:
+                return stdout.decode("utf-8", errors="replace").strip(), over_budget
 
         return (
             stdout.decode("utf-8", errors="replace").strip(),
@@ -153,5 +201,7 @@ async def execute_sandboxed(
         log.error("Sandbox execution failed: %s", e)
         return "", f"Sandbox error: {e}"
     finally:
+        if watchdog is not None:
+            watchdog.cancel()
         if tmpdir and os.path.exists(tmpdir):
             shutil.rmtree(tmpdir, ignore_errors=True)

--- a/kronos/tools/sandbox.py
+++ b/kronos/tools/sandbox.py
@@ -1,7 +1,11 @@
-"""Docker sandbox for dynamic tool execution.
+"""Docker sandbox for running code the agent wrote.
 
-Runs untrusted code in isolated Docker containers instead of exec() in-process.
-Public-safe default fails closed if Docker is unavailable.
+Everything here runs in a container with no network, a read-only root, every
+capability dropped and a non-root uid. **There is no fallback.** An earlier
+version dropped to ``exec()`` in the agent's own process when Docker was
+missing and ``require_dynamic_tool_sandbox`` was off — a mode described in its
+own log line as unsafe, one environment variable away from arbitrary code in
+production. Missing Docker now means the code does not run.
 """
 
 import asyncio
@@ -113,21 +117,8 @@ async def execute_sandboxed(
     Returns:
         Tuple of (stdout, stderr)
     """
-    from kronos.config import settings
-
-    if not _docker_available():
-        if settings.require_dynamic_tool_sandbox:
-            return "", "Sandbox unavailable: Docker is required for dynamic tool execution."
-
-        log.warning("Docker not available, falling back to in-process exec")
-        return _exec_in_process(code, timeout)
-
-    if not _docker_image_available():
-        if settings.require_dynamic_tool_sandbox:
-            return "", f"Sandbox unavailable: {sandbox_unavailable_message()}"
-
-        log.warning("Docker sandbox image not available, falling back to in-process exec")
-        return _exec_in_process(code, timeout)
+    if not sandbox_ready():
+        return "", f"Sandbox unavailable: {sandbox_unavailable_message()}"
 
     tmpdir = None
     try:
@@ -156,39 +147,11 @@ async def execute_sandboxed(
         )
 
     except FileNotFoundError:
-        from kronos.config import settings
-
-        if settings.require_dynamic_tool_sandbox:
-            return "", "Sandbox unavailable: Docker binary not found."
-
-        log.warning("Docker binary not found, falling back to in-process exec")
-        return _exec_in_process(code, timeout)
+        # Docker disappeared between the readiness check and the run.
+        return "", "Sandbox unavailable: Docker binary not found."
     except Exception as e:
         log.error("Sandbox execution failed: %s", e)
         return "", f"Sandbox error: {e}"
     finally:
         if tmpdir and os.path.exists(tmpdir):
             shutil.rmtree(tmpdir, ignore_errors=True)
-
-
-def _exec_in_process(code: str, timeout: int = DEFAULT_TIMEOUT) -> tuple[str, str]:
-    """Fallback: execute code in-process (unsafe, for dev/testing only)."""
-    import io
-    import sys
-
-    log.warning("Executing dynamic tool in-process (no sandbox isolation)")
-
-    old_stdout = sys.stdout
-    old_stderr = sys.stderr
-    sys.stdout = captured_out = io.StringIO()
-    sys.stderr = captured_err = io.StringIO()
-
-    try:
-        namespace: dict = {}
-        exec(code, namespace)  # noqa: S102
-        return captured_out.getvalue().strip(), captured_err.getvalue().strip()
-    except Exception as e:
-        return "", f"Execution error: {e}"
-    finally:
-        sys.stdout = old_stdout
-        sys.stderr = old_stderr

--- a/kronos/tools/sandbox_platform.py
+++ b/kronos/tools/sandbox_platform.py
@@ -74,6 +74,37 @@ class PolicyDecision:
     violations: tuple[str, ...] = ()
 
 
+def sandbox_policy() -> SandboxPolicy:
+    """The ceilings and allowlists for a run, taken from the governance policy.
+
+    The point of reading them here is that the caller cannot supply them. A
+    policy assembled from the same request it validates is not a check, and that
+    is exactly what the dynamic-tool path used to do — ``allowed_inputs`` built
+    from ``request.input_mounts``, so an input violation was unreachable.
+
+    Input names are deliberately unrestricted: they are argument and file names,
+    not a security boundary. What bounds a run is the container, the clock and
+    the disk watchdog. The allowlists that do matter — network, packages, secret
+    capabilities — start empty, which means refused.
+    """
+    from kronos.policy import get_policy
+
+    declared = get_policy().sandbox
+    return SandboxPolicy(
+        allowed_inputs=("*",),
+        allowed_network_domains=tuple(declared.network_domains),
+        allowed_packages=tuple(declared.packages),
+        allowed_secret_capabilities=tuple(declared.secret_capabilities),
+        max_resources=SandboxResourceLimits(
+            cpu=declared.max_cpu,
+            memory_mb=declared.max_memory_mb,
+            timeout_seconds=declared.max_timeout_seconds,
+            process_count=declared.max_process_count,
+            storage_mb=declared.max_storage_mb,
+        ),
+    )
+
+
 def evaluate_policy(request: SandboxRunRequest, policy: SandboxPolicy | None = None) -> PolicyDecision:
     """Evaluate a run request using fail-closed allowlists."""
     policy = policy or SandboxPolicy()
@@ -114,13 +145,22 @@ def create_session_workspace(
     *,
     base_dir: Path | None = None,
 ) -> dict[str, str]:
-    """Create an isolated workspace skeleton for a sandbox session."""
-    root = (base_dir or sandbox_workspace_root()) / _safe_path_part(request.session_id) / _run_id(request)
+    """Create the workspace for one run, and the session's shared file directory.
+
+    ``files`` lives one level up from the run, next to its siblings, because it is
+    the point of having a session at all: a run today writes ``offers.csv`` and a
+    plan step three days later reads it. It is the only directory the container
+    can write to, and the only one that outlives the run.
+
+    ``root`` holds this run's own record (its manifest, later its output). The
+    two are separate so that clearing a session's files does not erase the
+    history of what ran.
+    """
+    session = (base_dir or sandbox_workspace_root()) / _safe_path_part(request.session_id)
+    root = session / _run_id(request)
     paths = {
         "root": root,
-        "inputs": root / "inputs",
-        "outputs": root / "outputs",
-        "artifacts": root / "artifacts",
+        "files": session / "files",
         "tmp": root / "tmp",
     }
     for path in paths.values():
@@ -136,6 +176,18 @@ def create_session_workspace(
     }
     (root / "manifest.json").write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return {key: str(path) for key, path in paths.items()}
+
+
+def directory_size_bytes(path: Path) -> int:
+    """Total size of a directory tree, symlinks not followed."""
+    total = 0
+    for entry in path.rglob("*"):
+        try:
+            if entry.is_file() and not entry.is_symlink():
+                total += entry.stat().st_size
+        except OSError:  # pragma: no cover - a file removed mid-walk
+            continue
+    return total
 
 
 def record_sandbox_decision(

--- a/policy.example.yaml
+++ b/policy.example.yaml
@@ -15,6 +15,7 @@ version: 1
 capabilities:
   dynamic_tools: false                # LLM-authored Python tools
   dynamic_tool_sandbox_required: true # ...and only inside the Docker sandbox
+  code_execution: false               # run_code: one-off analysis in the sandbox
   mcp_gateway_management: false       # add/remove MCP servers at runtime
   dynamic_mcp_servers: false          # load MCP servers persisted by the agent
   server_ops: false                   # SSH / systemd / docker control

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -293,6 +293,20 @@ else
       exit 1
     fi
 
+    # Build the code sandbox image if it is missing. Without it, run_code and
+    # dynamic tools refuse to run — there is no unsandboxed fallback — so the
+    # capability would look enabled and never work. Only when absent: the image
+    # is a base python layer and rebuilding it on every deploy buys nothing.
+    if command -v docker >/dev/null 2>&1; then
+      if ! docker image inspect kronos-sandbox:latest >/dev/null 2>&1; then
+        echo "Building the code sandbox image..."
+        bash app/scripts/build-sandbox.sh \
+          || echo "WARNING: sandbox image build failed — run_code and dynamic tools will refuse to run."
+      fi
+    else
+      echo "NOTE: docker not installed — sandboxed code execution is unavailable on this host."
+    fi
+
     # Rebuild the dashboard UI: rsync excludes dist/ (the pattern also matches
     # Python build dirs), so the served bundle must be rebuilt from the synced
     # sources — otherwise UI changes never reach the host. Best-effort: the

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -145,7 +145,12 @@ async def test_dynamic_tool_creation_requires_ready_sandbox_image(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_dynamic_tool_can_register_from_ast_metadata_without_required_sandbox(monkeypatch, tmp_path):
+async def test_asking_not_to_require_a_sandbox_turns_the_feature_off(monkeypatch, tmp_path):
+    """There is no unsandboxed mode: the answer is "no tool", not "in this process".
+
+    This test used to assert the opposite — that the tool was created and ran
+    in-process — which is precisely the mode that was removed.
+    """
     from kronos.tools import dynamic, sandbox
 
     class FakeModel:
@@ -168,7 +173,17 @@ async def test_dynamic_tool_can_register_from_ast_metadata_without_required_sand
 
     tool, message = await dynamic.create_tool("hello_tool", "Say hello")
 
-    assert tool is not None
-    assert "created successfully" in message
-    assert await tool.ainvoke({"name": "Ada"}) == "hello Ada"
-    assert (tmp_path / "hello_tool.py").exists()
+    assert tool is None
+    assert "outside the sandbox is not supported" in message
+    assert not (tmp_path / "hello_tool.py").exists(), "nothing is persisted for a mode that cannot run"
+
+
+def test_persisted_tools_are_not_loaded_without_a_sandbox(monkeypatch, tmp_path):
+    from kronos.tools import dynamic
+
+    monkeypatch.setattr(settings, "enable_dynamic_tools", True)
+    monkeypatch.setattr(settings, "require_dynamic_tool_sandbox", False)
+    monkeypatch.setattr(dynamic, "TOOLS_DIR", tmp_path)
+    (tmp_path / "hello_tool.py").write_text("async def hello_tool() -> str:\n    return 'hi'\n")
+
+    assert dynamic.load_persisted_tools() == []

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -97,7 +97,10 @@ def test_sandbox_command_uses_restrictive_docker_flags():
     assert "--cap-drop=ALL" in cmd
     assert "--security-opt=no-new-privileges" in cmd
     assert "--pids-limit=50" in cmd
-    assert "--user=10001:10001" in cmd
+    # Not a fixed uid: the container runs as the agent's own user so the bind
+    # mounts are usable, and never as root.
+    assert f"--user={sandbox.container_user()}" in cmd
+    assert "--user=0:0" not in cmd
     assert "--tmpfs=/tmp:rw,noexec,nosuid,nodev,size=64m" in cmd
     assert "kronos-sandbox:latest" in cmd
     assert cmd[-2:] == ["python", "/sandbox/runner.py"]

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,214 @@
+"""Comparing offers — the three refusals are the feature.
+
+A missing deposit is not a zero deposit; two currencies do not add up; a one-off
+cost is not a monthly one. Each of those, got wrong, produces a number that
+looks right and is not, which is worse than no comparison at all.
+"""
+
+import json
+
+import pytest
+
+from kronos.tools.compare import CompareError, compare, compare_offers, render
+
+
+def _bali():
+    return [
+        {"name": "Villa A", "price": 800, "utilities": 90, "deposit": 1600, "rating": 4.8},
+        {"name": "Villa B", "price": 700, "utilities": 150, "deposit": 2100, "rating": 4.4},
+    ]
+
+
+# --- the arithmetic -----------------------------------------------------------
+
+
+def test_recurring_costs_are_multiplied_and_one_offs_are_not():
+    result = compare(_bali(), recurring=["price", "utilities"], one_off=["deposit"], periods=3)
+
+    by_name = {row["name"]: row for row in result.ranked}
+    assert by_name["Villa A"]["total"] == 800 * 3 + 90 * 3 + 1600
+    assert by_name["Villa B"]["total"] == 700 * 3 + 150 * 3 + 2100
+
+
+def test_the_cheapest_over_the_whole_stay_is_not_the_cheapest_month():
+    """The point of the function: B is cheaper per month and dearer to live in."""
+    result = compare(_bali(), recurring=["price", "utilities"], one_off=["deposit"], periods=3)
+
+    assert result.ranked[0]["name"] == "Villa A"
+    assert result.ranked[1]["over_cheapest"] == 380
+
+
+def test_the_breakdown_is_kept_so_the_total_can_be_checked():
+    result = compare(_bali(), recurring=["price"], one_off=["deposit"], periods=2)
+
+    assert result.ranked[0]["name"] == "Villa A"
+    assert result.ranked[0]["parts"] == {"price": 1600, "deposit": 1600}
+
+
+def test_prices_written_the_way_pages_write_them_are_read():
+    offers = [
+        {"name": "Toko", "price": "Rp 8.750.000", "shipping": "Rp 50.000"},
+        {"name": "Shopee", "price": "Rp 8.900.000", "shipping": "0"},
+    ]
+
+    result = compare(offers, recurring=["price"], one_off=["shipping"])
+
+    assert result.ranked[0]["total"] == 8_800_000
+
+
+def test_fields_nobody_named_are_carried_through_untouched():
+    """Rating and distance are for the owner to weigh, not for this to score."""
+    result = compare(_bali(), recurring=["price"], one_off=["deposit"])
+
+    assert result.ranked[0]["other"]["rating"] in (4.8, 4.4)
+    assert "utilities" in result.ranked[0]["other"], "an unnamed cost is data, not silently added"
+
+
+# --- the refusals -------------------------------------------------------------
+
+
+def test_a_missing_cost_takes_the_offer_out_of_the_ranking():
+    """Treating it as zero would make the least documented offer look cheapest."""
+    offers = _bali() + [{"name": "Villa C", "price": 500, "utilities": 60}]
+
+    result = compare(offers, recurring=["price", "utilities"], one_off=["deposit"], periods=3)
+
+    assert [row["name"] for row in result.ranked] == ["Villa A", "Villa B"]
+    assert result.incomplete[0]["name"] == "Villa C"
+    assert result.incomplete[0]["missing"] == ["deposit not stated"]
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, "deposit empty"),
+        ("", "deposit empty"),
+        ("по договорённости", "deposit unreadable"),
+    ],
+)
+def test_an_unusable_value_is_reported_as_what_it_is(value, expected):
+    offers = [{"name": "Villa", "price": 800, "deposit": value}]
+
+    result = compare(offers, recurring=["price"], one_off=["deposit"])
+
+    assert result.ranked == []
+    assert expected in result.incomplete[0]["missing"][0]
+
+
+def test_two_currencies_are_refused_rather_than_added():
+    offers = [
+        {"name": "Local", "currency": "IDR", "price": 8_750_000},
+        {"name": "Import", "currency": "USD", "price": 560},
+    ]
+
+    with pytest.raises(CompareError, match="convert them to one currency"):
+        compare(offers, recurring=["price"])
+
+
+def test_one_currency_stated_once_is_fine():
+    offers = [{"name": "A", "currency": "USD", "price": 10}, {"name": "B", "price": 12}]
+
+    result = compare(offers, recurring=["price"])
+
+    assert result.currency == "USD"
+    assert result.ranked[0]["name"] == "A"
+
+
+def test_comparing_nothing_is_an_error():
+    with pytest.raises(CompareError, match="no offers"):
+        compare([], recurring=["price"])
+
+
+def test_comparing_without_naming_a_cost_is_an_error():
+    with pytest.raises(CompareError, match="at least one cost field"):
+        compare(_bali())
+
+
+def test_a_silly_number_of_offers_is_refused():
+    with pytest.raises(CompareError, match="more than this compares"):
+        compare([{"name": str(i), "price": 1} for i in range(200)], recurring=["price"])
+
+
+def test_periods_below_one_is_an_error():
+    with pytest.raises(CompareError, match="at least 1"):
+        compare(_bali(), recurring=["price"], periods=0)
+
+
+def test_an_offer_that_is_not_an_object_is_an_error():
+    with pytest.raises(CompareError, match="not an object"):
+        compare([{"name": "A", "price": 1}, "Villa B"], recurring=["price"])
+
+
+def test_an_offer_with_no_name_still_gets_one():
+    result = compare([{"price": 1}], recurring=["price"])
+
+    assert result.ranked[0]["name"] == "offer 1"
+
+
+# --- what the model reads -----------------------------------------------------
+
+
+def test_the_rendered_comparison_shows_the_sum_it_made():
+    result = compare(_bali(), recurring=["price"], one_off=["deposit"], periods=2)
+
+    text = render(result)
+
+    assert "price 1,600 + deposit 1,600" in text
+    assert "over 2 periods" in text
+
+
+def test_the_rendered_comparison_says_it_is_not_a_recommendation():
+    """Otherwise the model reports "the function chose Villa A"."""
+    text = render(compare(_bali(), recurring=["price"]))
+
+    assert "arithmetic only" in text
+    assert "yourself" in text
+
+
+def test_the_unranked_offers_are_named_with_the_reason():
+    offers = _bali() + [{"name": "Villa C", "price": 500}]
+
+    text = render(compare(offers, recurring=["price"], one_off=["deposit"]))
+
+    assert "Villa C: deposit not stated" in text
+    assert "missing figure is not a zero one" in text
+
+
+# --- the tool -----------------------------------------------------------------
+
+
+async def test_the_tool_compares_a_json_array():
+    out = await compare_offers.ainvoke(
+        {"offers": json.dumps(_bali()), "recurring": "price,utilities", "one_off": "deposit", "periods": 3}
+    )
+
+    assert "Villa A" in out
+    assert out.index("Villa A") < out.index("Villa B")
+
+
+async def test_the_tool_explains_bad_json_instead_of_raising():
+    out = await compare_offers.ainvoke({"offers": "{not json", "recurring": "price"})
+
+    assert out.startswith("[ERROR]")
+    assert "JSON" in out
+
+
+async def test_the_tool_refuses_a_json_object():
+    out = await compare_offers.ainvoke({"offers": '{"name":"A"}', "recurring": "price"})
+
+    assert out.startswith("[ERROR]")
+
+
+async def test_the_tool_passes_the_refusal_through():
+    offers = json.dumps([{"name": "A", "currency": "USD", "price": 1}, {"name": "B", "currency": "EUR", "price": 1}])
+
+    out = await compare_offers.ainvoke({"offers": offers, "recurring": "price"})
+
+    assert out.startswith("[ERROR]")
+    assert "one currency" in out
+
+
+async def test_cost_fields_can_be_separated_by_semicolons_too():
+    out = await compare_offers.ainvoke({"offers": json.dumps(_bali()), "recurring": "price; utilities"})
+
+    assert "utilities" in out

--- a/tests/test_run_code.py
+++ b/tests/test_run_code.py
@@ -1,0 +1,250 @@
+"""run_code — the gate, the workspace, and what the container is actually told.
+
+Docker is not available in CI, so what is checked here is everything around the
+run: that it is off unless enabled, that files persist per session and cannot
+escape it, that the command really mounts what the platform layer created, and
+that the declared storage budget is enforced rather than recorded.
+"""
+
+import json
+
+import pytest
+
+from kronos.config import settings
+from kronos.tools import code as code_tool
+from kronos.tools.code import default_session, run_code, safe_filename
+
+
+@pytest.fixture(autouse=True)
+def enabled(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path))
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
+    monkeypatch.setattr(settings, "agent_name", "kronos")
+    monkeypatch.setattr(settings, "enable_code_execution", True)
+    yield
+
+
+@pytest.fixture
+def sandbox(monkeypatch):
+    """A ready sandbox that records what it was asked to run."""
+    calls: list[dict] = []
+
+    def install(stdout: str = "42", stderr: str = "") -> list[dict]:
+        async def fake_execute(code, timeout=30, memory_limit="256m", network=False, files_dir=None, storage_mb=64):
+            calls.append(
+                {
+                    "code": code,
+                    "timeout": timeout,
+                    "network": network,
+                    "files_dir": files_dir,
+                    "storage_mb": storage_mb,
+                }
+            )
+            return stdout, stderr
+
+        monkeypatch.setattr("kronos.tools.sandbox.execute_sandboxed", fake_execute)
+        monkeypatch.setattr("kronos.tools.sandbox.sandbox_ready", lambda: True)
+        return calls
+
+    return install
+
+
+# --- the gate -----------------------------------------------------------------
+
+
+async def test_it_is_off_unless_turned_on(monkeypatch):
+    monkeypatch.setattr(settings, "enable_code_execution", False)
+
+    out = await run_code.ainvoke({"code": "print(1)"})
+
+    assert out.startswith("[ERROR]")
+    assert "ENABLE_CODE_EXECUTION" in out
+
+
+async def test_without_docker_it_says_what_to_do(monkeypatch):
+    monkeypatch.setattr("kronos.tools.sandbox.sandbox_ready", lambda: False)
+
+    out = await run_code.ainvoke({"code": "print(1)"})
+
+    assert out.startswith("[ERROR]")
+    assert "build-sandbox.sh" in out or "Docker" in out
+
+
+async def test_code_that_does_not_parse_is_refused_before_the_container(sandbox):
+    calls = sandbox()
+
+    out = await run_code.ainvoke({"code": "def broken(:\n"})
+
+    assert "does not parse" in out
+    assert calls == [], "no point starting a container for code Python cannot read"
+
+
+async def test_empty_and_oversized_code_are_refused(sandbox):
+    sandbox()
+
+    assert "No code" in await run_code.ainvoke({"code": "   "})
+    assert "longer than" in await run_code.ainvoke({"code": "x = 1\n" * 20_000})
+
+
+# --- what the container is told -----------------------------------------------
+
+
+async def test_the_session_directory_is_mounted_and_the_network_is_not(sandbox):
+    calls = sandbox()
+
+    await run_code.ainvoke({"code": "print(1)", "session": "bali"})
+
+    assert calls[0]["network"] is False
+    assert calls[0]["files_dir"].endswith("/files")
+    assert "bali" in calls[0]["files_dir"], "the session's own directory, not a shared one"
+
+
+async def test_the_timeout_is_capped_by_policy(sandbox):
+    calls = sandbox()
+
+    await run_code.ainvoke({"code": "print(1)", "timeout": 9999})
+
+    assert calls[0]["timeout"] <= code_tool.MAX_TIMEOUT_SECONDS
+
+
+async def test_the_storage_budget_is_passed_to_the_runner(sandbox):
+    """A budget the runner never sees is a number in a manifest."""
+    calls = sandbox()
+
+    await run_code.ainvoke({"code": "print(1)"})
+
+    assert calls[0]["storage_mb"] > 0
+
+
+# --- files --------------------------------------------------------------------
+
+
+async def test_files_are_placed_before_the_run_and_survive_it(sandbox, tmp_path):
+    calls = sandbox()
+    payload = json.dumps({"offers.json": '[{"price": 1}]'})
+
+    out = await run_code.ainvoke({"code": "print(1)", "session": "s", "files": payload})
+
+    written = tmp_path / "sandbox" / "s" / "files" / "offers.json"
+    assert written.read_text() == '[{"price": 1}]'
+    assert "offers.json" in out
+    assert calls[0]["files_dir"] == str(written.parent)
+
+
+async def test_two_runs_in_one_session_share_their_files(sandbox, tmp_path):
+    """The reason sessions exist: today's run prepares what Thursday's step reads."""
+    calls = sandbox()
+
+    await run_code.ainvoke({"code": "print(1)", "session": "bali", "files": json.dumps({"a.txt": "x"})})
+    await run_code.ainvoke({"code": "print(2)", "session": "bali"})
+
+    assert calls[0]["files_dir"] == calls[1]["files_dir"]
+    assert (tmp_path / "sandbox" / "bali" / "files" / "a.txt").exists()
+
+
+async def test_two_sessions_do_not_see_each_other(sandbox):
+    calls = sandbox()
+
+    await run_code.ainvoke({"code": "print(1)", "session": "one"})
+    await run_code.ainvoke({"code": "print(1)", "session": "two"})
+
+    assert calls[0]["files_dir"] != calls[1]["files_dir"]
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["../escape.txt", "/etc/passwd", "..", ".", "sub/dir.txt"],
+)
+def test_a_file_name_cannot_leave_the_session(name):
+    safe = safe_filename(name)
+
+    assert "/" not in safe
+    assert safe not in ("..", ".")
+
+
+async def test_a_hopeless_file_name_is_refused_rather_than_mangled(sandbox):
+    sandbox()
+
+    out = await run_code.ainvoke({"code": "print(1)", "files": json.dumps({"..": "x"})})
+
+    assert out.startswith("[ERROR]")
+
+
+async def test_files_must_be_a_json_object(sandbox):
+    sandbox()
+
+    assert "JSON object" in await run_code.ainvoke({"code": "print(1)", "files": "[1,2]"})
+    assert "JSON object" in await run_code.ainvoke({"code": "print(1)", "files": "not json"})
+
+
+async def test_too_many_or_too_large_files_are_refused(sandbox):
+    sandbox()
+    many = json.dumps({f"f{i}.txt": "x" for i in range(code_tool.MAX_INPUT_FILES + 1)})
+    huge = json.dumps({"big.txt": "x" * (code_tool.MAX_INPUT_FILE_CHARS + 1)})
+
+    assert "too many files" in await run_code.ainvoke({"code": "print(1)", "files": many})
+    assert "larger than" in await run_code.ainvoke({"code": "print(1)", "files": huge})
+
+
+# --- what comes back ----------------------------------------------------------
+
+
+async def test_the_output_is_returned_with_the_files_that_now_exist(sandbox):
+    sandbox(stdout="total 8,800,000")
+
+    out = await run_code.ainvoke({"code": "print(1)", "session": "s", "files": json.dumps({"in.csv": "a,b"})})
+
+    assert "total 8,800,000" in out
+    assert "in.csv" in out
+
+
+async def test_errors_are_not_folded_into_the_output(sandbox):
+    """Code that printed a total and then crashed did not produce a total."""
+    sandbox(stdout="partial", stderr="Traceback: boom")
+
+    out = await run_code.ainvoke({"code": "print(1)"})
+
+    assert "Output:" in out
+    assert "Errors:" in out
+    assert "boom" in out
+
+
+async def test_a_silent_program_is_told_that_stdout_is_the_answer(sandbox):
+    sandbox(stdout="", stderr="")
+
+    out = await run_code.ainvoke({"code": "x = 1"})
+
+    assert "printed nothing" in out
+
+
+async def test_long_output_is_truncated_visibly(sandbox):
+    sandbox(stdout="y" * (code_tool.MAX_OUTPUT_CHARS + 500))
+
+    out = await run_code.ainvoke({"code": "print(1)"})
+
+    assert "truncated at" in out
+
+
+# --- session naming -----------------------------------------------------------
+
+
+def test_the_session_defaults_to_the_thread_so_a_plan_shares_its_files():
+    from kronos.audit import reset_tool_audit_context, set_tool_audit_context
+
+    token = set_tool_audit_context(thread_id="plan:7", session_id="77")
+    try:
+        assert default_session() == "plan:7"
+    finally:
+        reset_tool_audit_context(token)
+
+
+def test_without_a_thread_there_is_still_a_session():
+    assert default_session() == "default"
+
+
+# --- how the runtime must treat it -------------------------------------------
+
+
+def test_running_code_counts_as_a_side_effect():
+    """Resume replays a turn; a second run would see the first one's files."""
+    assert (run_code.metadata or {}).get("side_effect") is True

--- a/tests/test_sandbox_platform.py
+++ b/tests/test_sandbox_platform.py
@@ -105,11 +105,68 @@ def test_create_session_workspace_writes_manifest(tmp_path):
 
     root = Path(paths["root"])
     assert root.exists()
-    assert (root / "inputs").is_dir()
-    assert (root / "outputs").is_dir()
-    assert (root / "artifacts").is_dir()
+    assert (root / "tmp").is_dir()
     assert "session-with-unsafe-chars" in str(root)
     assert "input.json" in (root / "manifest.json").read_text(encoding="utf-8")
+
+
+def test_the_files_directory_is_shared_by_every_run_of_a_session(tmp_path):
+    """The reason a session exists: one run prepares what a later one reads."""
+    first = create_session_workspace(SandboxRunRequest(tool_name="t", session_id="bali"), base_dir=tmp_path)
+    second = create_session_workspace(SandboxRunRequest(tool_name="t", session_id="bali"), base_dir=tmp_path)
+
+    assert first["files"] == second["files"]
+    assert Path(first["files"]).is_dir()
+    # Per-run history lives in the append-only sandbox audit, not in the manifest,
+    # so a repeated identical request reusing its run directory is fine.
+    assert (Path(first["root"]) / "manifest.json").exists()
+
+
+def test_files_of_different_sessions_are_separate(tmp_path):
+    one = create_session_workspace(SandboxRunRequest(tool_name="t", session_id="one"), base_dir=tmp_path)
+    two = create_session_workspace(SandboxRunRequest(tool_name="t", session_id="two"), base_dir=tmp_path)
+
+    assert one["files"] != two["files"]
+
+
+def test_directory_size_adds_up_what_is_actually_there(tmp_path):
+    from kronos.tools.sandbox_platform import directory_size_bytes
+
+    (tmp_path / "a.txt").write_bytes(b"x" * 10)
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "b.txt").write_bytes(b"y" * 5)
+
+    assert directory_size_bytes(tmp_path) == 15
+
+
+def test_the_policy_comes_from_governance_not_from_the_caller(monkeypatch):
+    """The old dynamic-tool path built the allowlist out of the request it checked."""
+    from kronos.policy import Policy
+    from kronos.policy import SandboxPolicy as DeclaredSandbox
+    from kronos.tools.sandbox_platform import sandbox_policy
+
+    declared = Policy(sandbox=DeclaredSandbox(network_domains=["api.example.com"], max_timeout_seconds=15))
+    monkeypatch.setattr("kronos.policy.get_policy", lambda: declared)
+
+    policy = sandbox_policy()
+
+    assert policy.allowed_network_domains == ("api.example.com",)
+    assert policy.max_resources.timeout_seconds == 15
+    assert policy.allowed_packages == (), "packages stay refused unless a deployment writes them"
+
+
+def test_a_run_asking_for_an_undeclared_domain_is_refused(monkeypatch):
+    from kronos.policy import Policy
+    from kronos.policy import SandboxPolicy as DeclaredSandbox
+    from kronos.tools.sandbox_platform import sandbox_policy
+
+    monkeypatch.setattr("kronos.policy.get_policy", lambda: Policy(sandbox=DeclaredSandbox()))
+    request = SandboxRunRequest(tool_name="t", session_id="s", network_domains=("evil.test",))
+
+    decision = evaluate_policy(request, sandbox_policy())
+
+    assert decision.allowed is False
+    assert "network:evil.test" in decision.violations
 
 
 def test_sandbox_platform_status_separates_platform_from_execution(monkeypatch, tmp_path):
@@ -137,7 +194,7 @@ def test_sandbox_platform_status_separates_platform_from_execution(monkeypatch, 
 async def test_dynamic_tool_execution_records_sandbox_audit(monkeypatch, tmp_path):
     from kronos.tools import dynamic, sandbox, sandbox_platform
 
-    async def fake_execute_sandboxed(code, timeout=30, memory_limit="256m", network=False):
+    async def fake_execute_sandboxed(code, timeout=30, memory_limit="256m", network=False, **mounts):
         return "hello Ada", ""
 
     code = 'async def hello_tool(name: str) -> str:\n    """Say hello."""\n    return f\'hello {name}\'\n'

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -1,0 +1,111 @@
+"""The container command and the disk watchdog.
+
+A read-write bind mount has no size of its own, so a declared storage budget is
+either enforced from outside or it is decoration. These check that it is the
+first — and that the command really carries the mounts and the lockdown flags
+rather than being assembled and ignored.
+"""
+
+import asyncio
+
+import pytest
+
+from kronos.tools import sandbox
+
+
+def test_the_command_locks_the_container_down():
+    command = sandbox.build_sandbox_command("/tmp/code")
+
+    assert "--network=none" in command
+    assert "--read-only" in command
+    assert "--cap-drop=ALL" in command
+    assert "--security-opt=no-new-privileges" in command
+    assert "--user=10001:10001" in command
+    assert "--pids-limit=50" in command
+    assert "-v" in command and "/tmp/code:/code:ro" in command
+
+
+def test_without_a_session_directory_nothing_is_writable():
+    command = sandbox.build_sandbox_command("/tmp/code")
+
+    assert not any(part.endswith(":/work:rw") for part in command)
+    assert "--workdir=/code" in command
+
+
+def test_with_a_session_directory_it_is_mounted_and_becomes_the_workdir():
+    """Model-written code does open("out.csv", "w"); that has to land somewhere real."""
+    command = sandbox.build_sandbox_command("/tmp/code", files_dir="/data/sandbox/bali/files")
+
+    assert "/data/sandbox/bali/files:/work:rw" in command
+    assert "--workdir=/work" in command
+
+
+def test_the_network_is_opt_in_per_run():
+    assert "--network=bridge" in sandbox.build_sandbox_command("/tmp/c", network=True)
+
+
+class FakeProc:
+    """A container process that never exits on its own."""
+
+    def __init__(self):
+        self.returncode = None
+        self.killed = False
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+
+async def test_a_run_that_fills_the_directory_is_stopped(tmp_path, monkeypatch):
+    monkeypatch.setattr(sandbox, "STORAGE_CHECK_INTERVAL_SECONDS", 0.01)
+    (tmp_path / "big.bin").write_bytes(b"x" * 2_100_000)
+    proc = FakeProc()
+
+    reason = await sandbox._kill_over_budget(str(tmp_path), limit_mb=2, proc=proc)
+
+    assert proc.killed is True
+    assert "more than 2 MB" in reason
+
+
+async def test_a_run_within_budget_is_left_alone(tmp_path, monkeypatch):
+    monkeypatch.setattr(sandbox, "STORAGE_CHECK_INTERVAL_SECONDS", 0.01)
+    (tmp_path / "small.txt").write_text("x")
+    proc = FakeProc()
+
+    async def finish_soon():
+        await asyncio.sleep(0.05)
+        proc.returncode = 0
+
+    asyncio.create_task(finish_soon())
+    reason = await sandbox._kill_over_budget(str(tmp_path), limit_mb=64, proc=proc)
+
+    assert proc.killed is False
+    assert reason == ""
+
+
+async def test_an_unready_sandbox_refuses_before_touching_docker(monkeypatch):
+    monkeypatch.setattr(sandbox, "sandbox_ready", lambda: False)
+    monkeypatch.setattr(
+        sandbox,
+        "sandbox_unavailable_message",
+        lambda: "Sandbox image kronos-sandbox:latest is missing. Run `scripts/build-sandbox.sh`.",
+    )
+
+    stdout, stderr = await sandbox.execute_sandboxed("print(1)")
+
+    assert stdout == ""
+    assert "build-sandbox.sh" in stderr
+
+
+def test_there_is_no_in_process_execution_left():
+    """The mode that ran model-written code in the agent's own process is gone."""
+    assert not hasattr(sandbox, "_exec_in_process")
+
+    from kronos.tools import dynamic
+
+    assert not hasattr(dynamic, "_run_locally_for_dev")
+
+
+@pytest.mark.parametrize("attribute", ["DEFAULT_STORAGE_MB", "STORAGE_CHECK_INTERVAL_SECONDS"])
+def test_the_budget_knobs_exist_and_are_positive(attribute):
+    assert getattr(sandbox, attribute) > 0

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -20,7 +20,8 @@ def test_the_command_locks_the_container_down():
     assert "--read-only" in command
     assert "--cap-drop=ALL" in command
     assert "--security-opt=no-new-privileges" in command
-    assert "--user=10001:10001" in command
+    assert f"--user={sandbox.container_user()}" in command
+    assert "--user=0:0" not in command
     assert "--pids-limit=50" in command
     assert "-v" in command and "/tmp/code:/code:ro" in command
 
@@ -42,6 +43,55 @@ def test_with_a_session_directory_it_is_mounted_and_becomes_the_workdir():
 
 def test_the_network_is_opt_in_per_run():
     assert "--network=bridge" in sandbox.build_sandbox_command("/tmp/c", network=True)
+
+
+def test_the_container_never_runs_as_root(monkeypatch):
+    """Matching the host uid is what makes bind mounts usable; root is not an option."""
+    monkeypatch.setattr(sandbox.os, "getuid", lambda: 0)
+
+    assert sandbox.container_user() == f"{sandbox.SANDBOX_UID}:{sandbox.SANDBOX_UID}"
+
+
+def test_the_container_runs_as_the_agents_own_uid(monkeypatch):
+    monkeypatch.setattr(sandbox.os, "getuid", lambda: 1001)
+    monkeypatch.setattr(sandbox.os, "getgid", lambda: 1002)
+
+    assert sandbox.container_user() == "1001:1002"
+
+
+async def test_the_code_is_actually_readable_inside_the_container(monkeypatch):
+    """The bug this catches: mkdtemp is 0700, so /code/tool.py was unreadable.
+
+    Every run failed with "Permission denied: '/code/tool.py'" on any host where
+    the container user differed from the file's owner — which is every host. It
+    went unnoticed because the image was never built and the feature is off by
+    default.
+    """
+    import os
+    import stat
+
+    seen: dict[str, int] = {}
+
+    class Recorder:
+        returncode = 0
+
+        async def communicate(self):
+            return b"", b""
+
+    async def fake_exec(*cmd, stdout=None, stderr=None):
+        mount = next(part for part in cmd if part.endswith(":/code:ro"))
+        code_dir = mount.split(":/code")[0]
+        seen["dir"] = stat.S_IMODE(os.stat(code_dir).st_mode)
+        seen["file"] = stat.S_IMODE(os.stat(os.path.join(code_dir, "tool.py")).st_mode)
+        return Recorder()
+
+    monkeypatch.setattr(sandbox, "sandbox_ready", lambda: True)
+    monkeypatch.setattr(sandbox.asyncio, "create_subprocess_exec", fake_exec)
+
+    await sandbox.execute_sandboxed("print(1)")
+
+    assert seen["dir"] & stat.S_IXOTH, "the code directory must be traversable by the container user"
+    assert seen["file"] & stat.S_IROTH, "the code file must be readable by the container user"
 
 
 class FakeProc:


### PR DESCRIPTION
Two things, in the order agreed: the deterministic comparison first, because it needs no container, then the sandbox — which turned out to have never run anything at all.

## `compare_offers`

Adding money up and noticing what is missing. Ranks on money only and says so in its own output, because otherwise the answer becomes "the function chose Villa A" — weighing a shorter commute against a higher rent stays with whoever reads it.

Three refusals carry the value:
- **A missing deposit is not a zero deposit.** The offer is set aside and named, never ranked as cheapest.
- **Two currencies do not add up** without a rate this has no business inventing.
- **A one-off cost is not a monthly one** — the difference between the cheapest month and the cheapest stay.

Prices are read the way pages write them (`Rp 8.750.000`), reusing the parser the plan conditions already needed.

## The sandbox: three things built and not connected

- `create_session_workspace` made a directory tree that the runner **never mounted**. It mounted its own temp dir read-only. No files in, none out, nothing survived a run.
- The storage budget was a number in a manifest.
- The dynamic-tool path built its policy from the same request it validated — `allowed_inputs=request_inputs` — so an input violation was unreachable. A check that could only pass.

Now: one writable directory per session mounted at `/work` and made the working directory, so `open("offers.csv", "w")` lands somewhere that outlives the container. A watchdog **outside** the container measures that directory twice a second and kills the run over budget — a read-write bind mount has no size of its own, so that is the difference between a declared limit and a real one. Policy comes from a new `sandbox:` section in `policy.yaml`. Input names are explicitly unrestricted, with the reason stated: they are argument names, not a boundary.

## It had never run

I built the image on a host with Docker and tried it. Every run died with `Permission denied: '/code/tool.py'` — `mkdtemp` is 0700 and the image runs as uid 10001, so the mounted code directory was not traversable by the process meant to execute it. Nobody noticed because the image is not built by default and the feature is off.

Fixed by making the code readable and running the container as the agent's own uid, which is also what lets code write into the session directory and leaves host files owned correctly. Root is never used inside the container.

Verified after the fix on the host: input read from the session directory, output persisted with the right owner, `cwd` `/work`, and a socket to 1.1.1.1 refused.

## `run_code`

The tool that was missing. Before it, the only thing that could enter the container was a *persisted* dynamic tool, so ad-hoc analysis had nowhere to go and stayed in the model's head. Own capability gate (`ENABLE_CODE_EXECUTION` / `capabilities.code_execution`), stdlib only, no network, stdout is the answer, errors reported separately — code that printed a total and then crashed did not produce a total.

Session defaults to the current thread, so for a plan step it is `plan:<id>` and **a plan accumulates its own working files**: a step normalises today, a step on Thursday reads the result.

**No import blocklist.** The container is the boundary. A regex rejecting `import os` inside a network-less, capability-less container as a non-root user refuses working code and buys nothing, while suggesting a protection that is not there.

## Removed

The unsandboxed execution path. Two places dropped to `exec()` in the agent's own process when Docker was missing, both logging "unsafe, dev only", both one environment variable from production. `REQUIRE_DYNAMIC_TOOL_SANDBOX=false` now turns dynamic tools **off** rather than running them unprotected. One test asserted the removed behaviour and now asserts the opposite.

`deploy.sh` builds the image when missing — without it the capability looks enabled on the host and never works.

## Checks

1747 passed, 73 new. `tests/test_mcp_smoke.py` fails identically on a clean checkout (an external MCP server that will not start locally).

Docs: [Sandbox](docs/SANDBOX.md), including which limits are enforced by the kernel, which by a watchdog, and that `secret_capabilities` is declared but unimplemented so a first secret has to be declared rather than injected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)