### PR TITLE
Compact context by size, which is the unit that costs money

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,6 +162,7 @@ AGENT_NAME=kronos                     # kronos | kaos-worker | kaos-analyst
 # DB_DIR=                             # optional DB directory; ops logs resolve to <DB_DIR>/logs
 # KAOS_LOG_DIR=                       # explicit single ops log dir for reports/audits
 # KAOS_LOG_MODE=single                # single | aggregate; aggregate scans ./data/*/logs
+CONTEXT_TOKEN_BUDGET=0                # tokens of history before compaction; 0 = default (12000)
 CONTEXT_STRATEGY=summarize            # summarize | sliding_window | hybrid
 
 # === Multi-Agent Deployment ===

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,19 @@ All notable changes to Kronos Agent OS are documented here.
 
 ### Changed
 
+- **Context is compacted by size, not by message count.** Measured before the
+  change: five turns carrying a pasted document each are 57,150 tokens and never
+  compacted, while sixteen one-line exchanges are 944 tokens and did — spending a
+  summarisation call to save nothing. A token budget (`CONTEXT_TOKEN_BUDGET` /
+  `budgets.context_tokens`, default 12,000 of persisted history) now drives all
+  three strategies; the count trigger keeps a floor so a tiny history is never
+  summarised. What survives is trimmed to the budget, and compaction no longer
+  depends on Mem0 being configured — deployments with no long-term memory were
+  the ones carrying unbounded histories. Tool output had the same bug in
+  miniature: whether the model saw all of it was decided by matching the tool's
+  *name*, so `run_code`, `plan_status` and `list_site_accounts` matched nothing
+  and went in whole at any size. There is now a general ceiling, and a tool whose
+  value is being complete declares `output_max_chars=0`.
 - **The sandbox now enforces what it declared.** `create_session_workspace` built
   a directory tree that the runner never mounted, so no files went in or out;
   the storage budget was a number in a manifest; and the dynamic-tool path

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -36,6 +36,49 @@ Thread IDs are transport-specific:
 Only the recent window is kept in the session table. Transient system context
 from group routing or peer reactions is not persisted.
 
+## Context Budget
+
+History is compacted by **size**, not by number of messages. The unit matters:
+five turns each carrying a pasted document are ~57,000 tokens in ten messages,
+while thirty-two one-line exchanges are under a thousand. A rule counting
+messages gets both wrong — it ignores the first and summarises the second at the
+cost of a model call.
+
+| Trigger | When |
+|---|---|
+| Over budget | history exceeds `budgets.context_tokens` (default 12,000) |
+| Long enough to be worth it | more messages than the strategy's window **and** at least a quarter of the budget |
+
+The budget is the *persisted history*, not the model's context window: the system
+prompt, retrieved memories and a turn's tool results are added on top of it.
+Configure with `CONTEXT_TOKEN_BUDGET` or `budgets.context_tokens`; `0` means the
+default.
+
+Whatever the strategy, what survives is trimmed to the budget — a window of
+twenty messages says nothing about the size of those twenty. One message larger
+than the whole budget is still sent, because dropping it would lose the request
+itself.
+
+Compaction does not depend on long-term memory being configured. Keeping a
+conversation sendable is context management; it used to be skipped wherever Mem0
+was absent, so the deployments with no memory were also the ones carrying
+unbounded histories.
+
+### Tool output
+
+The same question applies to what a tool returns:
+
+| Tool | Seen by the model |
+|---|---|
+| Verbose by nature (search, fetch, dumps) | first 2,400 characters, or a summary of the first 8 records |
+| Everything else | up to 8,000 characters |
+| Declares `output_max_chars=0` | all of it |
+
+The last row is for output that is bounded by construction and whose value is
+being complete — a ranking cut in half is a different ranking, and half a skill
+reads as a whole procedure. The full text is always kept in the tool-call audit
+regardless of what the model was shown.
+
 ## Long-Term Recall
 
 When memory is enabled and `DEEPSEEK_API_KEY` is available, KAOS can extract

--- a/kronos/audit.py
+++ b/kronos/audit.py
@@ -177,9 +177,21 @@ def _get_audit_dir() -> Path:
     return _audit_dir
 
 
+CHARS_PER_TOKEN = 3.5
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token estimate: ~3.5 chars per token for mixed RU/EN.
+
+    Public because context budgeting needs the same number cost accounting uses.
+    Two ratios in one codebase would drift, and then "why did it compact" and
+    "why did it cost that" would stop agreeing.
+    """
+    return math.ceil(len(text) / CHARS_PER_TOKEN)
+
+
 def _estimate_tokens(text: str) -> int:
-    """Rough token estimate: ~3.5 chars per token for mixed RU/EN."""
-    return math.ceil(len(text) / 3.5)
+    return estimate_tokens(text)
 
 
 def set_tool_audit_context(**context: str) -> Token:

--- a/kronos/config.py
+++ b/kronos/config.py
@@ -168,6 +168,10 @@ class Settings(BaseSettings):
     shared_workspace_path: str = ""  # optional common skills/notes workspace mounted read-mostly by all agents
     db_path: str = ""  # override; if empty, resolved to ./data/<agent_name>/session.db
     context_strategy: str = "summarize"  # summarize | sliding_window | hybrid
+    # How many tokens of *persisted history* to carry before compacting. Not the
+    # model's window: the system prompt, retrieved memories and a turn's tool
+    # results are added on top. 0 = use the code default.
+    context_token_budget: int = 0
 
     def model_post_init(self, __context: object) -> None:
         """Resolve empty paths from agent_name after initialization.

--- a/kronos/engine.py
+++ b/kronos/engine.py
@@ -108,8 +108,17 @@ def clear_delegation_ctx(token: Any) -> None:
 
 
 RAW_TOOL_CONTENT_KEY = "raw_content"
+# The tight cap, for sources whose output is long by nature (search results,
+# fetched pages, dumps). Named by tool below.
 MODEL_OUTPUT_MAX_CHARS = 2400
 MODEL_OUTPUT_MAX_ITEMS = 8
+# The ceiling every other tool gets. Name-matching alone left an open door: a
+# tool called run_code, plan_status or list_site_accounts matched no marker and
+# went into the context whole, however large it was. A name is a guess; a size
+# is a fact.
+GENERAL_OUTPUT_MAX_CHARS = 8000
+# Tools whose whole text is the point declare metadata["output_max_chars"] = 0.
+OUTPUT_LIMIT_METADATA_KEY = "output_max_chars"
 
 DEFAULT_APPROVAL_TOOL_NAMES = {
     "mcp_add_server",
@@ -282,7 +291,7 @@ def _compact_item(item: Any, index: int) -> str:
     return f"{index}. {_clip(str(data), 260)}"
 
 
-def compact_tool_output(result: Any) -> str:
+def compact_tool_output(result: Any, limit: int = MODEL_OUTPUT_MAX_CHARS) -> str:
     """Return a token-light representation of large tool results."""
     if isinstance(result, (list, tuple)):
         items = [_compact_item(item, idx) for idx, item in enumerate(result[:MODEL_OUTPUT_MAX_ITEMS], start=1)]
@@ -291,18 +300,34 @@ def compact_tool_output(result: Any) -> str:
         return "Tool result summary for model:\n" + "\n".join(items) + suffix
 
     raw = _render_tool_result(result)
-    if len(raw) <= MODEL_OUTPUT_MAX_CHARS:
+    if len(raw) <= limit:
         return raw
     return (
         f"[COMPRESSED tool output: {len(raw)} chars; full output is available "
         "in tool_result event/audit.]\n"
-        f"{raw[:MODEL_OUTPUT_MAX_CHARS].rstrip()}..."
+        f"{raw[:limit].rstrip()}..."
     )
 
 
 def _default_should_compact_tool_output(tool: BaseTool) -> bool:
     name = tool.name.lower()
     return any(marker in name for marker in DEFAULT_COMPACT_OUTPUT_NAME_MARKERS)
+
+
+def tool_output_limit(tool: BaseTool) -> int:
+    """Characters of this tool's output the model may see. 0 means no limit.
+
+    An explicit declaration wins, then the verbose-source list, then the general
+    ceiling. Declaring 0 is for output that is bounded by construction and whose
+    value is being complete — a skill body the model must follow, a comparison
+    whose rows are already capped.
+    """
+    metadata = getattr(tool, "metadata", None) or {}
+    if OUTPUT_LIMIT_METADATA_KEY in metadata:
+        return max(0, int(metadata[OUTPUT_LIMIT_METADATA_KEY]))
+    if _default_should_compact_tool_output(tool):
+        return MODEL_OUTPUT_MAX_CHARS
+    return GENERAL_OUTPUT_MAX_CHARS
 
 
 async def _maybe_await(value: Any) -> Any:
@@ -324,8 +349,14 @@ async def _tool_model_output(tool: BaseTool, result: Any) -> tuple[str, str]:
         except Exception as e:
             log.warning("Tool to_model_output failed for %s: %s", tool.name, e)
 
-    if _default_should_compact_tool_output(tool):
-        return compact_tool_output(result), raw_content
+    limit = tool_output_limit(tool)
+    # Two reasons to compact, and they are not the same. A verbose source is
+    # summarised whatever its size — thirty small search hits are still thirty
+    # records the model does not need in full. Everything else is compacted only
+    # when it is actually too large, which is the ceiling that used to be missing.
+    verbose_source = _default_should_compact_tool_output(tool)
+    if limit and (verbose_source or len(raw_content) > limit):
+        return compact_tool_output(result, limit=limit), raw_content
     return raw_content, raw_content
 
 

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -787,7 +787,13 @@ class KronosAgent:
             )
 
         # Step 5: Compact if needed (only for real user turns).
-        if self._memory_enabled and not is_ephemeral:
+        #
+        # Not conditional on memory: keeping a conversation sendable is context
+        # management, and it used to be skipped entirely wherever Mem0 was not
+        # configured — so the deployments with no long-term memory were also the
+        # ones carrying unbounded histories. The engines that flush to memory
+        # already cope with it being unavailable.
+        if not is_ephemeral:
             engine = get_context_engine()
             compact_state = {**state, "messages": list(persisted_history)}
             if engine.should_compact(compact_state):

--- a/kronos/memory/compaction.py
+++ b/kronos/memory/compaction.py
@@ -47,9 +47,10 @@ CHUNK_SIZE = 6000
 
 
 def should_compact(state: AgentState) -> bool:
-    """Check if conversation needs compaction."""
-    msg_count = len(state.get("messages", []))
-    return msg_count > MAX_MESSAGES
+    """Check if conversation needs compaction — by size as well as by count."""
+    from kronos.memory.context_engine import worth_compacting
+
+    return worth_compacting(state.get("messages", []), MAX_MESSAGES)
 
 
 def _build_conversation_text(messages: list) -> str:
@@ -127,16 +128,21 @@ def compact_messages(state: AgentState) -> AgentState:
     2. Flush key facts to Mem0 + FTS5
     3. Replace with [summary] + messages[-KEEP_RECENT:]
     """
+    from kronos.memory.context_engine import over_budget, trim_to_budget
+
     messages = state.get("messages", [])
-    if len(messages) <= MAX_MESSAGES:
+    if len(messages) <= MAX_MESSAGES and not over_budget(messages):
         return {}
 
     user_id = state.get("user_id", "")
     session_id = state.get("session_id", "")
 
-    # Split: old messages to summarize, recent to keep
-    old_messages = messages[:-KEEP_RECENT]
-    recent_messages = messages[-KEEP_RECENT:]
+    # Split: old messages to summarize, recent to keep. The tail is trimmed to
+    # the budget as well — six messages carrying a document each are still too
+    # much to send, and keeping them would leave the history over budget right
+    # after compacting it.
+    recent_messages = trim_to_budget(messages[-KEEP_RECENT:])
+    old_messages = messages[: len(messages) - len(recent_messages)]
 
     conversation_text = _build_conversation_text(old_messages)
     if not conversation_text:

--- a/kronos/memory/context_engine.py
+++ b/kronos/memory/context_engine.py
@@ -9,6 +9,12 @@ Usage in graph.py:
     engine = get_context_engine("summarize")
     if engine.should_compact(state):
         return engine.compact(state)
+
+**Size, not just count.** Every threshold here used to be a number of messages,
+which is the wrong unit: five turns carrying a pasted document each are 57k
+tokens and would never compact, while sixteen one-line exchanges are under a
+thousand and would — paying for a summarisation that saves nothing. Both
+triggers now apply, and the size one is the one that matters.
 """
 
 import logging
@@ -16,9 +22,72 @@ from abc import ABC, abstractmethod
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
+from kronos.audit import estimate_tokens
 from kronos.state import AgentState
 
 log = logging.getLogger("kronos.memory.context_engine")
+
+# How large the *persisted history* may get before it is compacted. Not the
+# model's context window: the working set adds the system prompt, retrieved
+# memories and a turn's tool results on top of this.
+DEFAULT_TOKEN_BUDGET = 12_000
+# A history below budget/this is too small to be worth a summarisation call.
+MIN_COMPACT_FRACTION = 4
+
+
+def message_text(message) -> str:
+    content = getattr(message, "content", message)
+    return content if isinstance(content, str) else str(content)
+
+
+def history_tokens(messages: list) -> int:
+    """What this history costs to send, near enough to budget with."""
+    return sum(estimate_tokens(message_text(message)) for message in messages)
+
+
+def token_budget() -> int:
+    """The configured history budget, or the default."""
+    from kronos.config import settings
+
+    configured = int(getattr(settings, "context_token_budget", 0) or 0)
+    return configured if configured > 0 else DEFAULT_TOKEN_BUDGET
+
+
+def over_budget(messages: list) -> bool:
+    return history_tokens(messages) > token_budget()
+
+
+def worth_compacting(messages: list, count_limit: int) -> bool:
+    """Whether to compact: over budget, or long enough that it is worth doing.
+
+    The count trigger carries a floor because compacting is not free — the
+    summarising engine spends a model call. Thirty-two one-line exchanges are a
+    thousand tokens; summarising them costs more than carrying them, and the old
+    count-only rule did exactly that.
+    """
+    if over_budget(messages):
+        return True
+    if len(messages) <= count_limit:
+        return False
+    return history_tokens(messages) >= token_budget() // MIN_COMPACT_FRACTION
+
+
+def trim_to_budget(messages: list, budget: int | None = None) -> list:
+    """Keep the newest messages that fit. Never returns nothing.
+
+    Used when even the sliding window is too large to send — a window counted in
+    messages says nothing about the size of those messages.
+    """
+    limit = budget if budget is not None else token_budget()
+    kept: list = []
+    used = 0
+    for message in reversed(messages):
+        cost = estimate_tokens(message_text(message))
+        if kept and used + cost > limit:
+            break
+        kept.append(message)
+        used += cost
+    return list(reversed(kept))
 
 
 class ContextEngine(ABC):
@@ -56,7 +125,7 @@ class SummarizeEngine(ContextEngine):
         self.keep_recent = keep_recent
 
     def should_compact(self, state: AgentState) -> bool:
-        return len(state.get("messages", [])) > self.max_messages
+        return worth_compacting(state.get("messages", []), self.max_messages)
 
     def compact(self, state: AgentState) -> AgentState:
         # Import here to avoid circular deps
@@ -76,17 +145,20 @@ class SlidingWindowEngine(ContextEngine):
         self.window_size = window_size
 
     def should_compact(self, state: AgentState) -> bool:
-        return len(state.get("messages", [])) > self.window_size
+        return worth_compacting(state.get("messages", []), self.window_size)
 
     def compact(self, state: AgentState) -> AgentState:
         messages = state.get("messages", [])
-        if len(messages) <= self.window_size:
+        if len(messages) <= self.window_size and not over_budget(messages):
             return {}
 
-        dropped = len(messages) - self.window_size
         kept = list(messages[-self.window_size :])
+        # A window counted in messages says nothing about their size, so the
+        # window itself gets trimmed to the budget.
+        kept = trim_to_budget(kept)
+        dropped = len(messages) - len(kept)
 
-        log.info("Sliding window: dropped %d messages, kept %d", dropped, self.window_size)
+        log.info("Sliding window: dropped %d messages, kept %d (%d tokens)", dropped, len(kept), history_tokens(kept))
 
         return {"messages": kept}
 
@@ -107,20 +179,21 @@ class HybridEngine(ContextEngine):
         self.flush_threshold = flush_threshold
 
     def should_compact(self, state: AgentState) -> bool:
-        return len(state.get("messages", [])) > self.flush_threshold
+        return worth_compacting(state.get("messages", []), self.flush_threshold)
 
     def compact(self, state: AgentState) -> AgentState:
         messages = state.get("messages", [])
-        if len(messages) <= self.flush_threshold:
+        if len(messages) <= self.flush_threshold and not over_budget(messages):
             return {}
 
         user_id = state.get("user_id", "")
         session_id = state.get("session_id", "")
 
-        # Messages to drop (will be flushed to memory)
-        drop_count = len(messages) - self.window_size
+        # What to keep is decided by size first: a few very large messages must
+        # be dropped even when there are fewer of them than the window allows.
+        to_keep = trim_to_budget(messages[-self.window_size :])
+        drop_count = len(messages) - len(to_keep)
         to_flush = messages[:drop_count]
-        to_keep = list(messages[drop_count:])
 
         # Flush dropped messages to long-term memory
         if user_id and to_flush:

--- a/kronos/policy.py
+++ b/kronos/policy.py
@@ -79,6 +79,10 @@ class BudgetPolicy(BaseModel):
     session_usd: float = 1.0
     degrade_at_fraction: float = 0.8
     per_agent_daily_usd: dict[str, float] = Field(default_factory=dict)
+    # Tokens of conversation history carried before it is compacted. A budget in
+    # money and a budget in context are the same question asked twice, so they
+    # live together. 0 = the code default.
+    context_tokens: int = 0
 
     @field_validator("degrade_at_fraction")
     @classmethod
@@ -265,6 +269,7 @@ _SETTINGS_MAP: tuple[tuple[str, str, str], ...] = (
     ("capabilities", "mcp_gateway_management", "enable_mcp_gateway_management"),
     ("capabilities", "dynamic_mcp_servers", "enable_dynamic_mcp_servers"),
     ("capabilities", "server_ops", "enable_server_ops"),
+    ("budgets", "context_tokens", "context_token_budget"),
     ("approvals", "enabled", "tool_approvals_enabled"),
     ("untrusted_output", "on_injection", "untrusted_injection_action"),
 )

--- a/kronos/skills/tools.py
+++ b/kronos/skills/tools.py
@@ -122,3 +122,9 @@ def import_skill_from_source(source: str) -> str:
     from kronos.skills.hub import import_skill
 
     return import_skill(source, _store)
+
+
+# A skill the model must follow is not something to truncate: half a procedure
+# reads as a complete one.
+for _skill_tool in (load_skill, load_skill_reference):
+    _skill_tool.metadata = {**(_skill_tool.metadata or {}), "output_max_chars": 0}

--- a/kronos/tools/compare.py
+++ b/kronos/tools/compare.py
@@ -243,3 +243,8 @@ async def compare_offers(offers: str, recurring: str = "", one_off: str = "", pe
         return f"[ERROR] {e}"
 
     return render(result)
+
+
+# The output is bounded by MAX_OFFERS, and its value is being complete: a ranking
+# cut off halfway is a different ranking. Exempt from the general output ceiling.
+compare_offers.metadata = {**(compare_offers.metadata or {}), "output_max_chars": 0}

--- a/policy.example.yaml
+++ b/policy.example.yaml
@@ -35,6 +35,7 @@ budgets:
   daily_usd: 5.0
   session_usd: 1.0
   degrade_at_fraction: 0.8            # above this, drop to the lite tier
+  context_tokens: 0                   # history tokens before compaction; 0 = default (12000)
   per_agent_daily_usd: {}
 
 # Content coming from outside the process (web pages, MCP servers, documents,

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -1,0 +1,157 @@
+"""Context management measured in tokens, which is the unit that costs money.
+
+Every threshold here used to be a number of messages. That is backwards in both
+directions at once: five turns carrying a pasted document each are 57k tokens
+and never compacted, while sixteen one-line exchanges are under a thousand and
+did — paying for a summarisation that saved nothing.
+"""
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from kronos.config import settings
+from kronos.memory.context_engine import (
+    DEFAULT_TOKEN_BUDGET,
+    HybridEngine,
+    SlidingWindowEngine,
+    SummarizeEngine,
+    history_tokens,
+    over_budget,
+    token_budget,
+    trim_to_budget,
+)
+
+
+def _history(turns: int, size: int) -> list:
+    messages = []
+    for _ in range(turns):
+        messages.append(HumanMessage(content="x" * size))
+        messages.append(AIMessage(content="ok"))
+    return messages
+
+
+HUGE = _history(5, 40_000)  # 10 messages, ~57k tokens
+CHATTY = _history(16, 200)  # 32 messages, ~1k tokens
+
+
+# --- measuring ----------------------------------------------------------------
+
+
+def test_history_is_measured_in_tokens():
+    assert history_tokens(_history(1, 3500)) > 1000
+    assert history_tokens([]) == 0
+
+
+def test_the_budget_is_configurable_and_has_a_default(monkeypatch):
+    assert token_budget() == DEFAULT_TOKEN_BUDGET
+
+    monkeypatch.setattr(settings, "context_token_budget", 500)
+    assert token_budget() == 500
+
+    monkeypatch.setattr(settings, "context_token_budget", 0)
+    assert token_budget() == DEFAULT_TOKEN_BUDGET, "0 means 'use the default', not 'no history'"
+
+
+def test_over_budget_looks_at_size_not_count():
+    assert over_budget(HUGE) is True, "10 huge messages are the case that used to slip through"
+    assert over_budget(CHATTY) is False, "32 tiny messages are not a context problem"
+
+
+# --- trimming -----------------------------------------------------------------
+
+
+def test_trimming_keeps_the_newest_that_fit():
+    messages = [HumanMessage(content="x" * 3500) for _ in range(10)]
+
+    kept = trim_to_budget(messages, budget=3000)
+
+    assert len(kept) == 3
+    assert kept[-1] is messages[-1], "the newest message is the one that must survive"
+
+
+def test_trimming_never_returns_nothing():
+    """A single message over budget still has to be sent — dropping it loses the ask."""
+    kept = trim_to_budget([HumanMessage(content="x" * 100_000)], budget=10)
+
+    assert len(kept) == 1
+
+
+# --- the three engines --------------------------------------------------------
+
+
+@pytest.mark.parametrize("engine", [SummarizeEngine(), SlidingWindowEngine(), HybridEngine()])
+def test_every_engine_compacts_a_large_history(engine):
+    assert engine.should_compact({"messages": HUGE}) is True
+
+
+def test_a_long_but_tiny_history_is_not_worth_a_model_call():
+    """Thirty-two one-line exchanges are a thousand tokens; summarising costs more."""
+    assert SummarizeEngine().should_compact({"messages": CHATTY}) is False
+
+
+def test_the_count_trigger_still_fires_once_there_is_something_to_gain():
+    """It is what keeps a long thread from creeping up on the budget."""
+    long_enough = _history(20, 700)  # 40 messages, several thousand tokens
+
+    assert len(long_enough) > 30
+    assert SummarizeEngine().should_compact({"messages": long_enough}) is True
+
+
+def test_a_short_small_history_is_left_alone():
+    assert SummarizeEngine().should_compact({"messages": _history(3, 200)}) is False
+    assert SlidingWindowEngine().should_compact({"messages": _history(3, 200)}) is False
+    assert HybridEngine().should_compact({"messages": _history(3, 200)}) is False
+
+
+def test_the_sliding_window_trims_by_size_too():
+    """Twenty messages is a window; twenty huge messages is still too much to send."""
+    result = SlidingWindowEngine(window_size=20).compact({"messages": HUGE})
+
+    assert result["messages"], "something must survive"
+    assert history_tokens(result["messages"]) <= token_budget()
+
+
+def test_the_hybrid_engine_keeps_what_fits_and_flushes_the_rest(monkeypatch):
+    flushed: list = []
+    monkeypatch.setattr(
+        "kronos.memory.store.add_memories",
+        lambda pairs, user_id, session_id: flushed.extend(pairs),
+    )
+
+    result = HybridEngine().compact({"messages": HUGE, "user_id": "u1", "session_id": "s1"})
+
+    assert history_tokens(result["messages"]) <= token_budget() + 200, "the marker adds a little"
+    assert flushed, "what was dropped goes to long-term memory rather than vanishing"
+
+
+def test_a_memory_flush_that_fails_does_not_lose_the_compaction(monkeypatch):
+    def broken(pairs, user_id, session_id):
+        raise RuntimeError("qdrant down")
+
+    monkeypatch.setattr("kronos.memory.store.add_memories", broken)
+
+    result = HybridEngine().compact({"messages": HUGE, "user_id": "u1", "session_id": "s1"})
+
+    assert history_tokens(result["messages"]) <= token_budget() + 200
+
+
+# --- the summarising path -----------------------------------------------------
+
+
+def test_compaction_keeps_a_tail_that_actually_fits(monkeypatch):
+    """Six recent messages carrying a document each are still over budget."""
+    from kronos.memory import compaction
+
+    monkeypatch.setattr(compaction, "_chunk_summarize", lambda text: "summary")
+    monkeypatch.setattr(compaction, "add_memories", lambda *a, **k: None)
+
+    result = compaction.compact_messages({"messages": HUGE, "user_id": "", "session_id": ""})
+
+    assert history_tokens(result["messages"]) <= token_budget()
+
+
+def test_the_standalone_trigger_agrees_with_the_engines():
+    from kronos.memory.compaction import should_compact
+
+    assert should_compact({"messages": HUGE}) is True
+    assert should_compact({"messages": _history(3, 200)}) is False

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -62,8 +62,13 @@ class TestRetrieveMemories:
 
 class TestCompaction:
     def test_should_compact_when_many_messages(self):
-        messages = [HumanMessage(content=f"msg {i}") for i in range(35)]
+        messages = [HumanMessage(content=f"msg {i} " + "детали " * 200) for i in range(35)]
         assert should_compact({"messages": messages}) is True
+
+    def test_should_not_compact_many_tiny_messages(self):
+        """Thirty-five one-word messages cost less to carry than to summarise."""
+        messages = [HumanMessage(content=f"msg {i}") for i in range(35)]
+        assert should_compact({"messages": messages}) is False
 
     def test_should_not_compact_when_few_messages(self):
         messages = [HumanMessage(content=f"msg {i}") for i in range(5)]

--- a/tests/test_tool_output_limits.py
+++ b/tests/test_tool_output_limits.py
@@ -1,0 +1,93 @@
+"""How much of a tool's output the model sees.
+
+This used to be decided by whether the tool's *name* contained one of twenty
+markers. A name is a guess: run_code, plan_status and list_site_accounts matched
+nothing and went into the context whole, however large. A size is a fact.
+"""
+
+import pytest
+from langchain_core.tools import tool
+
+from kronos.engine import (
+    GENERAL_OUTPUT_MAX_CHARS,
+    MODEL_OUTPUT_MAX_CHARS,
+    _tool_model_output,
+    compact_tool_output,
+    tool_output_limit,
+)
+
+
+@tool
+def fetch_something(url: str) -> str:
+    """A verbose source — its name carries a marker."""
+    return "page"
+
+
+@tool
+def plan_status_like(plan_id: int = 0) -> str:
+    """A tool whose name matches no marker at all."""
+    return "status"
+
+
+@tool
+def bounded_by_construction() -> str:
+    """A tool whose whole output is the point."""
+    return "table"
+
+
+bounded_by_construction.metadata = {"output_max_chars": 0}
+
+
+def test_a_verbose_source_keeps_the_tight_cap():
+    assert tool_output_limit(fetch_something) == MODEL_OUTPUT_MAX_CHARS
+
+
+def test_a_tool_matching_no_marker_still_has_a_ceiling():
+    """The hole this closes: unnamed tools used to be unbounded."""
+    assert tool_output_limit(plan_status_like) == GENERAL_OUTPUT_MAX_CHARS
+
+
+def test_a_tool_can_declare_that_it_must_not_be_cut():
+    assert tool_output_limit(bounded_by_construction) == 0
+
+
+def test_the_real_tools_land_where_intended():
+    from kronos.skills.tools import load_skill
+    from kronos.tools.acquire import fetch_page
+    from kronos.tools.compare import compare_offers
+
+    assert tool_output_limit(fetch_page) == MODEL_OUTPUT_MAX_CHARS, "a fetched page is long by nature"
+    assert tool_output_limit(compare_offers) == 0, "half a ranking is a different ranking"
+    assert tool_output_limit(load_skill) == 0, "half a procedure reads as a complete one"
+
+
+@pytest.mark.parametrize("limit", [500, 2400, 8000])
+def test_compaction_honours_the_limit_it_was_given(limit):
+    compacted = compact_tool_output("y" * 50_000, limit=limit)
+
+    assert "COMPRESSED tool output" in compacted
+    assert len(compacted) < limit + 200
+
+
+def test_short_output_is_left_exactly_as_it_is():
+    assert compact_tool_output("just this", limit=100) == "just this"
+
+
+async def test_output_under_the_ceiling_reaches_the_model_whole():
+    model_content, raw = await _tool_model_output(plan_status_like, "a" * 100)
+
+    assert model_content == raw == "a" * 100
+
+
+async def test_output_over_the_ceiling_is_cut_and_says_so():
+    model_content, raw = await _tool_model_output(plan_status_like, "a" * (GENERAL_OUTPUT_MAX_CHARS + 5_000))
+
+    assert "COMPRESSED tool output" in model_content
+    assert len(raw) == GENERAL_OUTPUT_MAX_CHARS + 5_000, "the full text is still kept for the audit"
+
+
+async def test_a_tool_that_declared_no_limit_is_not_cut():
+    model_content, raw = await _tool_model_output(bounded_by_construction, "a" * 50_000)
+
+    assert model_content == raw
+    assert "COMPRESSED" not in model_content


### PR DESCRIPTION
Every threshold for managing conversation context was a number of messages. That is the wrong unit, and it was wrong in both directions at once.

Measured before touching anything:

| History | Messages | Tokens | Compacted? |
|---|---|---|---|
| 5 turns, a pasted document each | 10 | 57,150 | **no** |
| 12 plan steps carrying dependency results | 24 | 27,444 | **no** |
| 16 short chat turns | 32 | 944 | **yes** |

So the histories that could not be sent were carried whole, and the ones that cost nothing paid for a summarisation call.

## What changed

A **token budget** — 12,000 of persisted history by default, `CONTEXT_TOKEN_BUDGET` or `budgets.context_tokens` — checked by all three strategies and by the standalone trigger. The count trigger stays, with a floor: below a quarter of the budget there is nothing worth a model call.

Whatever the strategy, what survives is **trimmed to the budget**. A window of twenty messages says nothing about the size of those twenty. One message larger than the whole budget is still sent, because dropping it would lose the request itself.

The budget is the persisted history, not the model's window — the system prompt, retrieved memories and a turn's tool results are added on top. That distinction is in the docs because it is the mistake someone tuning this would make.

**Compaction no longer depends on Mem0.** It was skipped entirely wherever memory was off, so the deployments with no long-term memory were also the ones carrying unbounded histories. Keeping a conversation sendable is context management, not a memory feature.

## Tool output had the same bug in miniature

Whether the model saw all of a tool's output was decided by matching the tool's **name** against twenty markers. A name is a guess: `run_code`, `plan_status` and `list_site_accounts` matched nothing and went into the context whole, at any size.

Now: a general ceiling for everything, the tight cap kept for sources that are verbose by nature, and an explicit `output_max_chars=0` for output that is bounded by construction and whose value is being complete — a ranking cut in half is a different ranking, and half a skill reads as a whole procedure. The full text is kept in the audit either way.

One regression caught by the existing suite while doing this: routing everything through the size check stopped list results being summarised into records. Verbose sources are summarised whatever their size — thirty small search hits are still thirty records the model does not need in full — so both reasons to compact are now explicit rather than conflated.

## After

| History | Tokens | Compacted? |
|---|---|---|
| 5 turns, a pasted document each | 57,150 | yes |
| 12 plan steps | 27,444 | yes |
| 16 short chat turns | 944 | no |

## Checks

1775 passed, 27 new. Two existing tests encoded the old rule (`should_compact` on 35 one-word messages, and the name-based list summarisation) and were updated to state the new one, with the reasoning in the assertion. `tests/test_mcp_smoke.py` fails identically on a clean checkout.

Docs: [Memory → Context Budget](docs/MEMORY.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)