### PR TITLE
Let the agent read the code, inside drawn lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to Kronos Agent OS are documented here.
 
 ### Added
 
+- **Repositories the agent may read** — "why did the build break" and "what
+  changed this week" are questions with a definite answer, usually asked away
+  from the laptop. `kaos repos add <name> <path>` registers a working copy;
+  `repo_list` / `repo_tree` / `repo_read` / `repo_search` / `repo_history` /
+  `repo_diff` answer from it. Read-only, and the boundary is the feature: nothing
+  outside a registered root, every path resolved before it is compared (so a
+  symlink out of the tree is refused like `../` is), and credentials refused
+  before being read — by name across every path segment, by the repository's own
+  gitignore, and never surfaced through a search result. What does get through is
+  redacted and marked untrusted, because a code comment is as good a place to
+  hide an instruction as a web page. Nothing is written: committing needs
+  credentials and a decision about which repositories may change unattended, so a
+  permission other than `read` is refused rather than quietly accepted. Docs:
+  [Repositories](docs/REPOSITORIES.md).
 - **compare_offers — totals as arithmetic, not prose** — "which flat is the
   better deal" is adding money correctly and noticing what is missing, and both
   are where invented numbers come from. The tool ranks on money only and says so

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Start here if you want to understand or contribute to Kronos Agent OS.
 | [MCP & Tools](MCP.md) | Static MCP, tool gateway, dynamic tool gates |
 | [Site Accounts](SITE-ACCOUNTS.md) | Acting as the owner on a site: sessions, permissions, the password vault |
 | [Plans](PLANS.md) | Work that outlives a turn: steps, waiting conditions, what reaches you |
+| [Repositories](REPOSITORIES.md) | Reading code the owner registered: the boundary, and what is refused |
 | [Sandbox](SANDBOX.md) | Running agent-written code: the container, session files, real budgets |
 | [Automations](AUTOMATIONS.md) | Scheduler, jobs, notifications, audit trail |
 | [Sub-Agents & Swarm](SWARM.md) | Optional multi-agent coordination |

--- a/docs/REPOSITORIES.md
+++ b/docs/REPOSITORIES.md
@@ -1,0 +1,72 @@
+# Repositories
+
+"Why did the build break", "what changed this week", "show me that function" —
+questions with a definite answer, usually asked when the laptop is shut. The
+agent can answer them by reading a working copy on the machine it runs on.
+
+Read-only. See [Limits](#limits) for what that excludes and why.
+
+```bash
+kaos repos add kaos ~/projects/kronos-agent-os/app --notes "the agent's own code"
+kaos repos list
+kaos repos remove kaos
+```
+
+Registering is the moment the boundary is drawn — nothing outside a registered
+root is reachable. The repository tools appear only once at least one is
+registered, so an agent with none is not handed six tools that all refuse.
+
+## Tools
+
+| Tool | Answers |
+|---|---|
+| `repo_list` | which repositories it can read |
+| `repo_tree` | what files are there |
+| `repo_read` | a file, or a range of lines, numbered |
+| `repo_search` | which lines match a pattern |
+| `repo_history` | recent commits, optionally for one path |
+| `repo_diff` | uncommitted work, or the difference against a ref |
+
+Output is bounded — a file range, forty matches, a truncated diff — and long
+answers say how to ask for the rest rather than silently stopping.
+
+## The boundary
+
+A directory tree has no edges unless someone draws them. Three are drawn, and
+each exists because of a specific way this goes wrong:
+
+**Only registered roots.** Without this, "read a file" is "read any file on the
+host".
+
+**Never outside the root.** Every path is resolved — symlinks included — before
+it is compared against the root. `docs/../../../../etc/passwd` and a symlink
+called `notes` pointing at `/` are the same request written twice.
+
+**Secrets are not source.** A repository contains `.env`, keys, tokens and a
+`data/` directory nobody meant to publish. Reading those into a model's context
+is a leak no later redaction undoes, so they are refused *before* being read:
+
+- by name — `.env*`, `*.pem`, `*.key`, `id_rsa*`, `*.p8`, `credentials.json`,
+  `*.session`, `*.db` and similar, matched on every path segment so
+  `config/.env.production` fails too;
+- by the repository's own `.gitignore`, which is a strong hint about what is
+  local state rather than code;
+- and a search never returns a line from a file that would have been refused.
+
+What does get through is passed through the same secret redaction the audit log
+uses, and marked **untrusted**: a README or a code comment is as good a place to
+hide an instruction aimed at an agent as a web page is.
+
+## Limits
+
+- **Nothing is written.** No commit, no branch, no push, no PR. Doing that well
+  needs credentials and a decision about which repositories may be changed
+  unattended; until that exists, a permission other than `read` is refused
+  rather than quietly accepted.
+- **The agent reads the machine it runs on.** A repository that lives on your
+  laptop is not visible to an agent on a server. Nothing here clones anything.
+- **`.gitignore` is a hint, not a guarantee.** It is honoured because what a
+  project ignores is usually its secrets and its data, but the name-based
+  refusals are the actual rule.
+- **A working copy is not the remote.** `repo_history` and `repo_diff` show what
+  that checkout knows; a branch nobody fetched is not there.

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -1649,6 +1649,49 @@ def run_plans_cancel(plan_id: int) -> int:
     return 0
 
 
+def run_repos_list(as_json: bool) -> int:
+    """Which repositories the agent may read."""
+    from kronos import repos
+
+    registered = repos.list_repos()
+    if as_json:
+        print(json.dumps([vars(repo) for repo in registered], ensure_ascii=False, indent=2))
+        return 0
+    if not registered:
+        print("No repositories registered. Add one: kaos repos add <name> <path>")
+        return 0
+    for repo in registered:
+        exists = "" if Path(repo.path).is_dir() else "  [MISSING]"
+        print(f"{repo.name}: {repo.path} ({repo.permission}){exists}")
+        if repo.notes:
+            print(f"    {repo.notes}")
+    return 0
+
+
+def run_repos_add(name: str, path: str, notes: str) -> int:
+    from kronos import repos
+
+    try:
+        repo = repos.add_repo(name, path, notes=notes)
+    except repos.RepoError as e:
+        print(f"[FAIL] {e}")
+        return 1
+    print(f"Registered '{repo.name}' → {repo.path} (read-only).")
+    print("The agent can now list, read, search, and see history and diffs there.")
+    print("Credentials and gitignored files are refused, and nothing is written.")
+    return 0
+
+
+def run_repos_remove(name: str) -> int:
+    from kronos import repos
+
+    if not repos.remove_repo(name):
+        print(f"No repository called '{name}'")
+        return 1
+    print(f"Removed '{name}'. Its files are untouched.")
+    return 0
+
+
 def run_vault_init(overwrite: bool) -> int:
     """Create the key that encrypts stored site passwords."""
     from kronos import vault
@@ -2101,6 +2144,17 @@ def build_parser() -> argparse.ArgumentParser:
     plans_cancel = plans_sub.add_parser("cancel", help="stop a plan")
     plans_cancel.add_argument("plan_id", type=int)
 
+    repos_cmd = sub.add_parser("repos", help="repositories the agent may read")
+    repos_sub = repos_cmd.add_subparsers(dest="repos_command")
+    repos_list = repos_sub.add_parser("list", help="registered repositories")
+    repos_list.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
+    repos_add = repos_sub.add_parser("add", help="register a repository (read-only)")
+    repos_add.add_argument("name")
+    repos_add.add_argument("path")
+    repos_add.add_argument("--notes", default="", help="what this repository is, for the agent")
+    repos_remove = repos_sub.add_parser("remove", help="stop the agent reading a repository")
+    repos_remove.add_argument("name")
+
     vault_cmd = sub.add_parser("vault", help="the key that encrypts stored site passwords")
     vault_sub = vault_cmd.add_subparsers(dest="vault_command")
     vault_init = vault_sub.add_parser("init", help="create the vault key")
@@ -2302,6 +2356,15 @@ def main(argv: list[str] | None = None) -> int:
         if args.plans_command == "cancel":
             return run_plans_cancel(args.plan_id)
         parser.parse_args(["plans", "--help"])
+        return 0
+    if args.command == "repos":
+        if args.repos_command == "list":
+            return run_repos_list(args.as_json)
+        if args.repos_command == "add":
+            return run_repos_add(args.name, args.path, args.notes)
+        if args.repos_command == "remove":
+            return run_repos_remove(args.name)
+        parser.parse_args(["repos", "--help"])
         return 0
     if args.command == "vault":
         if args.vault_command == "init":

--- a/kronos/graph.py
+++ b/kronos/graph.py
@@ -132,6 +132,18 @@ class KronosAgent:
 
         self._tools.extend(PLAN_TOOLS)
 
+        # Reading registered repositories. Added only when there are any, so an
+        # agent with no repositories is not offered six tools that all say no.
+        from kronos.repos import list_repos
+        from kronos.tools.repo_tools import REPO_TOOLS
+
+        try:
+            if list_repos():
+                self._tools.extend(REPO_TOOLS)
+                log.info("Repository tools added")
+        except Exception as e:
+            log.warning("Repository registry unavailable: %s", e)
+
         # Browser tools (stateful session; the acquire tools cover one-off reads)
         from kronos.tools.browser.tools import get_browser_tools
 

--- a/kronos/repos.py
+++ b/kronos/repos.py
@@ -1,0 +1,261 @@
+"""Repositories the agent may read, and the boundary around them.
+
+Answering "why did the build break" or "what changed this week" from a phone
+means the agent has to see the code. That is a different kind of access from
+everything else it has: a repository is a directory tree on the machine the
+agent runs on, and a directory tree has no edges unless someone draws them.
+
+So three lines are drawn here, and each one exists because of a specific way
+this goes wrong:
+
+* **Only registered roots.** A path that is not inside a repository the owner
+  added is refused. Without this, "read a file" is "read any file on the host".
+* **Never outside the root.** Every path is resolved — symlinks included —
+  before it is compared, because ``docs/../../../../etc/passwd`` and a symlink
+  called ``notes`` pointing at ``/`` are the same attack written twice.
+* **Secrets are not source.** A repository contains `.env`, keys, tokens and a
+  `data/` directory nobody meant to publish. Reading those into a model's
+  context is a leak that no later redaction undoes, so they are refused by name
+  and by gitignore before anything is read.
+
+Read-only on purpose. Committing and pushing need credentials and a decision
+about which repositories may be changed unattended; until that exists, a
+permission other than ``read`` is refused rather than quietly accepted.
+"""
+
+import fnmatch
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from kronos.db import get_db
+
+log = logging.getLogger("kronos.repos")
+
+PERMISSION_READ = "read"
+PERMISSIONS = (PERMISSION_READ,)
+
+# Names that are secrets wherever they appear. Matched on the file name and on
+# every path segment, so `config/.env.production` and `keys/id_rsa` both fail.
+SECRET_PATTERNS = (
+    ".env",
+    ".env.*",
+    "*.pem",
+    "*.key",
+    "*.p8",
+    "*.p12",
+    "*.pfx",
+    "id_rsa*",
+    "id_ed25519*",
+    "*.keystore",
+    "*.jks",
+    "credentials.json",
+    "service-account*.json",
+    "*.session",
+    ".netrc",
+    ".npmrc",
+    ".pypirc",
+    "secrets.*",
+    "*.sqlite",
+    "*.db",
+)
+
+# Directories never worth reading and expensive to walk.
+SKIP_DIRS = frozenset(
+    {".git", "node_modules", ".venv", "venv", "__pycache__", ".mypy_cache", ".pytest_cache", "dist", "build", ".next"}
+)
+
+MAX_FILE_BYTES = 400_000
+
+
+class RepoError(Exception):
+    """Raised when a repository is unknown, or a path is outside the lines."""
+
+
+@dataclass
+class Repo:
+    name: str
+    path: str
+    permission: str = PERMISSION_READ
+    notes: str = ""
+    added_at: float = 0.0
+
+    @property
+    def root(self) -> Path:
+        return Path(self.path)
+
+
+def _init_schema(conn) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS repos (
+            name        TEXT PRIMARY KEY,
+            path        TEXT NOT NULL,
+            permission  TEXT NOT NULL DEFAULT 'read',
+            notes       TEXT NOT NULL DEFAULT '',
+            added_at    REAL NOT NULL
+        );
+        """
+    )
+
+
+def _db():
+    db = get_db("repos")
+    db.init_schema(_init_schema)
+    return db
+
+
+def _row(row) -> Repo:
+    return Repo(
+        name=row["name"],
+        path=row["path"],
+        permission=row["permission"],
+        notes=row["notes"] or "",
+        added_at=row["added_at"],
+    )
+
+
+# --- the registry -------------------------------------------------------------
+
+
+def add_repo(name: str, path: str, *, permission: str = PERMISSION_READ, notes: str = "") -> Repo:
+    """Register a repository. The path must exist and be a directory."""
+    name = name.strip().lower()
+    if not name:
+        raise RepoError("a repository needs a name")
+    if permission not in PERMISSIONS:
+        raise RepoError(
+            f"permission '{permission}' is not available: this reads repositories and does not change them yet"
+        )
+
+    root = Path(path).expanduser().resolve()
+    if not root.is_dir():
+        raise RepoError(f"{root} is not a directory")
+
+    _db().write(
+        """
+        INSERT INTO repos (name, path, permission, notes, added_at)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(name) DO UPDATE SET path = excluded.path, permission = excluded.permission, notes = excluded.notes
+        """,
+        (name, str(root), permission, notes, time.time()),
+    )
+    log.info("Repository registered: %s → %s", name, root)
+    return get_repo(name)
+
+
+def get_repo(name: str) -> Repo:
+    row = _db().read_one("SELECT * FROM repos WHERE name = ?", (name.strip().lower(),))
+    if row is None:
+        known = ", ".join(repo.name for repo in list_repos()) or "none registered"
+        raise RepoError(f"no repository called '{name}' (known: {known})")
+    return _row(row)
+
+
+def list_repos() -> list[Repo]:
+    return [_row(row) for row in _db().read("SELECT * FROM repos ORDER BY name")]
+
+
+def remove_repo(name: str) -> bool:
+    return _db().write("DELETE FROM repos WHERE name = ?", (name.strip().lower(),)).rowcount > 0
+
+
+# --- the boundary -------------------------------------------------------------
+
+
+def looks_secret(relative: str) -> bool:
+    """Whether a path names something that is a credential rather than source.
+
+    Checked on every segment: a secret one directory down is still a secret, and
+    `config/.env.production` is the shape this exists for.
+    """
+    for segment in Path(relative).parts:
+        for pattern in SECRET_PATTERNS:
+            if fnmatch.fnmatch(segment.lower(), pattern):
+                return True
+    return False
+
+
+def _gitignore_patterns(root: Path) -> list[str]:
+    """The repository's own idea of what does not belong in it.
+
+    Not a security boundary — it is a strong hint. What a project gitignores is
+    usually its local configuration, its data and its keys, which is exactly the
+    set nobody wants read into a model's context.
+    """
+    patterns: list[str] = []
+    ignore_file = root / ".gitignore"
+    if not ignore_file.is_file():
+        return patterns
+    try:
+        for line in ignore_file.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and not line.startswith("!"):
+                patterns.append(line.rstrip("/"))
+    except OSError as e:  # pragma: no cover - unreadable .gitignore
+        log.debug("Cannot read %s: %s", ignore_file, e)
+    return patterns
+
+
+def is_ignored(root: Path, relative: str) -> bool:
+    patterns = _gitignore_patterns(root)
+    parts = Path(relative).parts
+    for pattern in patterns:
+        if fnmatch.fnmatch(relative, pattern) or fnmatch.fnmatch(relative, f"{pattern}/*"):
+            return True
+        if any(fnmatch.fnmatch(part, pattern) for part in parts):
+            return True
+    return False
+
+
+def resolve(repo: Repo, relative: str = "") -> Path:
+    """Turn a path inside a repository into a real one, or refuse.
+
+    The comparison happens after resolution, so a symlink pointing out of the
+    tree is caught as well as ``../``. Both are the same request in different
+    clothes.
+    """
+    root = repo.root.resolve()
+    candidate = (root / relative).resolve() if relative else root
+
+    if candidate != root and root not in candidate.parents:
+        raise RepoError(f"{relative} is outside repository '{repo.name}'")
+
+    inside = "" if candidate == root else str(candidate.relative_to(root))
+    if inside and looks_secret(inside):
+        raise RepoError(f"{inside} looks like a credential, not source — refusing to read it")
+    if inside and is_ignored(root, inside):
+        raise RepoError(f"{inside} is gitignored in '{repo.name}' — it is local state, not code")
+    return candidate
+
+
+def readable_file(repo: Repo, relative: str) -> Path:
+    """A resolved path that is a file small enough to read."""
+    target = resolve(repo, relative)
+    if not target.is_file():
+        raise RepoError(f"{relative} is not a file in '{repo.name}'")
+    size = target.stat().st_size
+    if size > MAX_FILE_BYTES:
+        raise RepoError(f"{relative} is {size:,} bytes — larger than this reads ({MAX_FILE_BYTES:,})")
+    return target
+
+
+def walk(repo: Repo, relative: str = "", *, limit: int = 500) -> list[str]:
+    """Paths inside a repository worth showing, skipping noise and secrets."""
+    start = resolve(repo, relative)
+    root = repo.root.resolve()
+    found: list[str] = []
+
+    for path in sorted(start.rglob("*")):
+        if len(found) >= limit:
+            break
+        if any(part in SKIP_DIRS for part in path.relative_to(root).parts):
+            continue
+        if not path.is_file():
+            continue
+        inside = str(path.relative_to(root))
+        if looks_secret(inside) or is_ignored(root, inside):
+            continue
+        found.append(inside)
+    return found

--- a/kronos/tools/repo_tools.py
+++ b/kronos/tools/repo_tools.py
@@ -1,0 +1,222 @@
+"""Reading a repository from wherever the agent happens to be.
+
+"Why did the build break", "what changed this week", "show me that function" —
+questions with a definite answer, asked from a phone. The answers come from the
+working copy on the machine the agent runs on, through :mod:`kronos.repos`,
+which is where the boundary lives.
+
+Everything here is read-only, and everything it returns is **untrusted**: a
+README, a comment or a commit message is text somebody else wrote, and a
+repository is a perfectly ordinary place to hide an instruction aimed at an
+agent. The same framing that covers fetched web pages covers this.
+
+Git is read through the command line rather than a library — `log`, `diff`,
+`status` and nothing else, with the repository path fixed by the registry, so
+there is no argument through which another command could be reached.
+"""
+
+import asyncio
+import logging
+
+from langchain_core.tools import tool
+
+from kronos import repos
+from kronos.audit import redact_secrets
+from kronos.security.untrusted import mark_untrusted
+
+log = logging.getLogger("kronos.tools.repo")
+
+GIT_TIMEOUT_SECONDS = 20
+MAX_MATCHES = 40
+MAX_MATCH_CHARS = 200
+MAX_LINES = 400
+MAX_DIFF_CHARS = 6000
+DEFAULT_HISTORY = 10
+
+
+async def _git(repo: repos.Repo, *args: str, ok_codes: tuple[int, ...] = (0,)) -> str:
+    """Run one read-only git command inside a registered repository.
+
+    ``ok_codes`` is how a caller says which exit codes are answers rather than
+    failures: `git grep` returns 1 when nothing matched, and "nothing matched"
+    is a result the owner asked for.
+    """
+    process = await asyncio.create_subprocess_exec(
+        "git",
+        "-C",
+        str(repo.root),
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=GIT_TIMEOUT_SECONDS)
+    except TimeoutError:
+        process.kill()
+        await process.wait()
+        raise repos.RepoError(f"git took longer than {GIT_TIMEOUT_SECONDS}s") from None
+
+    if process.returncode not in ok_codes:
+        detail = stderr.decode("utf-8", errors="replace").strip()
+        raise repos.RepoError(detail or f"git exited {process.returncode}")
+    return stdout.decode("utf-8", errors="replace")
+
+
+@tool
+async def repo_list() -> str:
+    """List the repositories this agent can read, and where they are."""
+    registered = repos.list_repos()
+    if not registered:
+        return "No repositories registered. Add one with `kaos repos add <name> <path>`."
+    return "\n".join(f"- {repo.name}: {repo.path}" + (f" — {repo.notes}" if repo.notes else "") for repo in registered)
+
+
+@tool
+async def repo_tree(repo: str, path: str = "", limit: int = 200) -> str:
+    """List the files in a repository, or in one directory of it.
+
+    Build, dependency and cache directories are skipped, and so is anything the
+    repository gitignores or that looks like a credential.
+
+    Args:
+        repo: Registered repository name — see repo_list.
+        path: Optional subdirectory.
+        limit: How many paths to return at most.
+    """
+    try:
+        target = repos.get_repo(repo)
+        found = repos.walk(target, path, limit=max(1, min(limit, 500)))
+    except repos.RepoError as e:
+        return f"[ERROR] {e}"
+
+    if not found:
+        return f"Nothing readable under {path or '/'} in '{repo}'."
+    return f"{len(found)} file(s) in '{repo}':\n" + "\n".join(found)
+
+
+@tool
+async def repo_read(repo: str, path: str, start: int = 1, end: int = 0) -> str:
+    """Read a file from a repository, optionally a range of lines.
+
+    Args:
+        repo: Registered repository name.
+        path: File path inside the repository.
+        start: First line (1-based).
+        end: Last line; 0 means "as far as the limit allows".
+    """
+    try:
+        target = repos.readable_file(repos.get_repo(repo), path)
+        text = target.read_text(encoding="utf-8", errors="replace")
+    except repos.RepoError as e:
+        return f"[ERROR] {e}"
+    except OSError as e:
+        return f"[ERROR] Cannot read {path}: {e}"
+
+    lines = text.splitlines()
+    first = max(1, start)
+    last = min(len(lines), end if end > 0 else first + MAX_LINES - 1)
+    if first > len(lines):
+        return f"[ERROR] {path} has {len(lines)} lines; {first} is past the end."
+
+    body = "\n".join(f"{number:>5}  {line}" for number, line in enumerate(lines[first - 1 : last], start=first))
+    header = f"{repo}/{path} lines {first}-{last} of {len(lines)}"
+    truncated = "\n… more lines follow; ask for them by range." if last < len(lines) else ""
+    return f"{header}\n{redact_secrets(body)}{truncated}"
+
+
+@tool
+async def repo_search(repo: str, pattern: str, path: str = "", limit: int = MAX_MATCHES) -> str:
+    """Search a repository for a pattern and return the matching lines.
+
+    Args:
+        repo: Registered repository name.
+        pattern: What to look for — a regular expression.
+        path: Optional subdirectory to search in.
+        limit: How many matches to return at most.
+    """
+    try:
+        target = repos.get_repo(repo)
+        # Resolved through the registry so the search cannot start outside it.
+        repos.resolve(target, path)
+        args = ["grep", "-n", "-I", "--untracked", "-e", pattern]
+        if path:
+            args += ["--", path]
+        output = await _git(target, *args, ok_codes=(0, 1))
+    except repos.RepoError as e:
+        return f"[ERROR] {e}"
+
+    matches = []
+    for line in output.splitlines():
+        if len(matches) >= max(1, min(limit, MAX_MATCHES)):
+            break
+        if repos.looks_secret(line.split(":", 1)[0]):
+            continue  # never surface a line from a file that should not be read
+        matches.append(line[:MAX_MATCH_CHARS])
+
+    if not matches:
+        return f"No match for /{pattern}/ in '{repo}'."
+    more = "\n… more matches; narrow the pattern or the path." if len(output.splitlines()) > len(matches) else ""
+    return f"{len(matches)} match(es) in '{repo}':\n" + redact_secrets("\n".join(matches)) + more
+
+
+@tool
+async def repo_history(repo: str, path: str = "", limit: int = DEFAULT_HISTORY) -> str:
+    """Recent commits in a repository, or touching one path.
+
+    Args:
+        repo: Registered repository name.
+        path: Optional file or directory to follow.
+        limit: How many commits.
+    """
+    try:
+        target = repos.get_repo(repo)
+        if path:
+            repos.resolve(target, path)
+        args = ["log", f"-{max(1, min(limit, 50))}", "--date=short", "--pretty=%h %ad %an: %s"]
+        if path:
+            args += ["--", path]
+        output = await _git(target, *args)
+    except repos.RepoError as e:
+        return f"[ERROR] {e}"
+
+    return output.strip() or f"No commits in '{repo}'" + (f" touching {path}" if path else "") + "."
+
+
+@tool
+async def repo_diff(repo: str, ref: str = "", path: str = "") -> str:
+    """What changed — uncommitted work by default, or against a ref.
+
+    Args:
+        repo: Registered repository name.
+        ref: Compare against this ref (e.g. "main", "HEAD~3"). Empty = the
+            working tree's own uncommitted changes.
+        path: Optional file or directory to limit the diff to.
+    """
+    try:
+        target = repos.get_repo(repo)
+        if path:
+            repos.resolve(target, path)
+        args = ["diff", "--stat", "-p"]
+        if ref:
+            args.append(ref)
+        if path:
+            args += ["--", path]
+        output = await _git(target, *args)
+    except repos.RepoError as e:
+        return f"[ERROR] {e}"
+
+    if not output.strip():
+        return f"Nothing changed in '{repo}'" + (f" against {ref}" if ref else "") + "."
+    body = redact_secrets(output)
+    if len(body) > MAX_DIFF_CHARS:
+        body = body[:MAX_DIFF_CHARS] + "\n… diff truncated; narrow it with a path."
+    return body
+
+
+# A repository is text other people wrote. A comment, a README or a commit
+# message is as good a place to hide an instruction as a web page, so the same
+# untrusted framing applies.
+REPO_TOOLS = mark_untrusted(
+    [repo_list, repo_tree, repo_read, repo_search, repo_history, repo_diff],
+    reason="repository contents",
+)

--- a/tests/test_repo_tools.py
+++ b/tests/test_repo_tools.py
@@ -1,0 +1,211 @@
+"""Reading a repository through the tools, against a real git repository.
+
+Real, because the interesting failures are git's: a search that matched nothing
+exits non-zero, a diff of an untracked tree is empty, a ref that does not exist
+is an error rather than a silence. Faking git would test the fake.
+"""
+
+import subprocess
+
+import pytest
+
+from kronos import repos
+from kronos.config import settings
+from kronos.tools.repo_tools import (
+    REPO_TOOLS,
+    repo_diff,
+    repo_history,
+    repo_list,
+    repo_read,
+    repo_search,
+    repo_tree,
+)
+
+
+@pytest.fixture(autouse=True)
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path / "data"))
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "data" / "session.db"))
+    import kronos.db as _db
+
+    _db._instances.clear()
+    yield
+    _db._instances.clear()
+
+
+def _git(root, *args):
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    root = tmp_path / "project"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "main.py").write_text("def main():\n    return 'hello'\n\n\ndef helper():\n    return 42\n")
+    (root / "README.md").write_text("# Project\n")
+    (root / ".env").write_text("API_KEY=sk-live-must-not-appear\n")
+    (root / ".gitignore").write_text(".env\n")
+
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "first commit")
+    return repos.add_repo("project", str(root))
+
+
+# --- listing ------------------------------------------------------------------
+
+
+async def test_listing_with_nothing_registered_says_how_to_add_one():
+    assert "kaos repos add" in await repo_list.ainvoke({})
+
+
+async def test_registered_repositories_are_listed(repo):
+    assert "project" in await repo_list.ainvoke({})
+
+
+async def test_the_tree_shows_source_and_not_secrets(repo):
+    out = await repo_tree.ainvoke({"repo": "project"})
+
+    assert "src/main.py" in out
+    assert ".env" not in out
+
+
+async def test_an_unknown_repository_is_an_error(repo):
+    assert (await repo_tree.ainvoke({"repo": "trackvibe"})).startswith("[ERROR]")
+
+
+# --- reading ------------------------------------------------------------------
+
+
+async def test_a_file_comes_back_with_line_numbers(repo):
+    out = await repo_read.ainvoke({"repo": "project", "path": "src/main.py"})
+
+    assert "def main" in out
+    assert "    1  " in out, "line numbers make a follow-up range possible"
+    assert "lines 1-6 of 6" in out
+
+
+async def test_a_range_can_be_asked_for(repo):
+    out = await repo_read.ainvoke({"repo": "project", "path": "src/main.py", "start": 5, "end": 6})
+
+    assert "def helper" in out
+    assert "def main" not in out
+
+
+async def test_reading_past_the_end_says_so(repo):
+    out = await repo_read.ainvoke({"repo": "project", "path": "src/main.py", "start": 999})
+
+    assert out.startswith("[ERROR]")
+    assert "past the end" in out
+
+
+async def test_reading_a_secret_is_refused(repo):
+    """The file exists and is readable on disk; the boundary is what stops it."""
+    out = await repo_read.ainvoke({"repo": "project", "path": ".env"})
+
+    assert out.startswith("[ERROR]")
+    assert "sk-live-must-not-appear" not in out
+
+
+async def test_escaping_the_repository_is_refused(repo):
+    out = await repo_read.ainvoke({"repo": "project", "path": "../../etc/passwd"})
+
+    assert out.startswith("[ERROR]")
+    assert "outside repository" in out
+
+
+# --- searching ----------------------------------------------------------------
+
+
+async def test_a_search_returns_the_matching_lines(repo):
+    out = await repo_search.ainvoke({"repo": "project", "pattern": "def "})
+
+    assert "src/main.py" in out
+    assert "def helper" in out
+
+
+async def test_a_search_that_matches_nothing_is_an_answer_not_a_failure(repo):
+    """git grep exits 1 when nothing matched; that is not an error to report."""
+    out = await repo_search.ainvoke({"repo": "project", "pattern": "zzz-not-here"})
+
+    assert not out.startswith("[ERROR]")
+    assert "No match" in out
+
+
+async def test_a_search_never_surfaces_a_line_from_a_secret_file(repo):
+    out = await repo_search.ainvoke({"repo": "project", "pattern": "API_KEY"})
+
+    assert "sk-live-must-not-appear" not in out
+
+
+async def test_searching_outside_the_repository_is_refused(repo):
+    assert (await repo_search.ainvoke({"repo": "project", "pattern": "x", "path": "../"})).startswith("[ERROR]")
+
+
+# --- history and diff ---------------------------------------------------------
+
+
+async def test_history_shows_recent_commits(repo):
+    out = await repo_history.ainvoke({"repo": "project"})
+
+    assert "first commit" in out
+
+
+async def test_history_can_follow_one_path(repo):
+    out = await repo_history.ainvoke({"repo": "project", "path": "src/main.py"})
+
+    assert "first commit" in out
+
+
+async def test_a_clean_tree_reports_no_changes(repo):
+    assert "Nothing changed" in await repo_diff.ainvoke({"repo": "project"})
+
+
+async def test_uncommitted_work_shows_up_in_the_diff(repo):
+    (repo.root / "src" / "main.py").write_text("def main():\n    return 'goodbye'\n")
+
+    out = await repo_diff.ainvoke({"repo": "project"})
+
+    assert "goodbye" in out
+    assert "src/main.py" in out
+
+
+async def test_a_bad_ref_is_reported_rather_than_swallowed(repo):
+    out = await repo_diff.ainvoke({"repo": "project", "ref": "no-such-branch"})
+
+    assert out.startswith("[ERROR]")
+
+
+async def test_a_large_diff_is_truncated_with_a_way_forward(repo, monkeypatch):
+    import kronos.tools.repo_tools as tools
+
+    monkeypatch.setattr(tools, "MAX_DIFF_CHARS", 200)
+    (repo.root / "src" / "big.py").write_text("# line\n" * 500)
+    _git(repo.root, "add", "-A")
+
+    out = await repo_diff.ainvoke({"repo": "project", "ref": "HEAD"})
+
+    assert "truncated" in out
+
+
+# --- how the runtime must treat this ------------------------------------------
+
+
+def test_repository_contents_are_treated_as_untrusted():
+    """A comment in a repository is as good a place to hide an instruction as a web page."""
+    for tool in REPO_TOOLS:
+        assert (tool.metadata or {}).get("untrusted_output") is True, tool.name
+
+
+def test_nothing_here_writes():
+    """v1 reads. A tool that could commit would need a different approval story."""
+    assert {tool.name for tool in REPO_TOOLS} == {
+        "repo_list",
+        "repo_tree",
+        "repo_read",
+        "repo_search",
+        "repo_history",
+        "repo_diff",
+    }

--- a/tests/test_repos.py
+++ b/tests/test_repos.py
@@ -1,0 +1,208 @@
+"""The boundary around a repository, which is the whole of this module.
+
+A directory tree has no edges unless someone draws them. These tests are the
+edges: nothing outside a registered root, nothing that looks like a credential,
+nothing the repository itself gitignores. Each has a way of being got around —
+`../`, a symlink, a secret one directory down — and each is checked.
+"""
+
+import pytest
+
+from kronos import repos
+from kronos.config import settings
+
+
+@pytest.fixture(autouse=True)
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path / "data"))
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "data" / "session.db"))
+    import kronos.db as _db
+
+    _db._instances.clear()
+    yield
+    _db._instances.clear()
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A small repository with the shapes that matter in it."""
+    root = tmp_path / "project"
+    (root / "src").mkdir(parents=True)
+    (root / "config").mkdir()
+    (root / "data").mkdir()
+    (root / "src" / "main.py").write_text("def main():\n    return 'hello'\n")
+    (root / "README.md").write_text("# Project\n\nIt does things.\n")
+    (root / ".env").write_text("API_KEY=sk-real-secret\n")
+    (root / "config" / ".env.production").write_text("DB_PASSWORD=hunter2\n")
+    (root / "config" / "id_rsa").write_text("-----BEGIN PRIVATE KEY-----\n")
+    (root / "data" / "notes.txt").write_text("local state\n")
+    (root / ".gitignore").write_text("data/\n*.log\n")
+    (root / "debug.log").write_text("noisy\n")
+    return repos.add_repo("project", str(root))
+
+
+# --- the registry -------------------------------------------------------------
+
+
+def test_a_repository_round_trips(repo, tmp_path):
+    stored = repos.get_repo("project")
+
+    assert stored.path == str((tmp_path / "project").resolve())
+    assert stored.permission == repos.PERMISSION_READ
+
+
+def test_registering_the_same_name_twice_updates_it(repo, tmp_path):
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+
+    repos.add_repo("project", str(other))
+
+    assert len(repos.list_repos()) == 1
+    assert repos.get_repo("project").path == str(other.resolve())
+
+
+def test_a_path_that_is_not_a_directory_is_refused(tmp_path):
+    (tmp_path / "file.txt").write_text("x")
+
+    with pytest.raises(repos.RepoError, match="not a directory"):
+        repos.add_repo("nope", str(tmp_path / "file.txt"))
+
+
+def test_write_permission_is_refused_while_it_does_not_exist(tmp_path):
+    """Accepting a permission nothing honours would be a promise, not a setting."""
+    (tmp_path / "r").mkdir()
+
+    with pytest.raises(repos.RepoError, match="does not change them yet"):
+        repos.add_repo("r", str(tmp_path / "r"), permission="write")
+
+
+def test_an_unknown_repository_lists_what_is_registered(repo):
+    with pytest.raises(repos.RepoError, match="known: project"):
+        repos.get_repo("trackvibe")
+
+
+def test_removing_a_repository_is_idempotent(repo):
+    assert repos.remove_repo("project") is True
+    assert repos.remove_repo("project") is False
+
+
+# --- staying inside the root --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "relative",
+    ["../outside.txt", "../../etc/passwd", "src/../../escape", "/etc/passwd"],
+)
+def test_nothing_outside_the_repository_can_be_reached(repo, relative):
+    with pytest.raises(repos.RepoError, match="outside repository"):
+        repos.resolve(repo, relative)
+
+
+def test_a_symlink_pointing_out_of_the_tree_is_refused(repo, tmp_path):
+    """Resolution happens before comparison, so a link is the same as `../`."""
+    secret = tmp_path / "outside.txt"
+    secret.write_text("not yours")
+    (repo.root / "shortcut").symlink_to(secret)
+
+    with pytest.raises(repos.RepoError, match="outside repository"):
+        repos.resolve(repo, "shortcut")
+
+
+def test_ordinary_paths_resolve(repo):
+    assert repos.resolve(repo, "src/main.py").name == "main.py"
+    assert repos.resolve(repo).is_dir()
+
+
+# --- secrets ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        ".env",
+        "config/.env.production",
+        "config/id_rsa",
+        "certs/key.pem",
+        "AuthKey_ABC.p8",
+        "keys/service-account-prod.json",
+        "kronos.session",
+        "data/app.db",
+    ],
+)
+def test_credentials_are_refused_by_name(relative):
+    assert repos.looks_secret(relative) is True
+
+
+@pytest.mark.parametrize("relative", ["src/main.py", "README.md", "docs/environment.md", "src/keyboard.py"])
+def test_ordinary_source_is_not_mistaken_for_a_secret(relative):
+    assert repos.looks_secret(relative) is False
+
+
+def test_reading_a_credential_is_refused_with_the_reason(repo):
+    with pytest.raises(repos.RepoError, match="looks like a credential"):
+        repos.resolve(repo, ".env")
+
+    with pytest.raises(repos.RepoError, match="looks like a credential"):
+        repos.resolve(repo, "config/.env.production")
+
+
+def test_gitignored_paths_are_refused_as_local_state(repo):
+    with pytest.raises(repos.RepoError, match="gitignored"):
+        repos.resolve(repo, "data/notes.txt")
+
+    with pytest.raises(repos.RepoError, match="gitignored"):
+        repos.resolve(repo, "debug.log")
+
+
+def test_a_repository_without_a_gitignore_still_works(tmp_path):
+    root = tmp_path / "bare"
+    root.mkdir()
+    (root / "main.py").write_text("x = 1\n")
+    bare = repos.add_repo("bare", str(root))
+
+    assert repos.resolve(bare, "main.py").is_file()
+
+
+# --- reading ------------------------------------------------------------------
+
+
+def test_a_file_can_be_read(repo):
+    assert repos.readable_file(repo, "src/main.py").read_text().startswith("def main")
+
+
+def test_a_directory_is_not_a_file(repo):
+    with pytest.raises(repos.RepoError, match="not a file"):
+        repos.readable_file(repo, "src")
+
+
+def test_a_huge_file_is_refused_rather_than_truncated_silently(repo, monkeypatch):
+    monkeypatch.setattr(repos, "MAX_FILE_BYTES", 10)
+
+    with pytest.raises(repos.RepoError, match="larger than this reads"):
+        repos.readable_file(repo, "README.md")
+
+
+def test_walking_shows_source_and_hides_the_rest(repo):
+    found = repos.walk(repo)
+
+    assert "src/main.py" in found
+    assert "README.md" in found
+    assert ".env" not in found
+    assert "config/.env.production" not in found
+    assert "config/id_rsa" not in found
+    assert "data/notes.txt" not in found, "gitignored state is not source"
+    assert "debug.log" not in found
+
+
+def test_walking_skips_directories_nobody_wants_read(repo):
+    (repo.root / "node_modules" / "left-pad").mkdir(parents=True)
+    (repo.root / "node_modules" / "left-pad" / "index.js").write_text("module.exports = 1\n")
+
+    assert not any("node_modules" in path for path in repos.walk(repo))
+
+
+def test_walking_is_bounded(repo):
+    for index in range(50):
+        (repo.root / "src" / f"file{index}.py").write_text("x = 1\n")
+
+    assert len(repos.walk(repo, limit=10)) == 10

--- a/tests/test_repos_cli.py
+++ b/tests/test_repos_cli.py
@@ -1,0 +1,102 @@
+"""`kaos repos` — the only way a directory becomes readable by the agent.
+
+Registering is the moment the boundary is drawn, so what this command says
+matters: an owner should finish it knowing that the access is read-only and
+that credentials are refused.
+"""
+
+import json
+
+import pytest
+
+from kronos import repos
+from kronos.cli import main
+from kronos.config import settings
+
+
+@pytest.fixture(autouse=True)
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path / "data"))
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "data" / "session.db"))
+    import kronos.db as _db
+
+    _db._instances.clear()
+    yield
+    _db._instances.clear()
+
+
+@pytest.fixture
+def project(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / "main.py").write_text("x = 1\n")
+    return root
+
+
+def test_listing_nothing_says_how_to_add(capsys):
+    assert main(["repos", "list"]) == 0
+
+    assert "kaos repos add" in capsys.readouterr().out
+
+
+def test_adding_a_repository_states_what_it_allows(project, capsys):
+    assert main(["repos", "add", "project", str(project)]) == 0
+
+    out = capsys.readouterr().out
+    assert "read-only" in out
+    assert "Credentials" in out, "the owner should learn the boundary at the moment they draw it"
+    assert repos.get_repo("project").path == str(project.resolve())
+
+
+def test_adding_a_path_that_is_not_a_directory_fails(tmp_path, capsys):
+    (tmp_path / "file.txt").write_text("x")
+
+    assert main(["repos", "add", "bad", str(tmp_path / "file.txt")]) == 1
+    assert "not a directory" in capsys.readouterr().out
+
+
+def test_listing_shows_the_path_and_notes(project, capsys):
+    main(["repos", "add", "project", str(project), "--notes", "the agent itself"])
+    capsys.readouterr()
+
+    assert main(["repos", "list"]) == 0
+
+    out = capsys.readouterr().out
+    assert str(project.resolve()) in out
+    assert "the agent itself" in out
+
+
+def test_a_repository_that_moved_is_flagged(project, capsys):
+    main(["repos", "add", "project", str(project)])
+    capsys.readouterr()
+    project.rename(project.parent / "moved")
+
+    main(["repos", "list"])
+
+    assert "[MISSING]" in capsys.readouterr().out, "a path that stopped existing must not read as fine"
+
+
+def test_list_json_is_machine_readable(project, capsys):
+    main(["repos", "add", "project", str(project)])
+    capsys.readouterr()
+
+    assert main(["repos", "list", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["name"] == "project"
+    assert payload[0]["permission"] == "read"
+
+
+def test_removing_says_the_files_are_untouched(project, capsys):
+    main(["repos", "add", "project", str(project)])
+    capsys.readouterr()
+
+    assert main(["repos", "remove", "project"]) == 0
+
+    assert "untouched" in capsys.readouterr().out
+    assert repos.list_repos() == []
+    assert project.is_dir(), "removing a registration must not remove a directory"
+
+
+def test_removing_something_unregistered_fails(capsys):
+    assert main(["repos", "remove", "ghost"]) == 1


### PR DESCRIPTION
"Why did the build break", "what changed this week", "show me that function" — questions with a definite answer, usually asked when the laptop is shut. Six read-only tools answer them from a working copy the owner registered.

```bash
kaos repos add kaos ~/projects/kronos-agent-os/app --notes "the agent's own code"
```

`repo_list` · `repo_tree` · `repo_read` · `repo_search` · `repo_history` · `repo_diff`. The tools appear only once a repository is registered, so an agent with none is not handed six tools that all refuse.

## The boundary is the feature

A directory tree has no edges unless someone draws them. Three are drawn, each for a specific way this goes wrong:

**Only registered roots** — without this, "read a file" is "read any file on the host".

**Never outside the root** — every path is resolved, symlinks included, *before* it is compared. A symlink called `notes` pointing at `/` and `docs/../../../../etc/passwd` are the same request written twice.

**Secrets are not source** — a repository holds `.env`, keys, tokens and a `data/` directory nobody meant to publish, and reading those into a model's context is a leak no later redaction undoes. So they are refused before being read: by name on **every path segment** (`config/.env.production` fails too), by the repository's own gitignore, and a search never returns a line from a file that would have been refused.

What does get through is redacted with the same patterns the audit log uses and marked **untrusted** — a code comment is as good a place to hide an instruction aimed at an agent as a web page is.

## Verified against this repository

Registered this repo, which has a real `.env` and a real `data/*.db` on disk:

- history, search and line-ranged reads work;
- `.env` → *"looks like a credential, not source — refusing to read it"*; same for `data/swarm.db`;
- the 280-file listing does not mention either.

Removing the containment and secret guards makes six tests fail, which is how I know they carry weight rather than decorate.

## Deliberately not built

**Nothing is written** — no commit, branch, push or PR. Doing that well needs credentials and a decision about which repositories may be changed unattended, so a permission other than `read` is refused rather than quietly accepted. Worth saying plainly: for authoring changes you already have a better tool; what this adds is the always-on half — reading and answering when you are not at a keyboard, and composing with plans (a step can watch a file) and `run_code` (a step can analyse what it found).

**The agent reads the machine it runs on.** A repository on your laptop is invisible to an agent on a server; nothing here clones anything.

## Checks

1837 passed, 62 new. `tests/test_mcp_smoke.py` fails identically on a clean checkout.

Docs: [Repositories](docs/REPOSITORIES.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)