### PR TITLE
Sandbox mount paths must be absolute

### DIFF
--- a/kronos/tools/sandbox.py
+++ b/kronos/tools/sandbox.py
@@ -132,10 +132,14 @@ def build_sandbox_command(
         f"--user={container_user()}",
         "--workdir=/work" if files_dir else "--workdir=/code",
         "-v",
-        f"{tmpdir}:/code:ro",
+        f"{Path(tmpdir).resolve()}:/code:ro",
     ]
     if files_dir:
-        command += ["-v", f"{files_dir}:/work:rw"]
+        # Absolute, always. Docker reads a relative path as a *named volume*, so
+        # `-v data/kronos/sandbox/x/files:/work` fails with "invalid characters
+        # for a local volume name" — and only on a host whose data directory is
+        # configured relatively, which is every real deployment and no test.
+        command += ["-v", f"{Path(files_dir).resolve()}:/work:rw"]
     command += [SANDBOX_IMAGE, "python", "/sandbox/runner.py"]
     return command
 

--- a/kronos/tools/sandbox_platform.py
+++ b/kronos/tools/sandbox_platform.py
@@ -281,8 +281,12 @@ def sandbox_audit_path() -> Path:
 
 
 def sandbox_workspace_root() -> Path:
-    """Return the base directory for isolated sandbox workspaces."""
-    return Path(settings.db_path).parent / "sandbox"
+    """Return the base directory for isolated sandbox workspaces.
+
+    Absolute: these paths are handed to Docker as bind mounts, and a relative
+    one is not a directory to Docker — it is a named volume.
+    """
+    return (Path(settings.db_path).parent / "sandbox").resolve()
 
 
 def _resource_violations(resources: SandboxResourceLimits, maximum: SandboxResourceLimits) -> list[str]:

--- a/tests/test_sandbox_runner.py
+++ b/tests/test_sandbox_runner.py
@@ -23,7 +23,7 @@ def test_the_command_locks_the_container_down():
     assert f"--user={sandbox.container_user()}" in command
     assert "--user=0:0" not in command
     assert "--pids-limit=50" in command
-    assert "-v" in command and "/tmp/code:/code:ro" in command
+    assert "-v" in command and any(part.endswith(":/code:ro") for part in command)
 
 
 def test_without_a_session_directory_nothing_is_writable():
@@ -37,8 +37,33 @@ def test_with_a_session_directory_it_is_mounted_and_becomes_the_workdir():
     """Model-written code does open("out.csv", "w"); that has to land somewhere real."""
     command = sandbox.build_sandbox_command("/tmp/code", files_dir="/data/sandbox/bali/files")
 
-    assert "/data/sandbox/bali/files:/work:rw" in command
+    assert any(part.endswith("/bali/files:/work:rw") for part in command)
     assert "--workdir=/work" in command
+
+
+def test_mount_paths_are_absolute_because_docker_reads_relative_ones_as_volumes():
+    """Found on a real host: every deployment configures data/ relatively.
+
+    `-v data/kronos/sandbox/x/files:/work` is not a directory to Docker, it is a
+    named volume, and the run dies with "invalid characters for a local volume
+    name". Tests using tmp_path never saw it because tmp_path is absolute.
+    """
+    command = sandbox.build_sandbox_command("relative/code", files_dir="data/agent/sandbox/s/files")
+
+    mounts = [part for part in command if ":/work:rw" in part or ":/code:ro" in part]
+
+    assert len(mounts) == 2
+    for mount in mounts:
+        assert mount.startswith("/"), f"{mount} is relative; Docker would read it as a volume name"
+
+
+def test_the_workspace_root_is_absolute(tmp_path, monkeypatch):
+    from kronos.config import settings
+    from kronos.tools.sandbox_platform import sandbox_workspace_root
+
+    monkeypatch.setattr(settings, "db_path", "./data/agent/session.db")
+
+    assert sandbox_workspace_root().is_absolute()
 
 
 def test_the_network_is_opt_in_per_run():


### PR DESCRIPTION
Found the moment `run_code` was switched on in production. Every run died:

```
docker: Error response from daemon: create data/kronos/sandbox/prod-selftest/files:
"data/kronos/sandbox/prod-selftest/files" includes invalid characters for a local
volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed.
If you intended to pass a host directory, use absolute path
```

A relative `-v` argument is not a directory to Docker — it is a **named volume**. Every real deployment configures `db_path` relatively (`./data/<agent>/session.db`), and every test used `tmp_path`, which is absolute. So the test suite could not have caught this and the first real use was guaranteed to.

The workspace root now resolves, and `build_sandbox_command` resolves whatever it is handed, because that is where the Docker contract lives.

The failure was at least visible rather than silent: the tool reported it under "Errors:" separately from output, so it read as a failed run rather than a run that produced nothing.

1858 passed, two new — one pinning that both mounts are absolute given relative input, one pinning the workspace root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)