### PR TITLE
The browser tier was absent, then broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,17 @@ All notable changes to Kronos Agent OS are documented here.
 
 ### Changed
 
+- **The browser tier is installed by deploy, and reads pages through the API that
+  still exists.** Two findings from pointing the deployed agent at real
+  marketplaces. The host had no Playwright at all, so the last acquisition tier
+  and every site session were dead — `deploy.sh` now installs the `browser` extra
+  and chromium when they are absent. And current Playwright has no
+  `page.accessibility`: `snapshot()` *returned* the resulting error message, so
+  the browser tier fed that sentence to the extractor as page content and the
+  signed-in check, finding no "log in" in it, said yes on a session that may have
+  expired. Snapshots now use `aria_snapshot` with visible text as a fallback, and
+  the browser tier returns markup — a price in an attribute is invisible in an
+  accessibility tree.
 - **Context is compacted by size, not by message count.** Measured before the
   change: five turns carrying a pasted document each are 57,150 tokens and never
   compacted, while sixteen one-line exchanges are 944 tokens and did — spending a

--- a/docs/SITE-ACCOUNTS.md
+++ b/docs/SITE-ACCOUNTS.md
@@ -67,6 +67,19 @@ password box. Same when a site rejects the attempt: it is reported as a failure,
 because claiming success would send the agent off to scrape a login wall and
 report prices that do not exist.
 
+## What the host needs
+
+Sessions are a real browser, so the host needs one:
+
+```bash
+pip install -e ".[browser]" && playwright install chromium
+```
+
+`deploy.sh` does both when they are missing. Without them `open_site_session`
+cannot open anything — and note that a *stale* Playwright is worse than a missing
+one: the API for reading a page changed, and code written against the old one
+returned its own error message as page content, which reads as a page that loaded.
+
 ## The vault
 
 Passwords are encrypted with AES-GCM by `kronos.vault`, bound to the site they

--- a/kronos/tools/acquire.py
+++ b/kronos/tools/acquire.py
@@ -230,7 +230,10 @@ async def fetch_browser(url: str) -> tuple[int, str]:
         raise FetchBlockedError(f"browser backend unavailable: {e}") from e
 
     await engine.navigate(url)
-    return 200, await engine.snapshot()
+    # The page's HTML, not a snapshot: every caller here runs html_to_text over
+    # what comes back, and a compact accessibility tree is the wrong input for
+    # extraction — it drops prices that live in attributes and markup.
+    return 200, await engine.page_html()
 
 
 async def fetch_tiered(url: str) -> tuple[str, str, list[str]]:

--- a/kronos/tools/browser/engine.py
+++ b/kronos/tools/browser/engine.py
@@ -114,20 +114,42 @@ async def navigate(url: str, wait_until: str = "domcontentloaded") -> str:
 
 
 async def snapshot() -> str:
-    """Get accessibility tree snapshot (compact, token-efficient).
+    """A compact view of the page — roles and text, not markup.
 
-    Returns structured text representation of the page,
-    ~500 tokens vs ~5000 for raw HTML.
+    Current Playwright has no ``accessibility`` on Page — it was removed, and the
+    failure was the quiet kind: the snapshot *returned* the error message, so the
+    browser tier fed that sentence to the extractor and the signed-in check found
+    no "log in" in it and said yes. ``aria_snapshot`` is the replacement and gives
+    the same tree in YAML; visible text is the fallback for a page with no
+    accessible structure worth printing.
     """
     page = await _ensure_browser()
     try:
-        # Use Playwright's accessibility snapshot
-        tree = await page.accessibility.snapshot()
-        if not tree:
-            return "[Empty page — no accessibility tree]"
-        return _format_a11y_tree(tree)
+        tree = await page.locator("body").aria_snapshot()
+        if tree and tree.strip():
+            return tree
+    except Exception as e:
+        log.debug("aria_snapshot unavailable (%s); falling back to visible text", e)
+
+    try:
+        text = await page.locator("body").inner_text(timeout=5000)
+        return text.strip() or "[Empty page]"
     except Exception as e:
         return f"Snapshot failed: {e}"
+
+
+async def page_html() -> str:
+    """The page's markup after scripts have run.
+
+    What a JavaScript-rendered listing actually contains — the point of using a
+    browser at all. Extraction needs the markup, not a compact tree: a price in
+    an attribute or a data- field is invisible in an accessibility snapshot.
+    """
+    page = await _ensure_browser()
+    try:
+        return await page.content()
+    except Exception as e:
+        return f"Could not read the page: {e}"
 
 
 async def screenshot() -> bytes:
@@ -194,28 +216,3 @@ async def close():
         await _pw.stop()
         _pw = None
     log.info("Browser closed")
-
-
-def _format_a11y_tree(node: dict, indent: int = 0) -> str:
-    """Format accessibility tree into compact text representation."""
-    lines = []
-    role = node.get("role", "")
-    name = node.get("name", "")
-    value = node.get("value", "")
-
-    # Skip generic/container nodes without useful info
-    if role in ("none", "generic", "presentation") and not name:
-        pass
-    else:
-        prefix = "  " * indent
-        parts = [role]
-        if name:
-            parts.append(f'"{name}"')
-        if value:
-            parts.append(f"[{value}]")
-        lines.append(f"{prefix}{' '.join(parts)}")
-
-    for child in node.get("children", []):
-        lines.append(_format_a11y_tree(child, indent + 1))
-
-    return "\n".join(line for line in lines if line)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -288,9 +288,21 @@ else
     # so PDF/DOCX ingest (roadmap 6.1) works on the host. A FAILED install must
     # abort the deploy — restarting agents against a half-updated venv (new code,
     # missing/old deps) would just crash-loop them. Errors are shown, not hidden.
-    if ! app/.venv/bin/python -m pip install -e "app/.[documents]" --quiet; then
+    if ! app/.venv/bin/python -m pip install -e "app/.[documents,browser]" --quiet; then
       echo "FATAL: dependency install failed — not restarting agents." >&2
       exit 1
+    fi
+
+    # Chromium for the browser: without it the last acquisition tier is gone
+    # (marketplaces that block a plain fetch become unreadable) and site sessions
+    # cannot open at all. Only when absent — the download is ~115 MB.
+    if [ -x app/.venv/bin/playwright ]; then
+      if ! app/.venv/bin/python -c "from playwright.sync_api import sync_playwright" 2>/dev/null \
+         || ! ls "$HOME/.cache/ms-playwright"/chromium* >/dev/null 2>&1; then
+        echo "Installing chromium for the browser tier..."
+        app/.venv/bin/playwright install chromium \
+          || echo "WARNING: chromium install failed — protected pages and site sessions will not work."
+      fi
     fi
 
     # Build the code sandbox image if it is missing. Without it, run_code and

--- a/tests/test_browser_snapshot.py
+++ b/tests/test_browser_snapshot.py
@@ -1,0 +1,115 @@
+"""Reading a page without the API Playwright removed.
+
+`page.accessibility` is gone from current Playwright, and the way it failed was
+the worst kind: `snapshot()` returned the string "Snapshot failed: 'Page' object
+has no attribute 'accessibility'", which is a *successful* return. So the browser
+acquisition tier handed that sentence to the extractor as page content, and
+`_looks_signed_in` — which searches a snapshot for the word "log in" — found none
+and answered "signed in" forever, on a session that may well have expired.
+
+Found by pointing the deployed agent at a real marketplace.
+"""
+
+import pytest
+
+from kronos.tools.browser import engine
+
+
+class FakeLocator:
+    def __init__(self, aria: str | Exception = "", text: str | Exception = ""):
+        self._aria = aria
+        self._text = text
+
+    async def aria_snapshot(self):
+        if isinstance(self._aria, Exception):
+            raise self._aria
+        return self._aria
+
+    async def inner_text(self, timeout: int = 0):
+        if isinstance(self._text, Exception):
+            raise self._text
+        return self._text
+
+
+class FakePage:
+    def __init__(self, locator: FakeLocator, html: str | Exception = "<html></html>"):
+        self._locator = locator
+        self._html = html
+
+    def locator(self, selector: str):
+        assert selector == "body"
+        return self._locator
+
+    async def content(self):
+        if isinstance(self._html, Exception):
+            raise self._html
+        return self._html
+
+
+@pytest.fixture
+def page(monkeypatch):
+    def install(fake: FakePage) -> FakePage:
+        async def fake_browser(profile_dir=None):
+            return fake
+
+        monkeypatch.setattr(engine, "_ensure_browser", fake_browser)
+        return fake
+
+    return install
+
+
+async def test_the_snapshot_uses_the_api_that_exists(page):
+    page(FakePage(FakeLocator(aria='- heading "Sold out" [level=1]')))
+
+    assert "Sold out" in await engine.snapshot()
+
+
+async def test_a_page_with_no_aria_structure_falls_back_to_its_text(page):
+    page(FakePage(FakeLocator(aria=RuntimeError("no aria"), text="Log in to continue")))
+
+    assert await engine.snapshot() == "Log in to continue"
+
+
+async def test_an_empty_aria_tree_is_not_treated_as_the_answer(page):
+    page(FakePage(FakeLocator(aria="   ", text="Some visible text")))
+
+    assert await engine.snapshot() == "Some visible text"
+
+
+async def test_a_page_that_cannot_be_read_says_so_rather_than_returning_prose(page):
+    """The bug: an error sentence returned as content reads as a signed-in page."""
+    page(FakePage(FakeLocator(aria=RuntimeError("gone"), text=RuntimeError("also gone"))))
+
+    result = await engine.snapshot()
+
+    assert result.startswith("Snapshot failed")
+
+
+async def test_a_blank_page_is_named_blank(page):
+    page(FakePage(FakeLocator(aria="", text="")))
+
+    assert await engine.snapshot() == "[Empty page]"
+
+
+async def test_the_browser_tier_returns_markup_not_a_summary(page):
+    """Extraction needs the markup: a price in an attribute is invisible in a tree."""
+    page(FakePage(FakeLocator(aria="- text: Rp 8.750.000"), html='<div data-price="8750000">Rp 8.750.000</div>'))
+
+    html = await engine.page_html()
+
+    assert 'data-price="8750000"' in html
+
+
+async def test_an_unreadable_page_reports_it(page):
+    page(FakePage(FakeLocator(), html=RuntimeError("navigation lost")))
+
+    assert "Could not read the page" in await engine.page_html()
+
+
+def test_the_removed_api_is_not_referenced_anywhere():
+    """A guard against reintroducing it: it exists in no current Playwright."""
+    from pathlib import Path
+
+    source = Path(engine.__file__).read_text(encoding="utf-8")
+
+    assert "accessibility.snapshot(" not in source


### PR DESCRIPTION
Pointed the deployed agent at the two marketplaces it was built for. It cannot read either, and finding out why turned up two separate faults.

## 1. There was no browser on the host

`deploy.sh` installs the `[documents]` extra only, so Playwright was never there. Probing from prod:

| | plain fetch | escalation |
|---|---|---|
| example.com | 200, 559 bytes, fine | — |
| tokopedia.com | **timeout** | no stealth backend, no playwright → **blocked** |
| shopee.co.id | 200, 158 KB, **detected as a shell** | no stealth backend, no playwright → **blocked** |

The block detector works — Shopee's 200-with-a-JS-shell is caught exactly as designed. There was simply nowhere left to escalate to. That also means every site session was dead: `open_site_session` needs the same browser.

`deploy.sh` now installs the `browser` extra and downloads chromium when either is missing (~115 MB, only when absent).

## 2. With a browser present, page reading was broken

Current Playwright has no `page.accessibility`. And the failure was the quiet kind — `snapshot()` caught the `AttributeError` and **returned its message**, which is a successful return. So:

- the browser acquisition tier handed `"Snapshot failed: 'Page' object has no attribute 'accessibility'"` to the extractor **as page content**;
- `_looks_signed_in` searched that sentence for "log in", found none, and reported a signed-in session — however expired it actually was.

Fixed with `aria_snapshot` (the replacement, same tree in YAML), visible text as the fallback, and a plain `Snapshot failed` only when both are impossible. The acquisition tier now asks for **markup** rather than a snapshot: a price in a `data-` attribute is invisible in an accessibility tree, so a compact tree was the wrong input for extraction regardless of which API produced it.

A guard test pins that the removed call cannot come back.

## Also on the host

The marketplace skill pack was bundled but installed for nobody — `workspaces/kronos/self/skills/` was empty. Installed for kronos.

## Checks

1866 passed, 8 new. Verified on the host: chromium launches, loads a page, and returns a title.

Worth stating plainly: this is the third bug this week that only a real run could find — the sandbox could not read its own code, its mount paths were relative, and now this. All three were invisible to a test suite because the suite fakes exactly the boundary that was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)