### PR TITLE
The browser tier must prove it read a page

### DIFF
--- a/kronos/tools/acquire.py
+++ b/kronos/tools/acquire.py
@@ -233,7 +233,17 @@ async def fetch_browser(url: str) -> tuple[int, str]:
     # The page's HTML, not a snapshot: every caller here runs html_to_text over
     # what comes back, and a compact accessibility tree is the wrong input for
     # extraction — it drops prices that live in attributes and markup.
-    return 200, await engine.page_html()
+    body = await engine.page_html()
+
+    # Validated like every other tier. A browser can hand back its own error
+    # sentence, or a shell whose 158 KB of markup carry no words at all, and
+    # calling either a successful fetch is how a marketplace that refused to be
+    # read becomes an empty answer with no explanation.
+    if not _looks_like_a_page(body):
+        raise FetchBlockedError(f"browser returned no usable content: {body.strip()[:200] or 'empty output'}")
+    if looks_blocked(200, body):
+        raise FetchBlockedError("browser loaded the page but it has no readable content (still a shell, or blocked)")
+    return 200, body
 
 
 async def fetch_tiered(url: str) -> tuple[str, str, list[str]]:

--- a/kronos/tools/browser/engine.py
+++ b/kronos/tools/browser/engine.py
@@ -138,18 +138,40 @@ async def snapshot() -> str:
         return f"Snapshot failed: {e}"
 
 
+CONTENT_SETTLE_MS = 4000
+
+
 async def page_html() -> str:
     """The page's markup after scripts have run.
 
     What a JavaScript-rendered listing actually contains — the point of using a
     browser at all. Extraction needs the markup, not a compact tree: a price in
     an attribute or a data- field is invisible in an accessibility snapshot.
+
+    A single-page app keeps navigating after DOMContentLoaded, and reading it
+    mid-flight fails with "the page is navigating and changing the content" —
+    which is what a marketplace does on every visit. So: wait for the network to
+    go quiet, and if the read still lands in a navigation, wait and take it once
+    more rather than reporting the race as an unreadable page.
     """
     page = await _ensure_browser()
     try:
-        return await page.content()
+        await page.wait_for_load_state("networkidle", timeout=CONTENT_SETTLE_MS)
     except Exception as e:
-        return f"Could not read the page: {e}"
+        log.debug("Page never went quiet (%s); reading it as it is", e)
+
+    for attempt in (1, 2):
+        try:
+            return await page.content()
+        except Exception as e:
+            if attempt == 2:
+                return f"Could not read the page: {e}"
+            log.debug("Content read raced with a navigation; retrying once")
+            try:
+                await page.wait_for_timeout(CONTENT_SETTLE_MS // 2)
+            except Exception:  # pragma: no cover - page went away entirely
+                pass
+    return "Could not read the page"
 
 
 async def screenshot() -> bytes:

--- a/tests/test_browser_snapshot.py
+++ b/tests/test_browser_snapshot.py
@@ -113,3 +113,96 @@ def test_the_removed_api_is_not_referenced_anywhere():
     source = Path(engine.__file__).read_text(encoding="utf-8")
 
     assert "accessibility.snapshot(" not in source
+
+
+# --- the browser tier's own output is not trusted just because a browser ran ---
+
+
+class NavigatingPage(FakePage):
+    """A single-page app that is still moving the first time it is read."""
+
+    def __init__(self, html: str, failures: int = 1):
+        super().__init__(FakeLocator(), html)
+        self._failures = failures
+        self.reads = 0
+
+    async def wait_for_load_state(self, state: str, timeout: int = 0):
+        return None
+
+    async def wait_for_timeout(self, ms: int):
+        return None
+
+    async def content(self):
+        self.reads += 1
+        if self.reads <= self._failures:
+            raise RuntimeError("Page.content: Unable to retrieve content because the page is navigating")
+        return self._html
+
+
+async def test_a_read_that_raced_a_navigation_is_retried(page):
+    """Every marketplace does this; giving up on the first race loses the page."""
+    fake = page(NavigatingPage("<html><body>Rp 8.750.000</body></html>"))
+
+    html = await engine.page_html()
+
+    assert "8.750.000" in html
+    assert fake.reads == 2
+
+
+async def test_a_page_that_never_settles_is_reported_not_guessed(page):
+    fake = page(NavigatingPage("<html/>", failures=5))
+
+    assert "Could not read the page" in await engine.page_html()
+    assert fake.reads == 2, "retried once, then said so"
+
+
+async def test_the_browser_tier_refuses_its_own_error_sentence(monkeypatch):
+    """The bug this closes: an error string counted as a successful fetch."""
+    from kronos.tools import acquire
+
+    async def fake_navigate(url, wait_until="domcontentloaded"):
+        return "ok"
+
+    async def fake_html():
+        return "Could not read the page: navigating"
+
+    monkeypatch.setattr(engine, "navigate", fake_navigate)
+    monkeypatch.setattr(engine, "page_html", fake_html)
+
+    with pytest.raises(acquire.FetchBlockedError, match="no usable content"):
+        await acquire.fetch_browser("https://shop.test/item")
+
+
+async def test_the_browser_tier_refuses_markup_with_no_words_in_it(monkeypatch):
+    """158 KB of shell and zero characters of text is not a page that loaded."""
+    from kronos.tools import acquire
+
+    async def fake_navigate(url, wait_until="domcontentloaded"):
+        return "ok"
+
+    async def fake_html():
+        return "<html><head>" + ("<script>x=1;</script>" * 3000) + "</head><body></body></html>"
+
+    monkeypatch.setattr(engine, "navigate", fake_navigate)
+    monkeypatch.setattr(engine, "page_html", fake_html)
+
+    with pytest.raises(acquire.FetchBlockedError, match="no readable content"):
+        await acquire.fetch_browser("https://shop.test/item")
+
+
+async def test_a_real_page_through_the_browser_tier_is_accepted(monkeypatch):
+    from kronos.tools import acquire
+
+    async def fake_navigate(url, wait_until="domcontentloaded"):
+        return "ok"
+
+    async def fake_html():
+        return "<html><body><h1>ROG Ally X</h1><p>Rp 8.750.000 — ready stock</p></body></html>"
+
+    monkeypatch.setattr(engine, "navigate", fake_navigate)
+    monkeypatch.setattr(engine, "page_html", fake_html)
+
+    status, body = await acquire.fetch_browser("https://shop.test/item")
+
+    assert status == 200
+    assert "8.750.000" in body


### PR DESCRIPTION
Follow-up to #56, from the same real run. With chromium finally present, neither marketplace came back readable — and both failures were being reported as success.

| | what came back | what it was called |
|---|---|---|
| tokopedia.com | `Could not read the page: Page.content: Unable to retrieve content because the page is navigating` | a successful 200 fetch |
| shopee.co.id | 158,917 bytes of markup, **0 characters of text** | a successful 200 fetch |

## Two fixes

**The read raced the page.** `navigate()` waits for DOMContentLoaded; a single-page app keeps navigating well past it, which is what a marketplace does on every visit. `page_html()` now waits for the network to go quiet and, if the read still lands mid-navigation, waits and takes it once more. Giving up on the first race throws away a page that was about to be there.

**The tier trusted itself.** Whatever came back was returned as a 200, so the error sentence above went to the extractor as page content, and Shopee's empty shell went as an article with nothing in it. Both now raise, reusing the validation the stealth tier already had: `_looks_like_a_page` for "did the backend honour its contract", `looks_blocked` for "is this a page or a shell". A browser having run is not evidence a page was read.

The distinction that matters downstream: a source that refused to be read now says so, instead of becoming an empty answer with no explanation — the same rule the plan conditions follow, where a site being down is never a price drop.

## Honest status of the marketplaces

This makes the failures visible and correct. It does not make Shopee readable: a client-rendered marketplace served to headless chromium from a datacenter IP may simply not hand over content, and that is the "anti-bot is a race" the plan flagged from the start. If it stays blocked, the answer is `STEALTH_FETCH_COMMAND` — the CloakBrowser/Scrapling stack, which lives outside this repo — and that is a decision about where to run it, not a bug to fix here.

1871 passed, 5 new: the retried race, the race that never settles, the error sentence refused, the wordless shell refused, and a real page still accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)