### PR TITLE
Adopt a browser profile signed in somewhere with a screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Kronos Agent OS are documented here.
 
 ### Added
 
+- **`kaos accounts import-profile`** — the site-accounts design says "sign in by
+  hand once", and the machine the agent runs on has no screen. So the profile is
+  made on a laptop and adopted here: the command checks the directory really is a
+  browser profile (pointing an account at the wrong path fails late and
+  unreadably, as a session that expired and never recovers), copies it into the
+  agent's data directory at 0700 because live session cookies are a credential,
+  and points the account at the copy. `kaos accounts list` shows what is
+  configured without the profile path or any hint of a password.
 - **Marketplace skill pack** — the five procedures the tools were built for:
   `housing-search`, `marketplace-compare`, `price-watch`,
   `seller-correspondence` and `structured-extraction`. They encode the domain

--- a/docs/SITE-ACCOUNTS.md
+++ b/docs/SITE-ACCOUNTS.md
@@ -50,6 +50,29 @@ the second factor. The agent reuses that session and stores nothing secret;
 revoking is deleting the directory. When the session expires, the agent tells
 you instead of guessing.
 
+*On a server there is no screen to sign in on.* Make the profile on a machine
+that has one, and bring it over:
+
+```bash
+# on your laptop — sign in, then close the browser so the profile is flushed
+python -c "
+from playwright.sync_api import sync_playwright
+with sync_playwright() as p:
+    ctx = p.chromium.launch_persistent_context('/tmp/airbnb-profile', headless=False)
+    input('sign in, then press Enter here')
+    ctx.close()
+"
+
+scp -r /tmp/airbnb-profile you@host:/tmp/
+ssh you@host 'cd /opt/kaos/app && .venv/bin/python -m kronos.cli accounts import-profile airbnb /tmp/airbnb-profile'
+```
+
+`import-profile` checks the directory really is a browser profile before adopting
+it — pointing an account at the wrong path fails late and unreadably, as an
+expired session that never recovers — copies it into the agent's data directory
+at 0700, and points the account at the copy. The profile holds live session
+cookies, so it is a credential: keep it as private as the vault key.
+
 **With a stored password.** The agent fills the site's own login form when the
 session expires, and carries on. The password goes from the vault into the page
 and nowhere else — not into a tool result, a message, the session history, or a

--- a/kronos/accounts.py
+++ b/kronos/accounts.py
@@ -28,6 +28,8 @@ without the value.
 """
 
 import logging
+import os
+import shutil
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -171,6 +173,50 @@ def _default_profile_dir(site: str) -> str:
     hand, so making them invent a path would be ceremony.
     """
     return str(Path(settings.db_dir) / "browser-profiles" / site)
+
+
+# What a Chromium user-data directory contains. Checked because the failure of a
+# wrong directory is late and confusing: the browser starts on an empty profile,
+# the site shows a login wall, and the account reports "session expired" forever
+# without anyone suspecting the path.
+PROFILE_MARKERS = ("Default", "Preferences", "Local State")
+
+
+def looks_like_profile(path: Path) -> bool:
+    return path.is_dir() and any((path / marker).exists() for marker in PROFILE_MARKERS)
+
+
+def import_profile(site: str, source: str) -> SiteAccount:
+    """Take a browser profile signed in elsewhere and make it this account's.
+
+    The headless answer to "how do I log in on a machine with no screen": sign in
+    on a laptop, copy the profile directory over, point the account at it. The
+    copy lands in the agent's own data directory at 0700 — it holds live session
+    cookies, which is to say credentials, and a profile readable by others is the
+    same leak as a readable key file.
+    """
+    account = get_account(site)
+    origin = Path(source).expanduser().resolve()
+    if not origin.is_dir():
+        raise AccountError(f"{origin} is not a directory")
+    if not looks_like_profile(origin):
+        raise AccountError(
+            f"{origin} does not look like a browser profile (expected one of {', '.join(PROFILE_MARKERS)} inside it)"
+        )
+
+    target = Path(_default_profile_dir(account.site))
+    if origin == target.resolve():
+        raise AccountError(f"{origin} is already this account's profile directory")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(origin, target, symlinks=False, ignore_dangling_symlinks=True)
+    os.chmod(target, 0o700)
+
+    _db().write("UPDATE site_accounts SET profile_dir = ? WHERE site = ?", (str(target), account.site))
+    log.info("Imported a browser profile for %s", account.site)
+    return get_account(site)
 
 
 def _stored_secret(site: str) -> bytes | None:

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -1649,6 +1649,39 @@ def run_plans_cancel(plan_id: int) -> int:
     return 0
 
 
+def run_accounts_list(as_json: bool) -> int:
+    """Which sites the agent may act on, and what it may do there."""
+    from kronos import accounts
+
+    configured = accounts.list_accounts()
+    if as_json:
+        print(json.dumps([vars(account) for account in configured], ensure_ascii=False, indent=2))
+        return 0
+    if not configured:
+        print("No site accounts. Add one in the dashboard (Accounts).")
+        return 0
+    for account in configured:
+        password = "password stored" if account.has_password else "no password"
+        print(f"{account.site}: may {account.permission}, session {account.session_state}, {password}")
+        print(f"    domains: {', '.join(account.domains)}")
+    return 0
+
+
+def run_accounts_import_profile(site: str, path: str) -> int:
+    """Adopt a browser profile that was signed into somewhere with a screen."""
+    from kronos import accounts
+
+    try:
+        account = accounts.import_profile(site, path)
+    except accounts.AccountError as e:
+        print(f"[FAIL] {e}")
+        return 1
+    print(f"Imported the profile for '{account.site}'.")
+    print("It holds live session cookies, so the copy is private to this user (0700).")
+    print(f"Check it worked: the agent's next use of '{account.site}' should report a signed-in session.")
+    return 0
+
+
 def run_repos_list(as_json: bool) -> int:
     """Which repositories the agent may read."""
     from kronos import repos
@@ -2144,6 +2177,16 @@ def build_parser() -> argparse.ArgumentParser:
     plans_cancel = plans_sub.add_parser("cancel", help="stop a plan")
     plans_cancel.add_argument("plan_id", type=int)
 
+    accounts_cmd = sub.add_parser("accounts", help="sites the agent may act on as you")
+    accounts_sub = accounts_cmd.add_subparsers(dest="accounts_command")
+    accounts_list = accounts_sub.add_parser("list", help="configured site accounts")
+    accounts_list.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
+    accounts_import = accounts_sub.add_parser(
+        "import-profile", help="adopt a browser profile signed in on another machine"
+    )
+    accounts_import.add_argument("site")
+    accounts_import.add_argument("path", help="the copied profile directory")
+
     repos_cmd = sub.add_parser("repos", help="repositories the agent may read")
     repos_sub = repos_cmd.add_subparsers(dest="repos_command")
     repos_list = repos_sub.add_parser("list", help="registered repositories")
@@ -2356,6 +2399,13 @@ def main(argv: list[str] | None = None) -> int:
         if args.plans_command == "cancel":
             return run_plans_cancel(args.plan_id)
         parser.parse_args(["plans", "--help"])
+        return 0
+    if args.command == "accounts":
+        if args.accounts_command == "list":
+            return run_accounts_list(args.as_json)
+        if args.accounts_command == "import-profile":
+            return run_accounts_import_profile(args.site, args.path)
+        parser.parse_args(["accounts", "--help"])
         return 0
     if args.command == "repos":
         if args.repos_command == "list":

--- a/tests/test_accounts_profile_import.py
+++ b/tests/test_accounts_profile_import.py
@@ -1,0 +1,179 @@
+"""Adopting a browser profile signed in somewhere with a screen.
+
+The gap this closes: the whole site-accounts design says "sign in by hand once",
+and the machine the agent runs on is a headless server. So the profile is made on
+a laptop and copied over — and the copy has to be checked, because the failure of
+pointing an account at the wrong directory is late and unreadable: the browser
+starts on an empty profile, the site shows its login wall, and the account
+reports an expired session forever.
+"""
+
+import json
+import os
+
+import pytest
+
+from kronos import accounts, vault
+from kronos.cli import main
+from kronos.config import settings
+
+
+@pytest.fixture(autouse=True)
+def store(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path / "data"))
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "data" / "session.db"))
+    monkeypatch.setattr(settings, "vault_key", vault.generate_key())
+    import kronos.db as _db
+
+    _db._instances.clear()
+    yield
+    _db._instances.clear()
+
+
+@pytest.fixture
+def account():
+    return accounts.save_account(
+        site="airbnb",
+        domains=["airbnb.com"],
+        login="roman@example.com",
+        profile_dir="/tmp/placeholder",
+    )
+
+
+@pytest.fixture
+def signed_in_profile(tmp_path):
+    """What Chromium leaves behind after someone logs in."""
+    profile = tmp_path / "from-laptop"
+    (profile / "Default").mkdir(parents=True)
+    (profile / "Default" / "Cookies").write_text("session=abc")
+    (profile / "Local State").write_text("{}")
+    return profile
+
+
+# --- what counts as a profile -------------------------------------------------
+
+
+@pytest.mark.parametrize("marker", ["Default", "Preferences", "Local State"])
+def test_a_directory_with_any_chromium_marker_is_a_profile(tmp_path, marker):
+    candidate = tmp_path / marker.replace(" ", "-")
+    candidate.mkdir()
+    (candidate / marker).write_text("x")
+
+    assert accounts.looks_like_profile(candidate) is True
+
+
+def test_an_ordinary_directory_is_not(tmp_path):
+    (tmp_path / "notes").mkdir()
+    (tmp_path / "notes" / "todo.md").write_text("x")
+
+    assert accounts.looks_like_profile(tmp_path / "notes") is False
+
+
+# --- importing ----------------------------------------------------------------
+
+
+def test_importing_copies_the_profile_and_points_the_account_at_it(account, signed_in_profile, tmp_path):
+    imported = accounts.import_profile("airbnb", str(signed_in_profile))
+
+    landed = tmp_path / "data" / "browser-profiles" / "airbnb"
+    assert imported.profile_dir == str(landed)
+    assert (landed / "Default" / "Cookies").read_text() == "session=abc"
+
+
+def test_the_copy_is_private_because_it_holds_live_cookies(account, signed_in_profile, tmp_path):
+    """A profile readable by others is the same leak as a readable key file."""
+    accounts.import_profile("airbnb", str(signed_in_profile))
+
+    mode = os.stat(tmp_path / "data" / "browser-profiles" / "airbnb").st_mode & 0o777
+
+    assert mode == 0o700
+
+
+def test_the_original_is_left_alone(account, signed_in_profile):
+    accounts.import_profile("airbnb", str(signed_in_profile))
+
+    assert (signed_in_profile / "Default" / "Cookies").exists()
+
+
+def test_importing_twice_replaces_rather_than_merges(account, signed_in_profile, tmp_path):
+    """A stale cookie left from the previous profile is a session nobody can explain."""
+    accounts.import_profile("airbnb", str(signed_in_profile))
+    landed = tmp_path / "data" / "browser-profiles" / "airbnb"
+    (landed / "Default" / "Stale").write_text("old")
+
+    accounts.import_profile("airbnb", str(signed_in_profile))
+
+    assert not (landed / "Default" / "Stale").exists()
+
+
+def test_a_directory_that_is_not_a_profile_is_refused(account, tmp_path):
+    (tmp_path / "downloads").mkdir()
+
+    with pytest.raises(accounts.AccountError, match="does not look like a browser profile"):
+        accounts.import_profile("airbnb", str(tmp_path / "downloads"))
+
+
+def test_a_path_that_does_not_exist_is_refused(account, tmp_path):
+    with pytest.raises(accounts.AccountError, match="not a directory"):
+        accounts.import_profile("airbnb", str(tmp_path / "nowhere"))
+
+
+def test_importing_into_itself_is_refused(account, signed_in_profile, tmp_path):
+    """Otherwise the directory is deleted and then copied from — losing the profile."""
+    accounts.import_profile("airbnb", str(signed_in_profile))
+    landed = tmp_path / "data" / "browser-profiles" / "airbnb"
+
+    with pytest.raises(accounts.AccountError, match="already this account's"):
+        accounts.import_profile("airbnb", str(landed))
+
+    assert (landed / "Default" / "Cookies").exists()
+
+
+def test_importing_for_an_unknown_site_says_which_exist(signed_in_profile):
+    with pytest.raises(accounts.AccountError, match="known:"):
+        accounts.import_profile("booking", str(signed_in_profile))
+
+
+# --- the command --------------------------------------------------------------
+
+
+def test_the_command_reports_what_it_did_and_how_to_check(account, signed_in_profile, capsys):
+    assert main(["accounts", "import-profile", "airbnb", str(signed_in_profile)]) == 0
+
+    out = capsys.readouterr().out
+    assert "0700" in out, "the owner should learn the copy is private"
+    assert "signed-in session" in out, "and how to confirm it worked"
+
+
+def test_the_command_fails_loudly_on_a_wrong_directory(account, tmp_path, capsys):
+    (tmp_path / "nope").mkdir()
+
+    assert main(["accounts", "import-profile", "airbnb", str(tmp_path / "nope")]) == 1
+    assert "does not look like" in capsys.readouterr().out
+
+
+def test_listing_accounts_never_shows_the_profile_path_or_a_password(account, capsys):
+    accounts.set_password("airbnb", "hunter2")
+    capsys.readouterr()
+
+    assert main(["accounts", "list"]) == 0
+
+    out = capsys.readouterr().out
+    assert "airbnb" in out
+    assert "password stored" in out
+    assert "hunter2" not in out
+    assert "/tmp/placeholder" not in out, "a profile path is secret-adjacent"
+
+
+def test_listing_with_nothing_configured_points_at_the_dashboard(capsys):
+    assert main(["accounts", "list"]) == 0
+
+    assert "dashboard" in capsys.readouterr().out.lower()
+
+
+def test_list_json_is_machine_readable(account, capsys):
+    assert main(["accounts", "list", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["site"] == "airbnb"
+    assert payload[0]["has_password"] is False


### PR DESCRIPTION
The site-accounts design says *"sign in by hand once"*. The machine the agent runs on is a headless server. There is nowhere to do that, and the documentation quietly assumed the problem away — I only noticed when working out what it would actually take to add an Airbnb account on prod.

So: make the profile on a laptop, bring it over.

```bash
scp -r /tmp/airbnb-profile you@host:/tmp/
ssh you@host 'kaos accounts import-profile airbnb /tmp/airbnb-profile'
```

## What the command is for

**It checks the directory really is a browser profile.** Pointing an account at the wrong path fails late and unreadably: the browser starts on an empty profile, the site shows its login wall, and the account reports an expired session forever with nobody suspecting the path. Checking at import turns a mystery into a sentence.

**The copy lands at 0700.** A profile holds live session cookies, which is to say credentials — one others can read is the same leak as a readable vault key.

**Re-importing replaces rather than merges**, so a stale cookie cannot outlive the profile it came from and produce a session nobody can explain.

`kaos accounts list` comes along for discoverability, and follows the same rule as the tools and the dashboard: what is configured, what it may do, whether a password exists — never the profile path, never the password.

Docs updated with the whole transfer, including how to open a headed profile to sign in.

1888 passed, 17 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)