### PR TITLE
Notice when a way of fetching a page stops working

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,9 +87,12 @@ EXA_API_KEY=                          # Exa semantic search
 # Optional: how to fetch pages that block ordinary requests (marketplaces,
 # listings, booking sites). A shell command containing {url}; left empty, that
 # escalation tier is skipped and fetch_page says so instead of failing silently.
-# Any fetcher that prints the page to stdout works, e.g. a Scrapling/CloakBrowser
-# helper:
-#   STEALTH_FETCH_COMMAND=uvx --from cloakbrowser --with scrapling[ai] python3 /path/to/scrape.py {url} --html
+# Any fetcher that prints the page to stdout works.
+#
+# `bash scripts/setup-stealth.sh` installs a backend and prints the exact line
+# to paste here — it looks like this, with the venv it just created:
+#   STEALTH_FETCH_COMMAND=/opt/<install>/tools/.venv/bin/python /opt/<install>/app/scripts/stealth_fetch.py {url}
+# Confirm it afterwards with `kaos acquire check`. See docs/ACQUISITION.md.
 STEALTH_FETCH_COMMAND=
 
 # Credential vault — encrypts the site passwords the agent uses to sign in as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to Kronos Agent OS are documented here.
 
 ### Added
 
+- **A reproducible stealth tier, and a daily check that it still exists** — the
+  middle way of fetching a page ran on a backend installed by hand, documented
+  nowhere, on one machine. A host rebuild would have removed it silently and the
+  first sign would have been a marketplace becoming unreadable weeks later,
+  blamed on the marketplace. `scripts/setup-stealth.sh` now installs it —
+  outside `app/`, because `deploy.sh` rsyncs with `--delete` and a venv
+  underneath it works exactly once — while the adapter it drives
+  (`scripts/stealth_fetch.py`) lives in the repo and ships with every deploy.
+  That adapter can only print a page or exit non-zero: the wrapper it replaces
+  printed *"Install scrapling for CSS extraction"* and exited 0, and 36
+  characters of advice is indistinguishable from a short page. A test reads the
+  source to keep it that way. `kaos acquire check` probes every tier on demand,
+  the new `acquire-smoke` job does it daily, and both distinguish a tier that is
+  *off* (never installed here — a choice) from one that is *broken*. It reports
+  only when that changes: a daily "all three fine" trains its reader to skip the
+  one morning it says something else. It probes `example.com` and deliberately
+  not a marketplace, since a checker that goes red whenever Shopee tightens its
+  defences is one people learn to ignore. `deploy.sh` warns when
+  `STEALTH_FETCH_COMMAND` points at an interpreter the host no longer has. Docs:
+  [Acquisition](docs/ACQUISITION.md).
 - **`kaos accounts import-profile`** — the site-accounts design says "sign in by
   hand once", and the machine the agent runs on has no screen. So the profile is
   made on a laptop and adopted here: the command checks the directory really is a

--- a/docs/ACQUISITION.md
+++ b/docs/ACQUISITION.md
@@ -1,0 +1,128 @@
+# Acquisition — getting a page
+
+Reading a web page is three different problems wearing one name. Most of the web
+answers an ordinary GET. Some of it answers only a browser that looks human. A
+little of it answers only a browser that *is* one, with a session and a history.
+`fetch_page` tries them in that order and reports which one worked.
+
+Escalation happens on evidence, never by default. Starting at the top would make
+every fetch slow and burn a browser on pages that never needed one; starting at
+the bottom and staying there is how a marketplace becomes "that site has no
+products".
+
+| Tier | What it is | Needs |
+|---|---|---|
+| `plain` | An ordinary GET | nothing |
+| `stealth` | A fingerprint-spoofing browser, one page at a time | `STEALTH_FETCH_COMMAND` + a backend |
+| `browser` | The stateful browser the agent already drives | `pip install -e ".[browser]"` |
+
+The tier that worked is reported back to the model, because "this came from a
+plain GET" and "this needed a fingerprint-spoofing browser" are different facts
+about a source.
+
+## What "blocked" actually means
+
+Three sites refusing you are usually three different problems, and treating them
+as one is how money gets spent on the wrong fix. Measured against the real sites
+these tools target:
+
+| | Symptom | Cause | Fix |
+|---|---|---|---|
+| A | Connection never establishes, or a challenge page | IP or fingerprint | the stealth tier |
+| B | A page that says *"login required"* | no session | a [site account](SITE-ACCOUNTS.md) |
+| C | 130 KB of markup, 300 characters of text | client-side rendering | the browser tier — sometimes nothing |
+
+Case B is the one worth naming twice: a login wall answered with a proxy is
+money spent on a problem you do not have. Read what the page says before
+deciding what it needs.
+
+## Judging a response
+
+A tier that trusts itself is the failure mode this subsystem keeps rediscovering.
+Every tier validates its own output before claiming success, because each has a
+way of returning something that is not a page while looking like it did:
+
+- **A plain fetch** can return 200 and a shell. Judged on *readable text*, not
+  raw HTML — Tokopedia sends 105 KB of markup wrapped around 234 characters, and
+  the ratio is the only thing that separates it from a genuinely short page.
+- **A stealth backend** can exit 0 having printed its own advice. That happened:
+  a misconfigured wrapper printed *"Install scrapling for CSS extraction"* and
+  36 characters of advice is indistinguishable from a short page by any rule
+  about pages. Backends are now checked for having returned a document at all.
+- **The browser** can hand back its own error sentence. That also happened, when
+  Playwright removed the API the code read pages through — the error string was
+  returned as page content, so a signed-in check answered "yes" forever.
+
+Scanning raw HTML for block markers is worse than useless, by the way: all six
+measured responses contain the word "captcha" as a string constant inside a
+JavaScript bundle. Marker checks run on text.
+
+## Installing the stealth tier
+
+Optional, and off by default. It is a ~150 MB browser binary that most
+deployments never need.
+
+```bash
+bash scripts/setup-stealth.sh          # or: setup-stealth.sh /custom/dir
+```
+
+It creates a virtualenv, installs the backend, downloads the browser, proves it
+can fetch a page, and prints the `STEALTH_FETCH_COMMAND` line to paste into
+`.env`. Restart the agents afterwards.
+
+**It installs outside `app/` on purpose.** `deploy.sh` rsyncs `app/` with
+`--delete`, so a venv underneath it would work exactly once. The split that
+survives deploys:
+
+- the **adapter** (`scripts/stealth_fetch.py`) lives in the repo and ships with
+  every deploy, so it stays in step with `acquire.py`;
+- the **backend** (the venv and the browser binary) lives beside `app/`, is
+  installed once per host, and is never version-controlled.
+
+That is also why the backend is not a dependency of this package: a missing
+backend is a *reported skipped tier*, not an import error at startup.
+
+`stealth_fetch.py` writes the page to stdout and nothing else. Any command that
+does the same works — the contract is a shell template containing `{url}` that
+prints a document and exits 0.
+
+## Checking that it still works
+
+Each tier degrades quietly. The backend lives outside the repo, so a host rebuild
+removes it without touching a line of code. Playwright can move an API. A plain
+fetch can start meeting a CDN. None of these raise at startup, none fail a test,
+and each turns into "the agent can't read that site any more" weeks later,
+blamed on the site.
+
+```bash
+kaos acquire check          # probe every tier now
+kaos acquire check --json   # same, machine-readable
+```
+
+`[--]` means a tier is not installed here — a choice, not a fault. `[FAIL]`
+means one that should work does not.
+
+The same probe runs daily as the `acquire-smoke` cron job, **and only speaks
+when something changes**. A daily "all three tiers fine" is a message that
+trains its reader to skip it, and the one morning it says something else it gets
+skipped too.
+
+It probes `example.com`, deliberately not a marketplace. The question is whether
+our machinery works; whether Shopee is in a good mood today is a different
+question, changes for reasons outside this repo, and a checker that goes red
+whenever a marketplace tightens its defences is one people learn to ignore.
+
+## Limits worth knowing
+
+- **The stealth tier is not a proxy.** It changes what the browser looks like,
+  not where the request comes from. A site blocking your datacentre's IP range
+  is unaffected by it.
+- **A residential proxy is for acting as yourself, not for reading.** Signing in
+  to your own account from a datacentre is the thing that makes a site suspicious
+  of *the account*. That is a different purchase from "read a public price".
+- **Some pages do not yield to any tier.** Search results rendered entirely by
+  client-side script, behind a session, are reported as unreadable — which is
+  the honest answer, and better than an empty list presented as "no results".
+- **Everything fetched is untrusted.** A product page telling the agent to
+  message someone is the textbook injection, and this is the tool that carries
+  it. Fetched content reaches the model framed as data, never as instructions.

--- a/docs/CRON-JOBS.md
+++ b/docs/CRON-JOBS.md
@@ -27,6 +27,7 @@ All core cron jobs are registered in `kronos/cron/setup.py` and run by the built
 | 19 | turn-retention | Weekly Sun 05:00 UTC (13:00 UTC+8) | Weekly | `turn_retention.py` |
 | 20 | swarm-weekly-report | Weekly Sun 06:00 UTC (14:00 UTC+8) | Weekly | `swarm_weekly.py` |
 | 21 | sla-escalation | Every 60 s | Periodic | `escalation.py` |
+| 22 | acquire-smoke | Daily 06:00 UTC (14:00 UTC+8) | Daily | `acquire_smoke.py` |
 
 Intake pollers registered alongside these: `user-reminders` (60 s),
 `handoff-intake`, `council-intake`, `memory-intake` (30 s each).
@@ -319,6 +320,29 @@ compare-and-set on the watch row, so exactly one of the six pollers creates the
 hand-off. A no-op ledger read when `agents.yaml` declares no ownership.
 
 **Notification:** none directly — delivery is the hand-off itself.
+
+### 22. acquire-smoke
+**Schedule:** Daily 06:00 UTC (14:00 UTC+8)
+**Module:** `kronos/cron/acquire_smoke.py`
+
+Fetches a known-good page through each acquisition tier (`plain`, `stealth`,
+`browser`) and records which ones worked. Guards internally to the `kronos`
+agent: the backends are per-host, so six probes would be five wasted browser
+launches and five duplicate alerts about one fault.
+
+It exists because each tier degrades quietly — the stealth backend lives outside
+the repo and a host rebuild removes it, Playwright once deleted the API the
+browser tier read pages through — and those turn into "the agent can't read that
+site any more" weeks later, blamed on the site. It probes `example.com`, not a
+marketplace: the question is whether our machinery works, not whether a
+marketplace is in a good mood today. See [ACQUISITION.md](ACQUISITION.md).
+
+A tier that is not installed reports `off`, which is a deployment choice and
+never an alert. Run the same probe by hand with `kaos acquire check`.
+
+**Notification:** only when a tier's status *changes* — Telegram webhook plus
+NTFY, `high` priority when a working tier was lost, `default` on recovery.
+Silence is the normal outcome.
 
 ## Scheduler Implementation
 

--- a/docs/CRON-JOBS.md
+++ b/docs/CRON-JOBS.md
@@ -27,7 +27,7 @@ All core cron jobs are registered in `kronos/cron/setup.py` and run by the built
 | 19 | turn-retention | Weekly Sun 05:00 UTC (13:00 UTC+8) | Weekly | `turn_retention.py` |
 | 20 | swarm-weekly-report | Weekly Sun 06:00 UTC (14:00 UTC+8) | Weekly | `swarm_weekly.py` |
 | 21 | sla-escalation | Every 60 s | Periodic | `escalation.py` |
-| 22 | acquire-smoke | Daily 06:00 UTC (14:00 UTC+8) | Daily | `acquire_smoke.py` |
+| 22 | acquire-smoke | Daily 07:00 UTC (15:00 UTC+8) | Daily | `acquire_smoke.py` |
 
 Intake pollers registered alongside these: `user-reminders` (60 s),
 `handoff-intake`, `council-intake`, `memory-intake` (30 s each).
@@ -322,7 +322,7 @@ hand-off. A no-op ledger read when `agents.yaml` declares no ownership.
 **Notification:** none directly — delivery is the hand-off itself.
 
 ### 22. acquire-smoke
-**Schedule:** Daily 06:00 UTC (14:00 UTC+8)
+**Schedule:** Daily 07:00 UTC (15:00 UTC+8)
 **Module:** `kronos/cron/acquire_smoke.py`
 
 Fetches a known-good page through each acquisition tier (`plain`, `stealth`,

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -1789,6 +1789,36 @@ def run_vault_status(as_json: bool) -> int:
     return 0 if usable else 1
 
 
+def run_acquire_check(as_json: bool) -> int:
+    """Whether each way of fetching a page still works.
+
+    The same probe the daily job runs, on demand — for right after installing a
+    backend, and for the moment a task reports a site as unreadable and the
+    question is whether the site changed or this host did.
+    """
+    import asyncio
+
+    from kronos.tools.acquire import SMOKE_URL, TIER_BROKEN, TIER_OFF, check_tier_health
+
+    results = asyncio.run(check_tier_health())
+    broken = [r for r in results if r.status == TIER_BROKEN]
+
+    if as_json:
+        print(json.dumps([{"tier": r.tier, "status": r.status, "detail": r.detail} for r in results], indent=2))
+        return 1 if broken else 0
+
+    print(f"Probed {SMOKE_URL}\n")
+    marks = {"ok": "[OK]  ", TIER_BROKEN: "[FAIL]", TIER_OFF: "[--]  "}
+    for r in results:
+        print(f"{marks.get(r.status, '[??]  ')} {r.tier:<8} {r.detail}")
+
+    if broken:
+        print(f"\n{len(broken)} tier(s) broken. Sites needing them are reported as unreadable, not fetched wrongly.")
+    elif any(r.status == TIER_OFF for r in results):
+        print("\nTiers marked [--] are not installed here — a choice, not a fault. See docs/ACQUISITION.md.")
+    return 1 if broken else 0
+
+
 def run_swarm_report(period: str, as_json: bool) -> int:
     """Post-mortem of the swarm's period: who answered, how well, at what cost."""
     from kronos.swarm_report import build_report, render_markdown
@@ -2198,6 +2228,11 @@ def build_parser() -> argparse.ArgumentParser:
     repos_remove = repos_sub.add_parser("remove", help="stop the agent reading a repository")
     repos_remove.add_argument("name")
 
+    acquire_cmd = sub.add_parser("acquire", help="how pages are fetched, and whether that still works")
+    acquire_sub = acquire_cmd.add_subparsers(dest="acquire_command")
+    acquire_check = acquire_sub.add_parser("check", help="probe every fetch tier against a known-good page")
+    acquire_check.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
+
     vault_cmd = sub.add_parser("vault", help="the key that encrypts stored site passwords")
     vault_sub = vault_cmd.add_subparsers(dest="vault_command")
     vault_init = vault_sub.add_parser("init", help="create the vault key")
@@ -2415,6 +2450,11 @@ def main(argv: list[str] | None = None) -> int:
         if args.repos_command == "remove":
             return run_repos_remove(args.name)
         parser.parse_args(["repos", "--help"])
+        return 0
+    if args.command == "acquire":
+        if args.acquire_command == "check":
+            return run_acquire_check(args.as_json)
+        parser.parse_args(["acquire", "--help"])
         return 0
     if args.command == "vault":
         if args.vault_command == "init":

--- a/kronos/cron/acquire_smoke.py
+++ b/kronos/cron/acquire_smoke.py
@@ -1,0 +1,119 @@
+"""Daily proof that the acquisition tiers still work — and a shout when one stops.
+
+Every tier in `kronos.tools.acquire` fails quietly. The stealth backend lives
+outside this repo, so a host rebuild removes it without touching a line of code.
+The browser tier broke once because Playwright deleted the API it was reading
+pages through — and returned its own error message as page content, which reads
+like a page that loaded. A plain fetch can start meeting a CDN that was not
+there last month.
+
+None of those raise at startup, none fail a test, and each turns into "the agent
+can't read that site any more" weeks later, blamed on the site. This job is the
+difference between finding out on a Tuesday and finding out from a task that
+quietly returned nothing.
+
+**It only speaks when something changes.** A daily "all three tiers fine" is a
+message that trains its reader to skip it, and the one day it says something
+else it gets skipped too.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+from kronos.config import settings
+from kronos.cron.notify import send_ntfy, send_webhook
+from kronos.tools.acquire import TIER_BROKEN, TIER_OK, check_tier_health
+
+log = logging.getLogger("kronos.cron.acquire_smoke")
+
+# The backends are per-host, not per-agent: six agents on one machine share one
+# stealth venv and one chromium. Six identical probes would be five wasted
+# browser launches and five duplicate alerts about the same fault.
+OWNER_AGENT = "kronos"
+
+
+def _state_file() -> Path:
+    # Next to the agent's own DB, matching the scheduler's own state file — not
+    # in swarm.db. This is a fact about one host's install, not shared knowledge.
+    return Path(settings.db_path).parent / "acquire_health.json"
+
+
+def _load_previous() -> dict[str, str]:
+    path = _state_file()
+    if not path.exists():
+        return {}
+    try:
+        loaded = json.loads(path.read_text())
+    except Exception as e:
+        # A corrupt state file must not stop the probe: the check is the point,
+        # the memory of it is the optimisation. Worst case is one extra alert.
+        log.warning("Could not read %s (%s); treating this as a first run", path.name, e)
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _save(current: dict[str, str]) -> None:
+    path = _state_file()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(current, indent=2))
+        tmp.replace(path)
+    except Exception as e:
+        log.warning("Could not persist acquisition health: %s", e)
+
+
+def _describe(tier: str, before: str | None, after: str, detail: str) -> str:
+    if before is None:
+        return f"{tier}: {after} — {detail}"
+    return f"{tier}: {before} → {after} — {detail}"
+
+
+async def run_acquire_smoke() -> None:
+    """Probe every tier, and report only what changed since yesterday."""
+    if settings.agent_name != OWNER_AGENT:
+        return
+
+    results = await check_tier_health()
+    current = {r.tier: r.status for r in results}
+    previous = _load_previous()
+
+    log.info("Acquisition tiers: %s", ", ".join(f"{r.tier}={r.status}" for r in results))
+
+    notable: list[str] = []
+    for result in results:
+        before = previous.get(result.tier)
+        if before == result.status:
+            continue
+        # A first run has nothing to compare against, so only a fault is worth
+        # saying. Announcing "stealth: off" on a host that never wanted stealth
+        # would be the checker's first message and its least useful one.
+        if before is None and result.status != TIER_BROKEN:
+            continue
+        notable.append(_describe(result.tier, before, result.status, result.detail))
+
+    _save(current)
+
+    if not notable:
+        return
+
+    # A tier that was working and now is not — whether it errored (`broken`) or
+    # vanished from the config (`off`) — is the case this job exists for.
+    lost = [r for r in results if previous.get(r.tier) == TIER_OK and r.status != TIER_OK]
+    healthy = [r.tier for r in results if r.status == TIER_OK]
+    body = (
+        "Acquisition tiers changed:\n"
+        + "\n".join(f"• {line}" for line in notable)
+        + f"\n\nStill working: {', '.join(healthy) or 'none'}"
+    )
+    if lost:
+        body += "\n\nSites that needed that tier will now be reported as unreadable, rather than fetched wrongly."
+
+    send_webhook(body)
+    send_ntfy(
+        body,
+        title="Kronos Agent OS — acquisition",
+        priority="high" if lost else "default",
+        tags="warning" if lost else "white_check_mark",
+    )

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -156,11 +156,13 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     # Source Quality Audit — weekly check with a 13-day guard = biweekly cadence.
     scheduler.add_weekly("source-quality-audit", run_source_quality_audit, weekday=6, hour_utc=4)
 
-    # Acquisition tier smoke — daily at 06:30 UTC. Proves plain/stealth/browser
-    # can still fetch a page, and speaks only when that changes. Guards inside
-    # to the owning agent: the backends are per-host, so six probes would be
-    # five wasted browser launches and five duplicate alerts.
-    scheduler.add_daily("acquire-smoke", run_acquire_smoke, hour_utc=6)
+    # Acquisition tier smoke — daily at 07:00 UTC, an hour kept clear of the
+    # Sunday swarm report at 06:00 so a browser launch never lands on top of an
+    # LLM digest. Proves plain/stealth/browser can still fetch a page, and speaks
+    # only when that changes. Guards inside to the owning agent: the backends are
+    # per-host, so six probes would be five wasted browser launches and five
+    # duplicate alerts about one fault.
+    scheduler.add_daily("acquire-smoke", run_acquire_smoke, hour_utc=7)
 
     # Swarm Retention — weekly Sunday 03:00 UTC. Prunes swarm_messages
     # older than MESSAGE_RETENTION_DAYS (90d). Safe on all 6 agents.

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -23,6 +23,7 @@ _AGENT_EXCLUSIVE_JOBS: dict[str, str] = {
 def setup_cron_jobs(scheduler: Scheduler) -> None:
     """Register all cron jobs. Matches Kronos I systemd timers."""
 
+    from kronos.cron.acquire_smoke import run_acquire_smoke
     from kronos.cron.analytics_alerts import run_analytics_alerts
     from kronos.cron.analytics_pulse import run_analytics_pulse
     from kronos.cron.analytics_weekly import run_analytics_weekly
@@ -155,6 +156,12 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     # Source Quality Audit — weekly check with a 13-day guard = biweekly cadence.
     scheduler.add_weekly("source-quality-audit", run_source_quality_audit, weekday=6, hour_utc=4)
 
+    # Acquisition tier smoke — daily at 06:30 UTC. Proves plain/stealth/browser
+    # can still fetch a page, and speaks only when that changes. Guards inside
+    # to the owning agent: the backends are per-host, so six probes would be
+    # five wasted browser launches and five duplicate alerts.
+    scheduler.add_daily("acquire-smoke", run_acquire_smoke, hour_utc=6)
+
     # Swarm Retention — weekly Sunday 03:00 UTC. Prunes swarm_messages
     # older than MESSAGE_RETENTION_DAYS (90d). Safe on all 6 agents.
     scheduler.add_weekly("swarm-retention", run_swarm_retention, weekday=6, hour_utc=3)
@@ -194,6 +201,6 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
         nexus_jobs_registered = 4
 
     total = (
-        22 + nexus_jobs_registered
-    )  # +reminders +plan-steps +handoff/council/memory intake +sla-escalation +swarm-weekly-report +persona-evolution; signal-jobs, travel insights, people-scout and group-digest paused
+        23 + nexus_jobs_registered
+    )  # +reminders +plan-steps +handoff/council/memory intake +sla-escalation +swarm-weekly-report +persona-evolution +acquire-smoke; signal-jobs, travel insights, people-scout and group-digest paused
     log.info("%d cron jobs registered for agent '%s'", total, me)

--- a/kronos/tools/acquire.py
+++ b/kronos/tools/acquire.py
@@ -31,6 +31,7 @@ import json
 import logging
 import re
 import shlex
+from dataclasses import dataclass
 
 from langchain_core.tools import tool
 
@@ -275,6 +276,112 @@ async def fetch_tiered(url: str) -> tuple[str, str, list[str]]:
         notes.append(f"browser fetch failed: {e}")
 
     raise FetchBlockedError("; ".join(notes) or "no backend could fetch this page")
+
+
+# ── Tier health ───────────────────────────────────────────────────────────────
+#
+# Every tier here degrades quietly. A stealth backend uninstalled by a host
+# rebuild, a browser whose API moved under it, a plain fetch that started
+# meeting a CDN — none of them raise at startup, none fail a test, and all of
+# them turn into "that marketplace can't be read" weeks later, attributed to
+# the marketplace. Three of this module's real bugs were found by running it
+# against the live web and none by the suite, because a test that fakes the
+# boundary cannot notice the boundary changing.
+
+TIER_OK = "ok"
+TIER_BROKEN = "broken"
+TIER_OFF = "off"
+
+# Deliberately not a marketplace. The question here is "does our machinery
+# still work", and a marketplace answers a different one — "is that site in a
+# good mood today" — which changes for reasons outside this repo and on a
+# schedule nobody controls. A checker that cries wolf whenever Shopee tightens
+# its defences is a checker people learn to ignore, and then it is worth less
+# than nothing. example.com exists for exactly this and changes for nobody.
+SMOKE_URL = "https://example.com"
+
+
+@dataclass(frozen=True)
+class TierHealth:
+    """What one acquisition tier can do right now."""
+
+    tier: str
+    status: str
+    detail: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.status == TIER_OK
+
+
+async def check_tier_health(url: str = SMOKE_URL) -> list[TierHealth]:
+    """Probe each tier against a page none of them has any reason to be refused.
+
+    Three outcomes per tier, and the third is the one worth having: `off` means
+    a backend this deployment never installed, which is a documented choice and
+    not a fault. Collapsing it into `broken` would page somebody about a stealth
+    browser they deliberately never wanted, and an alert that is usually wrong
+    gets muted — taking the real ones with it.
+    """
+    from kronos.security.egress import check_url
+
+    try:
+        check_url(url, tool="acquire-health")
+    except Exception as e:
+        # Bypassing the policy to run a health check would be a strange place
+        # to put a hole. Report instead: unrunnable is not the same as broken.
+        return [TierHealth(tier, TIER_OFF, f"cannot probe: {e}") for tier in (TIER_PLAIN, TIER_STEALTH, TIER_BROWSER)]
+
+    return [
+        await _check_plain(url),
+        await _check_stealth(url),
+        await _check_browser(url),
+    ]
+
+
+async def _check_plain(url: str) -> TierHealth:
+    try:
+        status, body = await fetch_plain(url)
+    except Exception as e:
+        return TierHealth(TIER_PLAIN, TIER_BROKEN, f"{type(e).__name__}: {e}")
+    if looks_blocked(status, body):
+        return TierHealth(TIER_PLAIN, TIER_BROKEN, f"HTTP {status}, and the body reads as a block or a shell")
+    return TierHealth(TIER_PLAIN, TIER_OK, f"HTTP {status}, {len(html_to_text(body))} characters of text")
+
+
+async def _check_stealth(url: str) -> TierHealth:
+    if stealth_command(url) is None:
+        return TierHealth(TIER_STEALTH, TIER_OFF, "no STEALTH_FETCH_COMMAND configured")
+    try:
+        _, body = await fetch_stealth(url)
+    except Exception as e:
+        return TierHealth(TIER_STEALTH, TIER_BROKEN, str(e))
+    return TierHealth(TIER_STEALTH, TIER_OK, f"{len(html_to_text(body))} characters of text")
+
+
+async def _check_browser(url: str) -> TierHealth:
+    import importlib.util
+
+    if importlib.util.find_spec("playwright") is None:
+        return TierHealth(TIER_BROWSER, TIER_OFF, "playwright is not installed (pip install -e '.[browser]')")
+
+    from kronos.tools.browser import engine
+
+    # Leave the process as we found it. If the agent already had a browser open
+    # — a signed-in site session, most likely — closing it here would end that
+    # session to prove an unrelated point.
+    was_running = engine.is_running()
+    try:
+        _, body = await fetch_browser(url)
+    except Exception as e:
+        return TierHealth(TIER_BROWSER, TIER_BROKEN, str(e))
+    finally:
+        if not was_running:
+            try:
+                await engine.close()
+            except Exception as e:  # pragma: no cover - best effort
+                log.debug("Closing the probe's browser failed: %s", e)
+    return TierHealth(TIER_BROWSER, TIER_OK, f"{len(html_to_text(body))} characters of text")
 
 
 @tool

--- a/kronos/tools/browser/engine.py
+++ b/kronos/tools/browser/engine.py
@@ -216,6 +216,17 @@ async def get_current_url() -> str:
     return page.url
 
 
+def is_running() -> bool:
+    """Whether a browser is already open.
+
+    For callers that start the browser only to prove it works: they should put
+    the process back as they found it, and must never close a session somebody
+    else opened. Asking first is the difference between a health check and an
+    interruption.
+    """
+    return _page is not None and not _page.is_closed()
+
+
 async def close():
     """Close browser and cleanup."""
     global _pw, _browser, _page, _profile_dir

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -305,6 +305,23 @@ else
       fi
     fi
 
+    # The stealth fetch tier is an optional backend installed OUTSIDE app/ (see
+    # scripts/setup-stealth.sh), precisely so this rsync --delete cannot erase
+    # it. The flip side is that a rebuilt or migrated host keeps the .env line
+    # and loses the interpreter it points at. One test -x here beats finding out
+    # three weeks later as "the agent stopped being able to read that site".
+    # Not auto-installed: it is a ~150 MB browser most deployments never need.
+    STEALTH_CMD=$(grep -m1 '^STEALTH_FETCH_COMMAND=' app/.env 2>/dev/null | cut -d= -f2- || true)
+    STEALTH_CMD=${STEALTH_CMD%\"}
+    STEALTH_CMD=${STEALTH_CMD#\"}
+    if [ -n "$STEALTH_CMD" ]; then
+      STEALTH_BIN=$(echo "$STEALTH_CMD" | awk '{print $1}')
+      if [ ! -x "$STEALTH_BIN" ]; then
+        echo "WARNING: STEALTH_FETCH_COMMAND points at '$STEALTH_BIN', which is not executable on this host."
+        echo "         The stealth tier is dead until you run: bash app/scripts/setup-stealth.sh"
+      fi
+    fi
+
     # Build the code sandbox image if it is missing. Without it, run_code and
     # dynamic tools refuse to run — there is no unsandboxed fallback — so the
     # capability would look enabled and never work. Only when absent: the image

--- a/scripts/setup-stealth.sh
+++ b/scripts/setup-stealth.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# setup-stealth.sh — install the optional stealth fetch backend.
+#
+# Usage: setup-stealth.sh [install-dir]
+#
+# The middle acquisition tier (kronos/tools/acquire.py) shells out to a stealth
+# browser for sites that refuse an ordinary GET. That browser is deliberately
+# NOT a dependency of this package: it is a ~150 MB binary, most deployments do
+# not need it, and a missing backend is a reported skipped tier rather than an
+# error. This script installs it, verifies it, and prints the one line that
+# wires it in.
+#
+# It installs OUTSIDE the app directory on purpose. deploy.sh rsyncs `app/` with
+# --delete, so anything placed under it is erased on the next deploy — a venv
+# there would work exactly once. The adapter (scripts/stealth_fetch.py) stays in
+# the repo and ships with every deploy; only the backend lives outside it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(dirname "$SCRIPT_DIR")"
+DEFAULT_DIR="$(dirname "$APP_DIR")/tools"
+INSTALL_DIR="${1:-${KAOS_STEALTH_DIR:-$DEFAULT_DIR}}"
+
+VENV="$INSTALL_DIR/.venv"
+PYTHON="$VENV/bin/python"
+FETCHER="$APP_DIR/scripts/stealth_fetch.py"
+
+fail() {
+  echo "FATAL: $*" >&2
+  exit 1
+}
+
+case "$INSTALL_DIR" in
+  "$APP_DIR"|"$APP_DIR"/*)
+    fail "refusing to install into $INSTALL_DIR: deploy.sh rsyncs app/ with --delete and would erase it on the next deploy."
+    ;;
+esac
+
+echo "Installing the stealth backend into $INSTALL_DIR"
+
+mkdir -p "$INSTALL_DIR"
+
+if [ -d "$VENV" ] && [ ! -x "$PYTHON" ]; then
+  echo "Removing an incomplete virtualenv from a previous run."
+  rm -rf "$VENV"
+fi
+
+if [ ! -x "$PYTHON" ]; then
+  python3 -m venv "$VENV" || fail "could not create a virtualenv at $VENV (is python3-venv installed?)"
+fi
+
+# Only cloakbrowser. The AI/parsing extras of the wider scraping stack pull in
+# hundreds of megabytes and this tier never parses — acquire.py wants the raw
+# document and does its own extraction.
+"$PYTHON" -m pip install --quiet --upgrade pip
+"$PYTHON" -m pip install --quiet cloakbrowser || fail "could not install cloakbrowser"
+
+echo "Downloading the stealth browser binary (skipped when already cached)..."
+"$VENV/bin/cloakbrowser" install || fail "could not download the stealth browser binary"
+
+# Prove it before claiming it works. An install that imports but cannot open a
+# page is the failure this whole exercise exists to stop being silent about.
+echo "Verifying against example.com..."
+if ! "$PYTHON" "$FETCHER" https://example.com >/dev/null; then
+  fail "the backend installed but could not fetch a page. Run '$VENV/bin/cloakbrowser info' for diagnostics."
+fi
+
+cat <<EOF
+
+Done. Add this to the agent's .env and restart the agents:
+
+STEALTH_FETCH_COMMAND=$PYTHON $FETCHER {url}
+
+Then confirm the tier is live:
+
+  .venv/bin/python -m kronos.cli acquire check
+EOF

--- a/scripts/stealth_fetch.py
+++ b/scripts/stealth_fetch.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Fetch one page through a stealth browser and print its HTML.
+
+The middle tier of `kronos.tools.acquire` runs a *command*, not an import, so
+the heavyweight browser stack stays out of the agent's process and out of this
+package's dependencies. This is the adapter for that contract: stdout is the
+page, stderr is the reason there isn't one, and the exit code says which.
+
+It lives in the repo — and the backend it drives does not — on purpose. The
+adapter is twenty lines that change with `acquire.py`; the backend is a browser
+binary that changes with the host. Deploying the first and installing the second
+separately is what keeps a machine-specific path out of version control while
+still making the wiring reproducible. `scripts/setup-stealth.sh` installs the
+backend and prints the line that connects the two.
+
+**Nothing but the page goes to stdout.** That rule is not stylistic. The
+previous wrapper here was a general-purpose scraper that, when its optional
+parser was absent, printed *"Install scrapling for CSS extraction"* and exited
+0 — and 37 characters of advice is indistinguishable from a short page to
+anything downstream. `acquire.py` now validates what a backend returns, but the
+backend should not have been lying in the first place. A script that can only
+print a page cannot print advice instead of one.
+"""
+
+import argparse
+import sys
+
+# A stealth browser is slow by construction; the caller's own ceiling is 90s.
+DEFAULT_NAVIGATION_TIMEOUT_MS = 30_000
+
+# Time to let client-side rendering finish after the document is ready. Most
+# pages need none of it; the ones this tier exists for need all of it.
+DEFAULT_SETTLE_MS = 3_000
+
+EXIT_BACKEND_MISSING = 2
+EXIT_NO_PAGE = 3
+EXIT_FETCH_FAILED = 4
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("url", help="the page to fetch")
+    parser.add_argument(
+        "--settle",
+        type=int,
+        default=DEFAULT_SETTLE_MS,
+        metavar="MS",
+        help=f"wait this long after load for client-side rendering (default: {DEFAULT_SETTLE_MS})",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=DEFAULT_NAVIGATION_TIMEOUT_MS,
+        metavar="MS",
+        help=f"navigation timeout (default: {DEFAULT_NAVIGATION_TIMEOUT_MS})",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        from cloakbrowser import launch
+    except ImportError as e:
+        # Not a crash worth a traceback: on a host that never installed the
+        # backend this is the expected answer, and the caller reports it as a
+        # skipped tier.
+        print(f"stealth backend not installed in this interpreter ({e}); see scripts/setup-stealth.sh", file=sys.stderr)
+        return EXIT_BACKEND_MISSING
+
+    try:
+        html = _fetch(launch, args.url, timeout_ms=args.timeout, settle_ms=args.settle)
+    except Exception as e:
+        print(f"stealth fetch failed: {type(e).__name__}: {e}", file=sys.stderr)
+        return EXIT_FETCH_FAILED
+
+    if not html.strip():
+        print("the browser returned an empty document", file=sys.stderr)
+        return EXIT_NO_PAGE
+
+    sys.stdout.write(html)
+    return 0
+
+
+def _fetch(launch, url: str, *, timeout_ms: int, settle_ms: int) -> str:
+    """Drive the browser and hand back the document it ended up with."""
+    browser = launch(headless=True)
+    try:
+        page = browser.new_page()
+        page.goto(url, timeout=timeout_ms, wait_until="domcontentloaded")
+        page.wait_for_timeout(settle_ms)
+        return page.content()
+    finally:
+        # Closing matters more than the result: a leaked headless browser on a
+        # host running six agents is a slow memory leak nobody attributes here.
+        browser.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_acquire_health.py
+++ b/tests/test_acquire_health.py
@@ -1,0 +1,282 @@
+"""Noticing that a fetch tier stopped working.
+
+Every tier degrades quietly: a stealth backend removed by a host rebuild, a
+browser whose API moved under it, a plain fetch that started meeting a CDN. The
+three real bugs in this module were all found by running it against the live web
+and none by the suite — so what is tested here is not "does fetching work" (a
+test that fakes the boundary cannot notice the boundary changing) but the
+reporting around it: that a fault is distinguished from a deliberate absence,
+and that probing does not damage what it probes.
+"""
+
+import pytest
+
+from kronos.config import settings
+from kronos.tools.acquire import (
+    SMOKE_URL,
+    TIER_BROKEN,
+    TIER_BROWSER,
+    TIER_OFF,
+    TIER_OK,
+    TIER_PLAIN,
+    TIER_STEALTH,
+    FetchBlockedError,
+    check_tier_health,
+)
+
+REAL_PAGE = "<html><body><h1>Example Domain</h1><p>For use in documents.</p></body></html>"
+
+
+@pytest.fixture(autouse=True)
+def no_backends(monkeypatch):
+    """Default to a host with nothing optional installed."""
+    monkeypatch.setattr(settings, "stealth_fetch_command", "")
+    return monkeypatch
+
+
+def _by_tier(results):
+    return {r.tier: r for r in results}
+
+
+def working_plain(monkeypatch):
+    async def _fetch(url):
+        return 200, REAL_PAGE
+
+    monkeypatch.setattr("kronos.tools.acquire.fetch_plain", _fetch)
+
+
+def _pretend_playwright(monkeypatch, installed: bool):
+    """Decide the browser tier's availability, whichever way this host is set up.
+
+    Pinned in both directions on purpose: the browser extra is optional, so a
+    test that reads the real answer passes or fails depending on which machine
+    ran it.
+    """
+    import importlib.util
+
+    real = importlib.util.find_spec
+
+    def _spec(name, *a, **kw):
+        if name == "playwright":
+            return object() if installed else None
+        return real(name, *a, **kw)
+
+    monkeypatch.setattr(importlib.util, "find_spec", _spec)
+
+
+def no_playwright(monkeypatch):
+    _pretend_playwright(monkeypatch, installed=False)
+
+
+def with_playwright(monkeypatch):
+    _pretend_playwright(monkeypatch, installed=True)
+
+
+# --- every tier reports something ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_every_tier_is_reported(monkeypatch):
+    working_plain(monkeypatch)
+    no_playwright(monkeypatch)
+
+    results = await check_tier_health()
+
+    assert [r.tier for r in results] == [TIER_PLAIN, TIER_STEALTH, TIER_BROWSER]
+
+
+# --- a fault is not the same as a deliberate absence --------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_uninstalled_backend_is_off_not_broken(monkeypatch):
+    """A stealth browser nobody wanted must not read as a fault.
+
+    Collapsing the two would alert about a backend this host deliberately never
+    installed — and an alert that is usually wrong gets muted, taking the real
+    ones with it.
+    """
+    working_plain(monkeypatch)
+    no_playwright(monkeypatch)
+
+    results = _by_tier(await check_tier_health())
+
+    assert results[TIER_STEALTH].status == TIER_OFF
+    assert results[TIER_BROWSER].status == TIER_OFF
+    assert "STEALTH_FETCH_COMMAND" in results[TIER_STEALTH].detail
+
+
+@pytest.mark.asyncio
+async def test_a_configured_backend_that_fails_is_broken(monkeypatch):
+    """This is the host-rebuild case: the .env line survives, the venv does not."""
+    working_plain(monkeypatch)
+    no_playwright(monkeypatch)
+    monkeypatch.setattr(settings, "stealth_fetch_command", "/gone/python /gone/fetch.py {url}")
+
+    async def _fails(url):
+        raise FetchBlockedError("stealth backend failed: No such file or directory")
+
+    monkeypatch.setattr("kronos.tools.acquire.fetch_stealth", _fails)
+
+    results = _by_tier(await check_tier_health())
+
+    assert results[TIER_STEALTH].status == TIER_BROKEN
+    assert "No such file" in results[TIER_STEALTH].detail
+
+
+@pytest.mark.asyncio
+async def test_a_plain_fetch_that_raises_is_broken(monkeypatch):
+    no_playwright(monkeypatch)
+
+    async def _boom(url):
+        raise OSError("Network is unreachable")
+
+    monkeypatch.setattr("kronos.tools.acquire.fetch_plain", _boom)
+
+    results = _by_tier(await check_tier_health())
+
+    assert results[TIER_PLAIN].status == TIER_BROKEN
+    assert "Network is unreachable" in results[TIER_PLAIN].detail
+
+
+@pytest.mark.asyncio
+async def test_a_plain_fetch_that_gets_a_block_page_is_broken(monkeypatch):
+    """example.com has no reason to refuse us; if it does, something is wrong here."""
+    no_playwright(monkeypatch)
+
+    async def _blocked(url):
+        return 403, "<html><body>Access denied</body></html>"
+
+    monkeypatch.setattr("kronos.tools.acquire.fetch_plain", _blocked)
+
+    results = _by_tier(await check_tier_health())
+
+    assert results[TIER_PLAIN].status == TIER_BROKEN
+    assert "403" in results[TIER_PLAIN].detail
+
+
+@pytest.mark.asyncio
+async def test_a_working_tier_reports_how_much_it_read(monkeypatch):
+    """ "ok" with no evidence is what a broken browser also said, once."""
+    working_plain(monkeypatch)
+    no_playwright(monkeypatch)
+
+    results = _by_tier(await check_tier_health())
+
+    assert results[TIER_PLAIN].status == TIER_OK
+    assert results[TIER_PLAIN].ok is True
+    assert "characters of text" in results[TIER_PLAIN].detail
+
+
+# --- probing must not damage what it probes -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_probe_closes_a_browser_it_started(monkeypatch):
+    """Otherwise a daily check leaks a headless browser onto a six-agent host."""
+    working_plain(monkeypatch)
+    with_playwright(monkeypatch)
+    closed = []
+
+    async def _fetch_browser(url):
+        return 200, REAL_PAGE
+
+    monkeypatch.setattr("kronos.tools.acquire.fetch_browser", _fetch_browser)
+    from kronos.tools.browser import engine
+
+    monkeypatch.setattr(engine, "is_running", lambda: False)
+
+    async def _close():
+        closed.append(True)
+
+    monkeypatch.setattr(engine, "close", _close)
+
+    await check_tier_health()
+
+    assert closed == [True]
+
+
+@pytest.mark.asyncio
+async def test_the_probe_leaves_an_existing_session_open(monkeypatch):
+    """A browser already open is most likely a signed-in site session.
+
+    Closing it to prove an unrelated point would end that session — and the next
+    task would report "needs login" for a reason nothing in its logs explains.
+    """
+    working_plain(monkeypatch)
+    with_playwright(monkeypatch)
+    closed = []
+
+    async def _fetch_browser(url):
+        return 200, REAL_PAGE
+
+    monkeypatch.setattr("kronos.tools.acquire.fetch_browser", _fetch_browser)
+    from kronos.tools.browser import engine
+
+    monkeypatch.setattr(engine, "is_running", lambda: True)
+
+    async def _close():
+        closed.append(True)
+
+    monkeypatch.setattr(engine, "close", _close)
+
+    await check_tier_health()
+
+    assert closed == []
+
+
+@pytest.mark.asyncio
+async def test_a_broken_browser_is_still_cleaned_up(monkeypatch):
+    working_plain(monkeypatch)
+    with_playwright(monkeypatch)
+    closed = []
+
+    async def _fetch_browser(url):
+        raise FetchBlockedError("browser returned no usable content")
+
+    monkeypatch.setattr("kronos.tools.acquire.fetch_browser", _fetch_browser)
+    from kronos.tools.browser import engine
+
+    monkeypatch.setattr(engine, "is_running", lambda: False)
+
+    async def _close():
+        closed.append(True)
+
+    monkeypatch.setattr(engine, "close", _close)
+
+    results = _by_tier(await check_tier_health())
+
+    assert results[TIER_BROWSER].status == TIER_BROKEN
+    assert closed == [True], "a failed probe still started a browser"
+
+
+# --- the probe respects egress policy -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_blocked_smoke_url_is_reported_not_bypassed(monkeypatch):
+    """A health check is a strange place to put a hole in the egress policy.
+
+    Unrunnable is also not the same as broken: reporting it as a fault would
+    send somebody hunting for a browser bug that does not exist.
+    """
+
+    def _refuse(url, tool=""):
+        raise RuntimeError(f"egress to {url} is not in the allowlist")
+
+    monkeypatch.setattr("kronos.security.egress.check_url", _refuse)
+
+    results = await check_tier_health()
+
+    assert {r.status for r in results} == {TIER_OFF}
+    assert all("cannot probe" in r.detail for r in results)
+
+
+def test_the_smoke_url_is_not_a_marketplace():
+    """A checker that goes red when Shopee tightens its defences gets ignored.
+
+    The question this job asks is whether our machinery works, not whether a
+    marketplace is in a good mood — those change for different reasons and only
+    one of them is actionable here.
+    """
+    assert SMOKE_URL == "https://example.com"

--- a/tests/test_acquire_smoke.py
+++ b/tests/test_acquire_smoke.py
@@ -1,0 +1,189 @@
+"""The daily job that notices a fetch tier died.
+
+Its whole value is in when it stays quiet. A checker that reports "all three
+tiers fine" every morning teaches its reader to skip it, and then the one
+morning it says something else gets skipped too — which is worse than not having
+it, because it comes with the feeling of being covered.
+"""
+
+import json
+
+import pytest
+
+from kronos.config import settings
+from kronos.cron import acquire_smoke
+from kronos.tools.acquire import (
+    TIER_BROKEN,
+    TIER_BROWSER,
+    TIER_OFF,
+    TIER_OK,
+    TIER_PLAIN,
+    TIER_STEALTH,
+    TierHealth,
+)
+
+
+@pytest.fixture
+def sent(tmp_path, monkeypatch):
+    """A host running the owning agent, with every message captured."""
+    monkeypatch.setattr(settings, "agent_name", acquire_smoke.OWNER_AGENT)
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
+
+    messages: list[tuple[str, str]] = []
+    monkeypatch.setattr(acquire_smoke, "send_webhook", lambda text, **kw: messages.append(("webhook", text)))
+    monkeypatch.setattr(acquire_smoke, "send_ntfy", lambda text, **kw: messages.append(("ntfy", text)))
+    return messages
+
+
+def tiers(monkeypatch, plain=TIER_OK, stealth=TIER_OK, browser=TIER_OK):
+    async def _check(url=None):
+        return [
+            TierHealth(TIER_PLAIN, plain, "detail"),
+            TierHealth(TIER_STEALTH, stealth, "detail"),
+            TierHealth(TIER_BROWSER, browser, "detail"),
+        ]
+
+    monkeypatch.setattr(acquire_smoke, "check_tier_health", _check)
+
+
+def state_file(tmp_path):
+    return tmp_path / "acquire_health.json"
+
+
+# --- silence is the default ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nothing_changed_means_nothing_said(sent, tmp_path, monkeypatch):
+    tiers(monkeypatch)
+    state_file(tmp_path).write_text(json.dumps({TIER_PLAIN: TIER_OK, TIER_STEALTH: TIER_OK, TIER_BROWSER: TIER_OK}))
+
+    await acquire_smoke.run_acquire_smoke()
+
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_a_first_run_does_not_announce_a_backend_nobody_installed(sent, tmp_path, monkeypatch):
+    """ "stealth: off" would be this job's first message and its least useful one."""
+    tiers(monkeypatch, stealth=TIER_OFF, browser=TIER_OFF)
+
+    await acquire_smoke.run_acquire_smoke()
+
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_only_the_owning_agent_probes(sent, tmp_path, monkeypatch):
+    """Six agents share one host: six probes are five wasted browser launches."""
+    monkeypatch.setattr(settings, "agent_name", "impulse")
+    called = []
+
+    async def _check(url=None):
+        called.append(True)
+        return []
+
+    monkeypatch.setattr(acquire_smoke, "check_tier_health", _check)
+
+    await acquire_smoke.run_acquire_smoke()
+
+    assert called == []
+    assert sent == []
+
+
+# --- but a change is always said ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_tier_that_broke_is_reported(sent, tmp_path, monkeypatch):
+    tiers(monkeypatch, browser=TIER_BROKEN)
+    state_file(tmp_path).write_text(json.dumps({TIER_PLAIN: TIER_OK, TIER_STEALTH: TIER_OK, TIER_BROWSER: TIER_OK}))
+
+    await acquire_smoke.run_acquire_smoke()
+
+    assert [channel for channel, _ in sent] == ["webhook", "ntfy"]
+    body = sent[0][1]
+    assert "browser: ok → broken" in body
+    assert "Still working: plain, stealth" in body
+
+
+@pytest.mark.asyncio
+async def test_a_tier_that_vanished_from_the_config_is_reported(sent, tmp_path, monkeypatch):
+    """The host-rebuild case: nothing errors, the tier is simply gone."""
+    tiers(monkeypatch, stealth=TIER_OFF)
+    state_file(tmp_path).write_text(json.dumps({TIER_PLAIN: TIER_OK, TIER_STEALTH: TIER_OK, TIER_BROWSER: TIER_OK}))
+
+    await acquire_smoke.run_acquire_smoke()
+
+    assert "stealth: ok → off" in sent[0][1]
+
+
+@pytest.mark.asyncio
+async def test_a_first_run_still_reports_something_actually_broken(sent, tmp_path, monkeypatch):
+    """No baseline is a reason not to compare, not a reason not to look."""
+    tiers(monkeypatch, plain=TIER_BROKEN, stealth=TIER_OFF, browser=TIER_OFF)
+
+    await acquire_smoke.run_acquire_smoke()
+
+    body = sent[0][1]
+    assert "plain: broken" in body
+    assert "stealth" not in body, "an uninstalled backend is not news"
+
+
+@pytest.mark.asyncio
+async def test_recovery_is_reported_too(sent, tmp_path, monkeypatch):
+    """Closing the loop matters: otherwise the last word on a tier is 'broken'."""
+    tiers(monkeypatch)
+    state_file(tmp_path).write_text(json.dumps({TIER_PLAIN: TIER_OK, TIER_STEALTH: TIER_BROKEN, TIER_BROWSER: TIER_OK}))
+
+    await acquire_smoke.run_acquire_smoke()
+
+    assert "stealth: broken → ok" in sent[0][1]
+
+
+@pytest.mark.asyncio
+async def test_a_loss_is_louder_than_a_recovery(sent, tmp_path, monkeypatch):
+    """A push that wakes someone should be reserved for something being wrong."""
+    priorities = []
+    monkeypatch.setattr(
+        acquire_smoke,
+        "send_ntfy",
+        lambda text, **kw: priorities.append(kw.get("priority")),
+    )
+
+    tiers(monkeypatch, browser=TIER_BROKEN)
+    state_file(tmp_path).write_text(json.dumps({TIER_PLAIN: TIER_OK, TIER_STEALTH: TIER_OK, TIER_BROWSER: TIER_OK}))
+    await acquire_smoke.run_acquire_smoke()
+
+    tiers(monkeypatch)
+    await acquire_smoke.run_acquire_smoke()
+
+    assert priorities == ["high", "default"]
+
+
+# --- remembering ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_result_is_remembered_so_it_is_said_once(sent, tmp_path, monkeypatch):
+    tiers(monkeypatch, browser=TIER_BROKEN)
+    state_file(tmp_path).write_text(json.dumps({TIER_BROWSER: TIER_OK}))
+
+    await acquire_smoke.run_acquire_smoke()
+    said_once = len(sent)
+    await acquire_smoke.run_acquire_smoke()
+
+    assert len(sent) == said_once, "a tier that is still broken is not new news"
+    assert json.loads(state_file(tmp_path).read_text())[TIER_BROWSER] == TIER_BROKEN
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_state_file_does_not_stop_the_probe(sent, tmp_path, monkeypatch):
+    """The check is the point; remembering it is the optimisation."""
+    tiers(monkeypatch, plain=TIER_BROKEN)
+    state_file(tmp_path).write_text("{not json")
+
+    await acquire_smoke.run_acquire_smoke()
+
+    assert "plain: broken" in sent[0][1]
+    assert json.loads(state_file(tmp_path).read_text())[TIER_PLAIN] == TIER_BROKEN

--- a/tests/test_stealth_fetch.py
+++ b/tests/test_stealth_fetch.py
@@ -1,0 +1,143 @@
+"""The adapter between the stealth backend and the fetch tiers.
+
+This exists because of a specific bug. The wrapper here used to be a
+general-purpose scraper that, when an optional parser was missing, printed
+"Install scrapling for CSS extraction" to stdout and exited 0 — and 37
+characters of advice is indistinguishable from a short page to anything
+downstream. `acquire.py` now validates what a backend returns, but a backend
+that lies is still the wrong shape. What is pinned here is that this script
+can only ever hand back a page or a non-zero exit.
+"""
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "stealth_fetch.py"
+
+
+@pytest.fixture
+def fetcher():
+    spec = importlib.util.spec_from_file_location("stealth_fetch_under_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeBrowser:
+    def __init__(self, html="", raises=None):
+        self.html = html
+        self.raises = raises
+        self.closed = False
+
+    def new_page(self):
+        return self
+
+    def goto(self, url, timeout=None, wait_until=None):
+        if self.raises:
+            raise self.raises
+
+    def wait_for_timeout(self, ms):
+        pass
+
+    def content(self):
+        return self.html
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def backend(monkeypatch):
+    """Install a fake `cloakbrowser` for the script to import."""
+    import types
+
+    def _install(browser):
+        module = types.ModuleType("cloakbrowser")
+        module.launch = lambda **kw: browser
+        monkeypatch.setitem(sys.modules, "cloakbrowser", module)
+        return browser
+
+    return _install
+
+
+# --- the page, and nothing else -----------------------------------------------
+
+
+def test_a_fetched_page_goes_to_stdout(fetcher, backend, capsys):
+    backend(FakeBrowser(html="<html><body>Example Domain</body></html>"))
+
+    code = fetcher.main(["https://example.com"])
+
+    assert code == 0
+    assert capsys.readouterr().out == "<html><body>Example Domain</body></html>"
+
+
+def test_a_missing_backend_exits_nonzero_and_prints_no_page(fetcher, monkeypatch, capsys):
+    """The expected answer on a host that never installed it — not a traceback."""
+    monkeypatch.setitem(sys.modules, "cloakbrowser", None)
+
+    code = fetcher.main(["https://example.com"])
+
+    captured = capsys.readouterr()
+    assert code == fetcher.EXIT_BACKEND_MISSING
+    assert captured.out == "", "advice on stdout is what the caller reads as a page"
+    assert "setup-stealth.sh" in captured.err
+
+
+def test_an_empty_document_is_a_failure_not_an_empty_page(fetcher, backend, capsys):
+    """Exit 0 with nothing is how "the site has no products" gets invented."""
+    backend(FakeBrowser(html="   \n  "))
+
+    code = fetcher.main(["https://example.com"])
+
+    captured = capsys.readouterr()
+    assert code == fetcher.EXIT_NO_PAGE
+    assert captured.out == ""
+    assert "empty document" in captured.err
+
+
+def test_a_navigation_failure_is_reported_on_stderr(fetcher, backend, capsys):
+    backend(FakeBrowser(raises=TimeoutError("navigation timeout")))
+
+    code = fetcher.main(["https://example.com"])
+
+    captured = capsys.readouterr()
+    assert code == fetcher.EXIT_FETCH_FAILED
+    assert captured.out == ""
+    assert "navigation timeout" in captured.err
+
+
+# --- housekeeping --------------------------------------------------------------
+
+
+def test_the_browser_is_closed_even_when_the_fetch_fails(fetcher, backend):
+    """A leaked headless browser on a six-agent host is nobody's obvious problem."""
+    browser = backend(FakeBrowser(raises=RuntimeError("boom")))
+
+    fetcher.main(["https://example.com"])
+
+    assert browser.closed is True
+
+
+def test_nothing_but_the_page_is_ever_written_to_stdout():
+    """Read from the source, so a future edit cannot quietly reintroduce the bug.
+
+    Every diagnostic must name stderr explicitly; the single unqualified write
+    is the page itself.
+    """
+    tree = ast.parse(SCRIPT.read_text(encoding="utf-8"))
+
+    prints_to_stdout = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "print"
+        and not any(kw.arg == "file" for kw in node.keywords)
+    ]
+
+    assert prints_to_stdout == [], "a diagnostic on stdout is read downstream as page content"


### PR DESCRIPTION
The stealth fetch tier was installed by hand on one machine and written down
nowhere. A rebuilt host would have lost it without touching a line of code, and
the first sign would have been a site becoming unreadable weeks later, blamed on
the site.

That is the general shape of this subsystem's failures. Three of its real bugs
were found by running it against the live web and none by the suite — a test
that fakes the boundary cannot notice the boundary changing.

## Reproducible instead of hand-installed

`scripts/setup-stealth.sh` installs the backend and proves it can fetch a page
before saying so. It installs **outside `app/`**: `deploy.sh` rsyncs with
`--delete`, so a venv underneath it works exactly once. Adapter in the repo,
backend beside it — which is also why the backend stays out of this package's
dependencies, where a missing one is a reported skipped tier rather than an
import error at startup.

`scripts/stealth_fetch.py` can only print a page or exit non-zero. The wrapper
it replaces printed *"Install scrapling for CSS extraction"* and exited 0, and
36 characters of advice is indistinguishable from a short page to anything
downstream. A test parses the source for unqualified `print()` calls so a later
edit cannot bring that shape back.

`deploy.sh` warns when `STEALTH_FETCH_COMMAND` points at an interpreter the host
no longer has.

## Noticing when a tier dies

`check_tier_health` probes each tier and separates three outcomes. The third is
the one worth having: **`off`** means a backend this deployment never installed
— a documented choice, not a fault. Collapsing it into `broken` would page
somebody about a browser they deliberately never wanted, and an alert that is
usually wrong gets muted, taking the real ones with it.

The daily `acquire-smoke` job **speaks only when a status changes**. A morning
report saying all three tiers are fine teaches its reader to skip it, and then
the one morning it says something else gets skipped too.

It probes `example.com`, deliberately not a marketplace: the question is whether
our machinery works, not whether a marketplace is in a good mood today, and a
checker that goes red whenever Shopee tightens its defences is one people learn
to ignore.

Two things the probe must not do, both tested:
- **bypass the egress policy** — a health check is a strange place to put a
  hole; an unrunnable probe is reported, not called broken;
- **close a browser somebody else opened**, which is most likely a signed-in
  site session. `engine.is_running()` is how it asks first.

`kaos acquire check` runs the same probe on demand, which is also how
`setup-stealth.sh` tells you to confirm the install.

## Verification

- 27 new tests; full suite 1915 passed locally (the one failure is
  `test_mcp_smoke.py`, `integration`-marked and excluded by CI's
  `-m "not integration"`, needing MCP binaries this machine lacks).
- `kaos acquire check` run against the live web: correctly reports plain `[OK]`
  with 142 characters of text, stealth and browser `[--]` on a machine with
  neither installed.
- Docs: [ACQUISITION.md](docs/ACQUISITION.md), CRON-JOBS.md job 22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)