### PR TITLE
Check that the sandbox runs code, and still contains it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to Kronos Agent OS are documented here.
 
 ### Added
 
+- **A sandbox check that runs code, because the readiness flag never could** —
+  `sandbox_ready()` asks whether Docker and the image exist, and both of this
+  subsystem's real failures answered that perfectly while every run inside
+  failed: a temp directory at `0700` the container could not read, and a bind
+  mount passed relatively, which Docker takes for a named volume. Neither raised
+  at startup, neither failed a test, and the sandbox called itself ready
+  throughout. `kaos sandbox check` and the daily `sandbox-smoke` job now execute
+  a program and read its output back. They also ask the container what it can
+  reach — only loopback, a root filesystem that refuses writes, a non-root uid —
+  turning three documented containment guarantees into three checked ones, all
+  answered from inside without sending a packet. Losing execution and losing
+  containment are opposite problems, so they get opposite messages: the first
+  costs a capability (nothing falls back to running unsandboxed), the second
+  means code still runs with a wall down, and that one names the off switch. A
+  check that could not be *determined* is left out rather than guessed at.
+  Verified against live Docker before it was written. Docs:
+  [Sandbox](docs/SANDBOX.md#checking-that-it-still-works).
 - **A reproducible stealth tier, and a daily check that it still exists** — the
   middle way of fetching a page ran on a backend installed by hand, documented
   nowhere, on one machine. A host rebuild would have removed it silently and the

--- a/docs/CRON-JOBS.md
+++ b/docs/CRON-JOBS.md
@@ -28,6 +28,7 @@ All core cron jobs are registered in `kronos/cron/setup.py` and run by the built
 | 20 | swarm-weekly-report | Weekly Sun 06:00 UTC (14:00 UTC+8) | Weekly | `swarm_weekly.py` |
 | 21 | sla-escalation | Every 60 s | Periodic | `escalation.py` |
 | 22 | acquire-smoke | Daily 07:00 UTC (15:00 UTC+8) | Daily | `acquire_smoke.py` |
+| 23 | sandbox-smoke | Daily 08:00 UTC (16:00 UTC+8) | Daily | `sandbox_smoke.py` |
 
 Intake pollers registered alongside these: `user-reminders` (60 s),
 `handoff-intake`, `council-intake`, `memory-intake` (30 s each).
@@ -343,6 +344,29 @@ never an alert. Run the same probe by hand with `kaos acquire check`.
 **Notification:** only when a tier's status *changes* — Telegram webhook plus
 NTFY, `high` priority when a working tier was lost, `default` on recovery.
 Silence is the normal outcome.
+
+### 23. sandbox-smoke
+**Schedule:** Daily 08:00 UTC (16:00 UTC+8)
+**Module:** `kronos/cron/sandbox_smoke.py`
+
+Runs code in the sandbox and asks the container what it can reach. Guards
+internally to the `kronos` agent: the Docker daemon and the image belong to the
+host, so six probes would be ten wasted container runs and five duplicate alerts
+about one fault.
+
+It exists because `sandbox_ready()` answers a different question — does Docker
+exist, does the image exist — and both of this subsystem's real failures answered
+that perfectly while every run inside failed. Seven checks in two groups: whether
+it can work at all (`docker`, `image`, `execution`, `workspace`) and whether it is
+still a sandbox (`no_network`, `readonly_root`, `non_root`). The two mean
+opposite things when they fail, and the message says which. See
+[SANDBOX.md](SANDBOX.md#checking-that-it-still-works).
+
+Run the same probe by hand with `kaos sandbox check`.
+
+**Notification:** only when a check's status *changes* — Telegram webhook plus
+NTFY, `high` priority when something is broken, `default` on recovery. Silence is
+the normal outcome.
 
 ## Scheduler Implementation
 

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -148,6 +148,12 @@ something changes** — see [ACQUISITION.md](ACQUISITION.md#checking-that-it-sti
 for why silence is the design and not an oversight. A host without Docker reports
 `off`: opting out of running code is a choice, not a fault.
 
+It probes whether or not `ENABLE_CODE_EXECUTION` is on, and the image is what
+gates it: a host that has one wants the sandbox, and learning it works *before*
+the flag is flipped beats learning it afterwards from a task that failed. The
+code it runs is the probe's own half-dozen lines reporting uid and interfaces —
+never anything the agent wrote.
+
 ## Honest limits
 
 - **Input names are not a security boundary.** They are validated for the audit

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -129,15 +129,18 @@ came back), `workspace` (a file written at `/work` outlived the container). Losi
 these costs a capability: `run_code` and dynamic tools then refuse, because there
 is no unsandboxed path to fall back to.
 
-**Is it still a sandbox** — `no_network` (the container sees only loopback),
-`readonly_root` (its root filesystem refuses a write), `non_root` (it is not
-running as uid 0). Losing one of these is the opposite problem: code still runs,
-with a wall down. The report says so plainly and names the off switch, because a
-message telling you no safety was lost would be exactly backwards.
+**Is it still a sandbox** — `no_network` (the container has nowhere to route a
+packet), `readonly_root` (its root filesystem refuses a write), `non_root` (it is
+not running as uid 0). Losing one of these is the opposite problem: code still
+runs, with a wall down. The report says so plainly and names the off switch,
+because a message telling you no safety was lost would be exactly backwards.
 
 Every answer comes from inside the container, and none of it sends traffic — the
-network question is settled by listing interfaces, not by dialling out to prove a
-call cannot be made.
+network question is settled by reading the routing table, not by dialling out to
+prove a call cannot be made. The **routing table** and not the interface list,
+because some kernels seed every new namespace with tunnel stubs (`tunl0`, `sit0`)
+and judging on interfaces would report a breach on those hosts and be wrong. A
+stub carries no route; a bridge carries a default one.
 
 A check that could not be *determined* is left out rather than guessed at. When
 nothing can run, the containment guarantees are simply absent from the report;

--- a/docs/SANDBOX.md
+++ b/docs/SANDBOX.md
@@ -102,6 +102,52 @@ decision, the resources declared, and redacted output. The dashboard's **Sandbox
 page reads it. Secrets and PII are masked on the way in — a run's stdout is
 untrusted content like any other.
 
+## Checking that it still works
+
+Readiness and capability are different questions, and only one of them was being
+asked. `sandbox_ready()` reports whether Docker and the image exist — and both of
+this subsystem's real failures answered that perfectly while every run inside
+failed:
+
+- a temp directory created at `0700` and mounted into a container running as
+  another user, so every run died on `Permission denied: '/code/tool.py'`;
+- a bind mount passed as a relative path, which Docker reads as a *named volume*
+  — broken on every host whose data directory is configured relatively, which is
+  every real deployment and no test.
+
+Neither raised at startup. Neither failed the suite. So the check runs code:
+
+```bash
+kaos sandbox check          # probe now
+kaos sandbox check --json   # same, machine-readable
+```
+
+It asks seven questions, in two groups that mean opposite things when they fail.
+
+**Can it work at all** — `docker`, `image`, `execution` (code ran and its output
+came back), `workspace` (a file written at `/work` outlived the container). Losing
+these costs a capability: `run_code` and dynamic tools then refuse, because there
+is no unsandboxed path to fall back to.
+
+**Is it still a sandbox** — `no_network` (the container sees only loopback),
+`readonly_root` (its root filesystem refuses a write), `non_root` (it is not
+running as uid 0). Losing one of these is the opposite problem: code still runs,
+with a wall down. The report says so plainly and names the off switch, because a
+message telling you no safety was lost would be exactly backwards.
+
+Every answer comes from inside the container, and none of it sends traffic — the
+network question is settled by listing interfaces, not by dialling out to prove a
+call cannot be made.
+
+A check that could not be *determined* is left out rather than guessed at. When
+nothing can run, the containment guarantees are simply absent from the report;
+they return, and are reported if broken, as soon as execution does.
+
+The same probe runs daily as the `sandbox-smoke` cron job, and **only speaks when
+something changes** — see [ACQUISITION.md](ACQUISITION.md#checking-that-it-still-works)
+for why silence is the design and not an oversight. A host without Docker reports
+`off`: opting out of running code is a choice, not a fault.
+
 ## Honest limits
 
 - **Input names are not a security boundary.** They are validated for the audit
@@ -116,3 +162,7 @@ untrusted content like any other.
 - **The image has no third-party packages.** For the arithmetic this exists for,
   `csv`, `json` and `statistics` are enough; pandas would add hundreds of
   megabytes to an image whose point is being small and boring.
+- **The daily check proves the walls are up, not that they are sufficient.** It
+  confirms `--network=none`, `--read-only` and a non-root uid are actually in
+  force; it does not audit the kernel, the daemon's configuration, or a container
+  escape. A sandbox is a boundary, not a proof.

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -1819,6 +1819,40 @@ def run_acquire_check(as_json: bool) -> int:
     return 1 if broken else 0
 
 
+def run_sandbox_check(as_json: bool) -> int:
+    """Whether the sandbox runs code, and still contains the code it runs.
+
+    Its readiness check answers a different question — does Docker exist, does
+    the image exist — and both of the real failures answered that one perfectly
+    while every run inside failed. This one runs code.
+    """
+    import asyncio
+
+    from kronos.health import STATUS_BROKEN, STATUS_OFF
+    from kronos.tools.sandbox import CONTAINMENT_CHECKS, check_sandbox_health
+
+    results = asyncio.run(check_sandbox_health())
+    broken = [r for r in results if r.status == STATUS_BROKEN]
+
+    if as_json:
+        print(json.dumps([{"check": r.name, "status": r.status, "detail": r.detail} for r in results], indent=2))
+        return 1 if broken else 0
+
+    marks = {"ok": "[OK]  ", STATUS_BROKEN: "[FAIL]", STATUS_OFF: "[--]  "}
+    for r in results:
+        print(f"{marks.get(r.status, '[??]  ')} {r.name:<14} {r.detail}")
+
+    breached = [r for r in broken if r.name in CONTAINMENT_CHECKS]
+    if breached:
+        print("\nContainment is down: code still runs, but a wall is missing.")
+        print("Stop it with ENABLE_CODE_EXECUTION=false until this is fixed.")
+    elif broken:
+        print("\nrun_code and dynamic tools will refuse rather than fall back — there is no unsandboxed path.")
+    elif any(r.status == STATUS_OFF for r in results):
+        print("\nMarked [--]: not installed here — a choice, not a fault. See docs/SANDBOX.md.")
+    return 1 if broken else 0
+
+
 def run_swarm_report(period: str, as_json: bool) -> int:
     """Post-mortem of the swarm's period: who answered, how well, at what cost."""
     from kronos.swarm_report import build_report, render_markdown
@@ -2233,6 +2267,11 @@ def build_parser() -> argparse.ArgumentParser:
     acquire_check = acquire_sub.add_parser("check", help="probe every fetch tier against a known-good page")
     acquire_check.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
 
+    sandbox_cmd = sub.add_parser("sandbox", help="the container the agent's own code runs in")
+    sandbox_sub = sandbox_cmd.add_subparsers(dest="sandbox_command")
+    sandbox_check = sandbox_sub.add_parser("check", help="run code in it, and check it still contains what it runs")
+    sandbox_check.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
+
     vault_cmd = sub.add_parser("vault", help="the key that encrypts stored site passwords")
     vault_sub = vault_cmd.add_subparsers(dest="vault_command")
     vault_init = vault_sub.add_parser("init", help="create the vault key")
@@ -2455,6 +2494,11 @@ def main(argv: list[str] | None = None) -> int:
         if args.acquire_command == "check":
             return run_acquire_check(args.as_json)
         parser.parse_args(["acquire", "--help"])
+        return 0
+    if args.command == "sandbox":
+        if args.sandbox_command == "check":
+            return run_sandbox_check(args.as_json)
+        parser.parse_args(["sandbox", "--help"])
         return 0
     if args.command == "vault":
         if args.vault_command == "init":

--- a/kronos/cron/acquire_smoke.py
+++ b/kronos/cron/acquire_smoke.py
@@ -12,18 +12,16 @@ can't read that site any more" weeks later, blamed on the site. This job is the
 difference between finding out on a Tuesday and finding out from a task that
 quietly returned nothing.
 
-**It only speaks when something changes.** A daily "all three tiers fine" is a
-message that trains its reader to skip it, and the one day it says something
-else it gets skipped too.
+When it speaks and how is `kronos.health`'s decision, shared with the sandbox
+check so both answer to one set of rules.
 """
 
-import json
 import logging
 from pathlib import Path
 
 from kronos.config import settings
-from kronos.cron.notify import send_ntfy, send_webhook
-from kronos.tools.acquire import TIER_BROKEN, TIER_OK, check_tier_health
+from kronos.health import report_changes
+from kronos.tools.acquire import check_tier_health
 
 log = logging.getLogger("kronos.cron.acquire_smoke")
 
@@ -39,81 +37,15 @@ def _state_file() -> Path:
     return Path(settings.db_path).parent / "acquire_health.json"
 
 
-def _load_previous() -> dict[str, str]:
-    path = _state_file()
-    if not path.exists():
-        return {}
-    try:
-        loaded = json.loads(path.read_text())
-    except Exception as e:
-        # A corrupt state file must not stop the probe: the check is the point,
-        # the memory of it is the optimisation. Worst case is one extra alert.
-        log.warning("Could not read %s (%s); treating this as a first run", path.name, e)
-        return {}
-    return loaded if isinstance(loaded, dict) else {}
-
-
-def _save(current: dict[str, str]) -> None:
-    path = _state_file()
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(current, indent=2))
-        tmp.replace(path)
-    except Exception as e:
-        log.warning("Could not persist acquisition health: %s", e)
-
-
-def _describe(tier: str, before: str | None, after: str, detail: str) -> str:
-    if before is None:
-        return f"{tier}: {after} — {detail}"
-    return f"{tier}: {before} → {after} — {detail}"
-
-
 async def run_acquire_smoke() -> None:
     """Probe every tier, and report only what changed since yesterday."""
     if settings.agent_name != OWNER_AGENT:
         return
 
-    results = await check_tier_health()
-    current = {r.tier: r.status for r in results}
-    previous = _load_previous()
-
-    log.info("Acquisition tiers: %s", ", ".join(f"{r.tier}={r.status}" for r in results))
-
-    notable: list[str] = []
-    for result in results:
-        before = previous.get(result.tier)
-        if before == result.status:
-            continue
-        # A first run has nothing to compare against, so only a fault is worth
-        # saying. Announcing "stealth: off" on a host that never wanted stealth
-        # would be the checker's first message and its least useful one.
-        if before is None and result.status != TIER_BROKEN:
-            continue
-        notable.append(_describe(result.tier, before, result.status, result.detail))
-
-    _save(current)
-
-    if not notable:
-        return
-
-    # A tier that was working and now is not — whether it errored (`broken`) or
-    # vanished from the config (`off`) — is the case this job exists for.
-    lost = [r for r in results if previous.get(r.tier) == TIER_OK and r.status != TIER_OK]
-    healthy = [r.tier for r in results if r.status == TIER_OK]
-    body = (
-        "Acquisition tiers changed:\n"
-        + "\n".join(f"• {line}" for line in notable)
-        + f"\n\nStill working: {', '.join(healthy) or 'none'}"
-    )
-    if lost:
-        body += "\n\nSites that needed that tier will now be reported as unreadable, rather than fetched wrongly."
-
-    send_webhook(body)
-    send_ntfy(
-        body,
+    report_changes(
+        subject="Acquisition tiers",
+        checks=await check_tier_health(),
+        state_path=_state_file(),
         title="Kronos Agent OS — acquisition",
-        priority="high" if lost else "default",
-        tags="warning" if lost else "white_check_mark",
+        consequence=("Sites that needed that tier will now be reported as unreadable, rather than fetched wrongly."),
     )

--- a/kronos/cron/sandbox_smoke.py
+++ b/kronos/cron/sandbox_smoke.py
@@ -1,0 +1,66 @@
+"""Daily proof that the sandbox both runs code and still contains it.
+
+`sandbox_ready()` asks whether Docker and the image exist. Both of this
+subsystem's real bugs passed that question and failed everything after it — a
+temp directory at 0700 that the container could not read, and a bind mount
+passed relatively, which Docker takes for a named volume. In each case the
+sandbox reported itself ready and every single run failed, and neither the
+suite nor startup noticed. Only running code sees this, so that is what the
+probe does.
+
+The second half matters more than the first. A sandbox that refuses to start is
+a capability nobody has; a sandbox that runs without containing is a capability
+everybody has, including whatever wrote the code. So the probe also asks the
+container what it can see and touch — no network, a read-only root, not root —
+and turns three documented guarantees into three checked ones.
+
+When it speaks and how is `kronos.health`'s decision, shared with the
+acquisition check so both answer to one set of rules.
+"""
+
+import logging
+from pathlib import Path
+
+from kronos.config import settings
+from kronos.health import STATUS_BROKEN, report_changes
+from kronos.tools.sandbox import CONTAINMENT_CHECKS, check_sandbox_health
+
+log = logging.getLogger("kronos.cron.sandbox_smoke")
+
+# Losing the ability to run code and losing the walls around it are opposite
+# problems, and one message cannot describe both. Saying "no safety was lost"
+# about a container that just gained a network would be exactly backwards.
+LOST_EXECUTION = (
+    "run_code and dynamic tools now refuse rather than falling back — there is no unsandboxed path, "
+    "so this is lost capability, not lost safety."
+)
+LOST_CONTAINMENT = (
+    "Code is still running, but with one of its walls down. Until this is fixed, treat run_code and "
+    "dynamic tools as unconfined: stop them with ENABLE_CODE_EXECUTION=false."
+)
+
+# Docker and the image belong to the host, not the agent: six agents on one
+# machine share one daemon and one image, so six probes would be ten wasted
+# container runs and five duplicate alerts about the same fault.
+OWNER_AGENT = "kronos"
+
+
+def _state_file() -> Path:
+    return Path(settings.db_path).parent / "sandbox_health.json"
+
+
+async def run_sandbox_smoke() -> None:
+    """Probe the sandbox, and report only what changed since yesterday."""
+    if settings.agent_name != OWNER_AGENT:
+        return
+
+    checks = await check_sandbox_health()
+    breached = any(c.name in CONTAINMENT_CHECKS and c.status == STATUS_BROKEN for c in checks)
+
+    report_changes(
+        subject="Sandbox",
+        checks=checks,
+        state_path=_state_file(),
+        title="Kronos Agent OS — sandbox",
+        consequence=LOST_CONTAINMENT if breached else LOST_EXECUTION,
+    )

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -43,6 +43,7 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     from kronos.cron.personal_observer import run_daily_scope, run_personal_observer
     from kronos.cron.plans import run_due_plan_steps
     from kronos.cron.reminders import run_due_reminders
+    from kronos.cron.sandbox_smoke import run_sandbox_smoke
     from kronos.cron.self_improve import run_self_improve
     from kronos.cron.signal_ideas import run_ideas_digest
 
@@ -164,6 +165,14 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     # duplicate alerts about one fault.
     scheduler.add_daily("acquire-smoke", run_acquire_smoke, hour_utc=7)
 
+    # Sandbox smoke — daily at 08:00 UTC, an hour after the acquisition probe so
+    # two container/browser launches never overlap. Runs code to prove the
+    # sandbox works at all (its readiness check cannot see the failures that
+    # actually happened) and asks the container what it can reach, turning three
+    # documented containment guarantees into three checked ones. Guards inside to
+    # the owning agent: the daemon and image are per-host.
+    scheduler.add_daily("sandbox-smoke", run_sandbox_smoke, hour_utc=8)
+
     # Swarm Retention — weekly Sunday 03:00 UTC. Prunes swarm_messages
     # older than MESSAGE_RETENTION_DAYS (90d). Safe on all 6 agents.
     scheduler.add_weekly("swarm-retention", run_swarm_retention, weekday=6, hour_utc=3)
@@ -203,6 +212,6 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
         nexus_jobs_registered = 4
 
     total = (
-        23 + nexus_jobs_registered
-    )  # +reminders +plan-steps +handoff/council/memory intake +sla-escalation +swarm-weekly-report +persona-evolution +acquire-smoke; signal-jobs, travel insights, people-scout and group-digest paused
+        24 + nexus_jobs_registered
+    )  # +reminders +plan-steps +handoff/council/memory intake +sla-escalation +swarm-weekly-report +persona-evolution +acquire-smoke +sandbox-smoke; signal-jobs, travel insights, people-scout and group-digest paused
     log.info("%d cron jobs registered for agent '%s'", total, me)

--- a/kronos/health.py
+++ b/kronos/health.py
@@ -1,0 +1,143 @@
+"""What a subsystem can do right now, and who needs to hear that it changed.
+
+Two subsystems here fail the same way: they degrade quietly, keep every sign of
+being configured, and surface weeks later as a task that returned nothing. The
+fetch tiers lose a backend to a host rebuild; the sandbox passes its readiness
+check while every run inside it fails. So both are probed the same way and
+reported by the same rules, because the rules are the hard part and a second
+copy of them is a second thing to get wrong.
+
+**Three statuses, and the third is the one that earns its keep.** `off` means a
+capability this deployment never installed — a documented choice, not a fault.
+Collapsing it into `broken` would alert about a browser or a container runtime
+somebody deliberately never wanted, and an alert that is usually wrong gets
+muted, taking the real ones with it.
+
+**Silence is the normal outcome.** A daily "everything is fine" is a message
+that teaches its reader to skip it, and then the one morning it says something
+else gets skipped too — which is worse than having no check at all, because it
+comes with the feeling of being covered.
+"""
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+log = logging.getLogger("kronos.health")
+
+STATUS_OK = "ok"
+STATUS_BROKEN = "broken"
+STATUS_OFF = "off"
+
+
+@dataclass(frozen=True)
+class HealthCheck:
+    """One thing that either works, doesn't, or isn't installed here."""
+
+    name: str
+    status: str
+    detail: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.status == STATUS_OK
+
+
+def load_previous(state_path: Path) -> dict[str, str]:
+    """Last run's statuses, or nothing when there is no usable record."""
+    if not state_path.exists():
+        return {}
+    try:
+        loaded = json.loads(state_path.read_text())
+    except Exception as e:
+        # A corrupt state file must not stop the probe: the check is the point,
+        # remembering it is the optimisation. Worst case is one extra message.
+        log.warning("Could not read %s (%s); treating this as a first run", state_path.name, e)
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def save(state_path: Path, current: dict[str, str]) -> None:
+    """Record this run's statuses, atomically."""
+    try:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = state_path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(current, indent=2))
+        tmp.replace(state_path)
+    except Exception as e:
+        log.warning("Could not persist %s: %s", state_path.name, e)
+
+
+def describe(name: str, before: str | None, after: str, detail: str) -> str:
+    if before is None:
+        return f"{name}: {after} — {detail}"
+    return f"{name}: {before} → {after} — {detail}"
+
+
+def report_changes(
+    *,
+    subject: str,
+    checks: list[HealthCheck],
+    state_path: Path,
+    title: str,
+    consequence: str = "",
+) -> bool:
+    """Compare with last time, speak only about what moved. Returns whether it spoke.
+
+    A check missing from `checks` is neither compared nor remembered. That is how
+    a probe reports "I could not determine this" without inventing a status for
+    it: when the sandbox cannot run code at all, its containment guarantees are
+    simply not in the list, and they come back — reported if broken — as soon as
+    it can run again.
+    """
+    current = {check.name: check.status for check in checks}
+    previous = load_previous(state_path)
+
+    log.info("%s: %s", subject, ", ".join(f"{c.name}={c.status}" for c in checks) or "nothing probed")
+
+    notable: list[HealthCheck] = []
+    lines: list[str] = []
+    for check in checks:
+        before = previous.get(check.name)
+        if before == check.status:
+            continue
+        # A first run has nothing to compare against, so only a fault is worth
+        # saying. Announcing "off" for a backend this host never wanted would be
+        # the checker's first message and its least useful one.
+        if before is None and check.status != STATUS_BROKEN:
+            continue
+        notable.append(check)
+        lines.append(describe(check.name, before, check.status, check.detail))
+
+    save(state_path, current)
+
+    if not notable:
+        return False
+
+    # Bad news is anything being reported that is not working *now* — a capability
+    # lost since yesterday, or one found broken on a first run, where there is no
+    # yesterday to have lost it from. Good news is a report made only of
+    # recoveries, and it should neither wake anyone nor carry a warning about a
+    # problem that has just ended.
+    bad = [c for c in notable if c.status != STATUS_OK]
+    healthy = [c.name for c in checks if c.status == STATUS_OK]
+
+    body = (
+        f"{subject} changed:\n"
+        + "\n".join(f"• {line}" for line in lines)
+        + f"\n\nStill working: {', '.join(healthy) or 'none'}"
+    )
+    if bad and consequence:
+        body += f"\n\n{consequence}"
+
+    from kronos.cron.notify import send_ntfy, send_webhook
+
+    send_webhook(body)
+    send_ntfy(
+        body,
+        title=title,
+        priority="high" if bad else "default",
+        tags="warning" if bad else "white_check_mark",
+    )
+    return True

--- a/kronos/tools/acquire.py
+++ b/kronos/tools/acquire.py
@@ -31,11 +31,11 @@ import json
 import logging
 import re
 import shlex
-from dataclasses import dataclass
 
 from langchain_core.tools import tool
 
 from kronos.config import settings
+from kronos.health import STATUS_BROKEN, STATUS_OFF, STATUS_OK, HealthCheck
 from kronos.security.untrusted import frame_external, mark_untrusted
 
 log = logging.getLogger("kronos.tools.acquire")
@@ -288,9 +288,11 @@ async def fetch_tiered(url: str) -> tuple[str, str, list[str]]:
 # against the live web and none by the suite, because a test that fakes the
 # boundary cannot notice the boundary changing.
 
-TIER_OK = "ok"
-TIER_BROKEN = "broken"
-TIER_OFF = "off"
+# The same vocabulary the sandbox checks report in — one meaning of "off"
+# across the whole system, so one set of rules can decide who hears about it.
+TIER_OK = STATUS_OK
+TIER_BROKEN = STATUS_BROKEN
+TIER_OFF = STATUS_OFF
 
 # Deliberately not a marketplace. The question here is "does our machinery
 # still work", and a marketplace answers a different one — "is that site in a
@@ -301,20 +303,7 @@ TIER_OFF = "off"
 SMOKE_URL = "https://example.com"
 
 
-@dataclass(frozen=True)
-class TierHealth:
-    """What one acquisition tier can do right now."""
-
-    tier: str
-    status: str
-    detail: str = ""
-
-    @property
-    def ok(self) -> bool:
-        return self.status == TIER_OK
-
-
-async def check_tier_health(url: str = SMOKE_URL) -> list[TierHealth]:
+async def check_tier_health(url: str = SMOKE_URL) -> list[HealthCheck]:
     """Probe each tier against a page none of them has any reason to be refused.
 
     Three outcomes per tier, and the third is the one worth having: `off` means
@@ -330,7 +319,7 @@ async def check_tier_health(url: str = SMOKE_URL) -> list[TierHealth]:
     except Exception as e:
         # Bypassing the policy to run a health check would be a strange place
         # to put a hole. Report instead: unrunnable is not the same as broken.
-        return [TierHealth(tier, TIER_OFF, f"cannot probe: {e}") for tier in (TIER_PLAIN, TIER_STEALTH, TIER_BROWSER)]
+        return [HealthCheck(tier, TIER_OFF, f"cannot probe: {e}") for tier in (TIER_PLAIN, TIER_STEALTH, TIER_BROWSER)]
 
     return [
         await _check_plain(url),
@@ -339,31 +328,31 @@ async def check_tier_health(url: str = SMOKE_URL) -> list[TierHealth]:
     ]
 
 
-async def _check_plain(url: str) -> TierHealth:
+async def _check_plain(url: str) -> HealthCheck:
     try:
         status, body = await fetch_plain(url)
     except Exception as e:
-        return TierHealth(TIER_PLAIN, TIER_BROKEN, f"{type(e).__name__}: {e}")
+        return HealthCheck(TIER_PLAIN, TIER_BROKEN, f"{type(e).__name__}: {e}")
     if looks_blocked(status, body):
-        return TierHealth(TIER_PLAIN, TIER_BROKEN, f"HTTP {status}, and the body reads as a block or a shell")
-    return TierHealth(TIER_PLAIN, TIER_OK, f"HTTP {status}, {len(html_to_text(body))} characters of text")
+        return HealthCheck(TIER_PLAIN, TIER_BROKEN, f"HTTP {status}, and the body reads as a block or a shell")
+    return HealthCheck(TIER_PLAIN, TIER_OK, f"HTTP {status}, {len(html_to_text(body))} characters of text")
 
 
-async def _check_stealth(url: str) -> TierHealth:
+async def _check_stealth(url: str) -> HealthCheck:
     if stealth_command(url) is None:
-        return TierHealth(TIER_STEALTH, TIER_OFF, "no STEALTH_FETCH_COMMAND configured")
+        return HealthCheck(TIER_STEALTH, TIER_OFF, "no STEALTH_FETCH_COMMAND configured")
     try:
         _, body = await fetch_stealth(url)
     except Exception as e:
-        return TierHealth(TIER_STEALTH, TIER_BROKEN, str(e))
-    return TierHealth(TIER_STEALTH, TIER_OK, f"{len(html_to_text(body))} characters of text")
+        return HealthCheck(TIER_STEALTH, TIER_BROKEN, str(e))
+    return HealthCheck(TIER_STEALTH, TIER_OK, f"{len(html_to_text(body))} characters of text")
 
 
-async def _check_browser(url: str) -> TierHealth:
+async def _check_browser(url: str) -> HealthCheck:
     import importlib.util
 
     if importlib.util.find_spec("playwright") is None:
-        return TierHealth(TIER_BROWSER, TIER_OFF, "playwright is not installed (pip install -e '.[browser]')")
+        return HealthCheck(TIER_BROWSER, TIER_OFF, "playwright is not installed (pip install -e '.[browser]')")
 
     from kronos.tools.browser import engine
 
@@ -374,14 +363,14 @@ async def _check_browser(url: str) -> TierHealth:
     try:
         _, body = await fetch_browser(url)
     except Exception as e:
-        return TierHealth(TIER_BROWSER, TIER_BROKEN, str(e))
+        return HealthCheck(TIER_BROWSER, TIER_BROKEN, str(e))
     finally:
         if not was_running:
             try:
                 await engine.close()
             except Exception as e:  # pragma: no cover - best effort
                 log.debug("Closing the probe's browser failed: %s", e)
-    return TierHealth(TIER_BROWSER, TIER_OK, f"{len(html_to_text(body))} characters of text")
+    return HealthCheck(TIER_BROWSER, TIER_OK, f"{len(html_to_text(body))} characters of text")
 
 
 @tool

--- a/kronos/tools/sandbox.py
+++ b/kronos/tools/sandbox.py
@@ -9,12 +9,15 @@ production. Missing Docker now means the code does not run.
 """
 
 import asyncio
+import json
 import logging
 import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+
+from kronos.health import STATUS_BROKEN, STATUS_OFF, STATUS_OK, HealthCheck
 
 log = logging.getLogger("kronos.tools.sandbox")
 
@@ -247,3 +250,175 @@ async def execute_sandboxed(
             watchdog.cancel()
         if tmpdir and os.path.exists(tmpdir):
             shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ── Health ────────────────────────────────────────────────────────────────────
+#
+# `sandbox_ready()` asks whether Docker and the image exist. Both of this
+# module's real bugs passed that question and failed everything after it: a
+# temp directory at 0700 mounted into a container running as another user, so
+# every run died on `Permission denied: '/code/tool.py'`; and a bind mount
+# passed relatively, which Docker reads as a *named volume* — broken on every
+# host whose data directory is configured relatively, which is every real
+# deployment and no test.
+#
+# A configuration check cannot see either. Only running code can, so that is
+# what this does. And since a sandbox that runs but does not contain is worse
+# than one that refuses to start, the same run checks that the walls are still
+# up: no network, a read-only root, and not running as root.
+
+PROBE_MARKER = "kronos-sandbox-probe"
+PROBE_SESSION = "health-check"
+PROBE_TIMEOUT = 60
+
+CHECK_DOCKER = "docker"
+CHECK_IMAGE = "image"
+CHECK_EXECUTION = "execution"
+CHECK_WORKSPACE = "workspace"
+CHECK_NO_NETWORK = "no_network"
+CHECK_READONLY_ROOT = "readonly_root"
+CHECK_NON_ROOT = "non_root"
+
+# The ones that are about safety rather than capability. A caller reporting a
+# failure needs to tell the two apart: losing execution costs a feature, losing
+# containment means code is still running with a wall down.
+CONTAINMENT_CHECKS = frozenset({CHECK_NO_NETWORK, CHECK_READONLY_ROOT, CHECK_NON_ROOT})
+
+# Reports uid, the interfaces it can see, and whether its root filesystem took a
+# write. Everything is answered from inside the container: asking the network
+# question by dialling out would send real packets to prove they cannot be sent.
+_PROBE_CODE = f"""
+import json, os
+
+report = {{"marker": "{PROBE_MARKER}", "uid": os.getuid()}}
+
+try:
+    report["interfaces"] = sorted(os.listdir("/sys/class/net"))
+except OSError as e:
+    report["interfaces"] = None
+    report["interfaces_error"] = str(e)
+
+try:
+    with open("/{PROBE_MARKER}", "w") as handle:
+        handle.write("x")
+    report["root_writable"] = True
+except OSError:
+    report["root_writable"] = False
+
+print(json.dumps(report))
+"""
+
+
+def _probe_workspace() -> Path:
+    """Where the workspace probe writes, derived exactly as a real run's is."""
+    from kronos.tools.sandbox_platform import sandbox_workspace_root
+
+    return sandbox_workspace_root() / PROBE_SESSION / "files"
+
+
+async def check_sandbox_health() -> list[HealthCheck]:
+    """Prove the sandbox can run code, and that it still contains what it runs.
+
+    A check that could not be *determined* is left out rather than guessed at:
+    when nothing can run, the containment guarantees are absent from the list
+    instead of being reported as broken, and they come back as soon as
+    execution does.
+    """
+    if not _docker_available():
+        # Not a fault: a host without Docker is a host that opted out of running
+        # code, and the tools that need it already refuse rather than fall back.
+        return [HealthCheck(CHECK_DOCKER, STATUS_OFF, "docker is not installed — code execution is unavailable here")]
+
+    checks = [HealthCheck(CHECK_DOCKER, STATUS_OK, "docker is available")]
+
+    if not _docker_image_available():
+        checks.append(HealthCheck(CHECK_IMAGE, STATUS_BROKEN, sandbox_unavailable_message()))
+        return checks
+    checks.append(HealthCheck(CHECK_IMAGE, STATUS_OK, SANDBOX_IMAGE))
+
+    stdout, stderr = await execute_sandboxed(_PROBE_CODE, timeout=PROBE_TIMEOUT)
+    report = _parse_probe(stdout)
+    if report is None:
+        checks.append(
+            HealthCheck(
+                CHECK_EXECUTION, STATUS_BROKEN, (stderr or stdout).strip()[:300] or "the container printed nothing"
+            )
+        )
+        return checks
+
+    checks.append(HealthCheck(CHECK_EXECUTION, STATUS_OK, "ran code and read its output back"))
+    checks.extend(_containment_checks(report))
+    checks.append(await _check_workspace())
+    return checks
+
+
+def _parse_probe(stdout: str) -> dict | None:
+    """The probe's own JSON, or None when the container said something else."""
+    for line in reversed(stdout.strip().splitlines()):
+        try:
+            parsed = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(parsed, dict) and parsed.get("marker") == PROBE_MARKER:
+            return parsed
+    return None
+
+
+def _containment_checks(report: dict) -> list[HealthCheck]:
+    """Whether the walls the design promises are actually standing."""
+    interfaces = report.get("interfaces")
+    if interfaces is None:
+        network = HealthCheck(
+            CHECK_NO_NETWORK,
+            STATUS_BROKEN,
+            f"could not read the container's interfaces: {report.get('interfaces_error')}",
+        )
+    elif interfaces == ["lo"]:
+        network = HealthCheck(CHECK_NO_NETWORK, STATUS_OK, "loopback only")
+    else:
+        network = HealthCheck(
+            CHECK_NO_NETWORK,
+            STATUS_BROKEN,
+            f"the container can see {', '.join(interfaces)} — --network=none is not in force",
+        )
+
+    if report.get("root_writable"):
+        readonly = HealthCheck(CHECK_READONLY_ROOT, STATUS_BROKEN, "the container wrote to its own root filesystem")
+    else:
+        readonly = HealthCheck(CHECK_READONLY_ROOT, STATUS_OK, "root filesystem refused a write")
+
+    uid = report.get("uid")
+    if uid == 0:
+        non_root = HealthCheck(CHECK_NON_ROOT, STATUS_BROKEN, "the container is running as root")
+    else:
+        non_root = HealthCheck(CHECK_NON_ROOT, STATUS_OK, f"running as uid {uid}")
+
+    return [network, readonly, non_root]
+
+
+async def _check_workspace() -> HealthCheck:
+    """A file written at /work must survive the container that wrote it.
+
+    This is the mount that broke: passed relatively, Docker read it as a named
+    volume and every run with session files failed. The probe derives the path
+    the way a real run does rather than handing in an absolute one, so a
+    regression in that derivation shows up here.
+    """
+    files_dir = _probe_workspace()
+    marker = files_dir / f"{PROBE_MARKER}.txt"
+    try:
+        files_dir.mkdir(parents=True, exist_ok=True)
+        marker.unlink(missing_ok=True)
+    except OSError as e:
+        return HealthCheck(CHECK_WORKSPACE, STATUS_BROKEN, f"cannot prepare the session directory: {e}")
+
+    code = f"open({marker.name!r}, 'w').write('ok')\nprint('wrote')"
+    stdout, stderr = await execute_sandboxed(code, timeout=PROBE_TIMEOUT, files_dir=str(files_dir))
+
+    try:
+        if not marker.exists():
+            detail = (stderr or stdout or "the file was not there afterwards").strip()[:300]
+            return HealthCheck(CHECK_WORKSPACE, STATUS_BROKEN, detail)
+        return HealthCheck(CHECK_WORKSPACE, STATUS_OK, "a file written at /work survived the run")
+    finally:
+        marker.unlink(missing_ok=True)

--- a/kronos/tools/sandbox.py
+++ b/kronos/tools/sandbox.py
@@ -284,19 +284,31 @@ CHECK_NON_ROOT = "non_root"
 # containment means code is still running with a wall down.
 CONTAINMENT_CHECKS = frozenset({CHECK_NO_NETWORK, CHECK_READONLY_ROOT, CHECK_NON_ROOT})
 
-# Reports uid, the interfaces it can see, and whether its root filesystem took a
-# write. Everything is answered from inside the container: asking the network
-# question by dialling out would send real packets to prove they cannot be sent.
+# Reports uid, where it could route a packet, and whether its root filesystem
+# took a write. Everything is answered from inside the container: asking the
+# network question by dialling out would send the very packet it is checking for.
+#
+# The routing table, not the interface list, is what decides the network answer.
+# Some kernels put phantom tunnel stubs (tunl0, sit0) into every new namespace,
+# so `interfaces == ["lo"]` would report a breach on those hosts and be wrong —
+# and a checker that cries wolf is one people learn to ignore. A stub carries no
+# route; a bridge carries a default one. Measured empty under --network=none.
 _PROBE_CODE = f"""
 import json, os
 
 report = {{"marker": "{PROBE_MARKER}", "uid": os.getuid()}}
 
 try:
-    report["interfaces"] = sorted(os.listdir("/sys/class/net"))
+    with open("/proc/net/route") as handle:
+        report["routes"] = [line.split()[0] for line in handle.read().splitlines()[1:] if line.strip()]
 except OSError as e:
+    report["routes"] = None
+    report["routes_error"] = str(e)
+
+try:
+    report["interfaces"] = sorted(os.listdir("/sys/class/net"))
+except OSError:
     report["interfaces"] = None
-    report["interfaces_error"] = str(e)
 
 try:
     with open("/{PROBE_MARKER}", "w") as handle:
@@ -366,20 +378,26 @@ def _parse_probe(stdout: str) -> dict | None:
 
 def _containment_checks(report: dict) -> list[HealthCheck]:
     """Whether the walls the design promises are actually standing."""
-    interfaces = report.get("interfaces")
-    if interfaces is None:
+    routes = report.get("routes")
+    interfaces = report.get("interfaces") or []
+    if routes is None:
+        # Failing to read the routing table is not evidence that it is empty.
         network = HealthCheck(
             CHECK_NO_NETWORK,
             STATUS_BROKEN,
-            f"could not read the container's interfaces: {report.get('interfaces_error')}",
+            f"could not read the container's routing table: {report.get('routes_error')}",
         )
-    elif interfaces == ["lo"]:
-        network = HealthCheck(CHECK_NO_NETWORK, STATUS_OK, "loopback only")
+    elif routes:
+        network = HealthCheck(
+            CHECK_NO_NETWORK,
+            STATUS_BROKEN,
+            f"the container can route through {', '.join(sorted(set(routes)))} — --network=none is not in force",
+        )
     else:
         network = HealthCheck(
             CHECK_NO_NETWORK,
-            STATUS_BROKEN,
-            f"the container can see {', '.join(interfaces)} — --network=none is not in force",
+            STATUS_OK,
+            f"no routes ({', '.join(interfaces) or 'no interfaces'})",
         )
 
     if report.get("root_writable"):

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -332,6 +332,16 @@ else
         bash app/scripts/build-sandbox.sh \
           || echo "WARNING: sandbox image build failed — run_code and dynamic tools will refuse to run."
       fi
+
+      # Having the image is not having a working sandbox: both of the real
+      # failures here had the image and failed every run. This runs code in it.
+      # Informational — a deploy is not the place to block on it, and the daily
+      # sandbox-smoke job carries the same check afterwards.
+      if docker image inspect kronos-sandbox:latest >/dev/null 2>&1; then
+        echo "Checking the sandbox..."
+        (cd app && .venv/bin/python -m kronos.cli sandbox check) \
+          || echo "WARNING: the sandbox is not fully healthy (see above) — run 'kaos sandbox check' for detail."
+      fi
     else
       echo "NOTE: docker not installed — sandboxed code execution is unavailable on this host."
     fi

--- a/tests/test_acquire_health.py
+++ b/tests/test_acquire_health.py
@@ -35,7 +35,7 @@ def no_backends(monkeypatch):
 
 
 def _by_tier(results):
-    return {r.tier: r for r in results}
+    return {r.name: r for r in results}
 
 
 def working_plain(monkeypatch):
@@ -82,7 +82,7 @@ async def test_every_tier_is_reported(monkeypatch):
 
     results = await check_tier_health()
 
-    assert [r.tier for r in results] == [TIER_PLAIN, TIER_STEALTH, TIER_BROWSER]
+    assert [r.name for r in results] == [TIER_PLAIN, TIER_STEALTH, TIER_BROWSER]
 
 
 # --- a fault is not the same as a deliberate absence --------------------------

--- a/tests/test_acquire_smoke.py
+++ b/tests/test_acquire_smoke.py
@@ -1,9 +1,9 @@
 """The daily job that notices a fetch tier died.
 
-Its whole value is in when it stays quiet. A checker that reports "all three
-tiers fine" every morning teaches its reader to skip it, and then the one
-morning it says something else gets skipped too — which is worse than not having
-it, because it comes with the feeling of being covered.
+Thin by design: probing lives in `kronos.tools.acquire` and the rules about who
+hears what live in `kronos.health` (tested in test_health_report.py). What is
+left here is the wiring — and the one decision this module owns, which is that
+only one of six agents does the work.
 """
 
 import json
@@ -12,69 +12,31 @@ import pytest
 
 from kronos.config import settings
 from kronos.cron import acquire_smoke
-from kronos.tools.acquire import (
-    TIER_BROKEN,
-    TIER_BROWSER,
-    TIER_OFF,
-    TIER_OK,
-    TIER_PLAIN,
-    TIER_STEALTH,
-    TierHealth,
-)
+from kronos.health import STATUS_BROKEN, STATUS_OK, HealthCheck
 
 
 @pytest.fixture
-def sent(tmp_path, monkeypatch):
-    """A host running the owning agent, with every message captured."""
+def host(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "agent_name", acquire_smoke.OWNER_AGENT)
     monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
 
-    messages: list[tuple[str, str]] = []
-    monkeypatch.setattr(acquire_smoke, "send_webhook", lambda text, **kw: messages.append(("webhook", text)))
-    monkeypatch.setattr(acquire_smoke, "send_ntfy", lambda text, **kw: messages.append(("ntfy", text)))
-    return messages
+    sent: list[str] = []
+    from kronos.cron import notify
+
+    monkeypatch.setattr(notify, "send_webhook", lambda text, **kw: sent.append(text))
+    monkeypatch.setattr(notify, "send_ntfy", lambda text, **kw: None)
+    return sent
 
 
-def tiers(monkeypatch, plain=TIER_OK, stealth=TIER_OK, browser=TIER_OK):
+def tiers(monkeypatch, **statuses):
     async def _check(url=None):
-        return [
-            TierHealth(TIER_PLAIN, plain, "detail"),
-            TierHealth(TIER_STEALTH, stealth, "detail"),
-            TierHealth(TIER_BROWSER, browser, "detail"),
-        ]
+        return [HealthCheck(name, status, "detail") for name, status in statuses.items()]
 
     monkeypatch.setattr(acquire_smoke, "check_tier_health", _check)
 
 
-def state_file(tmp_path):
-    return tmp_path / "acquire_health.json"
-
-
-# --- silence is the default ---------------------------------------------------
-
-
 @pytest.mark.asyncio
-async def test_nothing_changed_means_nothing_said(sent, tmp_path, monkeypatch):
-    tiers(monkeypatch)
-    state_file(tmp_path).write_text(json.dumps({TIER_PLAIN: TIER_OK, TIER_STEALTH: TIER_OK, TIER_BROWSER: TIER_OK}))
-
-    await acquire_smoke.run_acquire_smoke()
-
-    assert sent == []
-
-
-@pytest.mark.asyncio
-async def test_a_first_run_does_not_announce_a_backend_nobody_installed(sent, tmp_path, monkeypatch):
-    """ "stealth: off" would be this job's first message and its least useful one."""
-    tiers(monkeypatch, stealth=TIER_OFF, browser=TIER_OFF)
-
-    await acquire_smoke.run_acquire_smoke()
-
-    assert sent == []
-
-
-@pytest.mark.asyncio
-async def test_only_the_owning_agent_probes(sent, tmp_path, monkeypatch):
+async def test_only_the_owning_agent_probes(host, monkeypatch):
     """Six agents share one host: six probes are five wasted browser launches."""
     monkeypatch.setattr(settings, "agent_name", "impulse")
     called = []
@@ -88,102 +50,25 @@ async def test_only_the_owning_agent_probes(sent, tmp_path, monkeypatch):
     await acquire_smoke.run_acquire_smoke()
 
     assert called == []
-    assert sent == []
-
-
-# --- but a change is always said ----------------------------------------------
+    assert host == []
 
 
 @pytest.mark.asyncio
-async def test_a_tier_that_broke_is_reported(sent, tmp_path, monkeypatch):
-    tiers(monkeypatch, browser=TIER_BROKEN)
-    state_file(tmp_path).write_text(json.dumps({TIER_PLAIN: TIER_OK, TIER_STEALTH: TIER_OK, TIER_BROWSER: TIER_OK}))
+async def test_a_broken_tier_is_reported_and_remembered(host, tmp_path, monkeypatch):
+    tiers(monkeypatch, plain=STATUS_OK, stealth=STATUS_BROKEN)
 
     await acquire_smoke.run_acquire_smoke()
 
-    assert [channel for channel, _ in sent] == ["webhook", "ntfy"]
-    body = sent[0][1]
-    assert "browser: ok → broken" in body
-    assert "Still working: plain, stealth" in body
+    assert "stealth: broken" in host[0]
+    assert "reported as unreadable" in host[0], "the consequence should be spelled out"
+    assert json.loads(acquire_smoke._state_file().read_text())["stealth"] == STATUS_BROKEN
 
 
 @pytest.mark.asyncio
-async def test_a_tier_that_vanished_from_the_config_is_reported(sent, tmp_path, monkeypatch):
-    """The host-rebuild case: nothing errors, the tier is simply gone."""
-    tiers(monkeypatch, stealth=TIER_OFF)
-    state_file(tmp_path).write_text(json.dumps({TIER_PLAIN: TIER_OK, TIER_STEALTH: TIER_OK, TIER_BROWSER: TIER_OK}))
+async def test_state_lives_beside_this_agent_s_database(host, tmp_path, monkeypatch):
+    """Not in swarm.db: this is a fact about one host's install, not shared knowledge."""
+    tiers(monkeypatch, plain=STATUS_OK)
 
     await acquire_smoke.run_acquire_smoke()
 
-    assert "stealth: ok → off" in sent[0][1]
-
-
-@pytest.mark.asyncio
-async def test_a_first_run_still_reports_something_actually_broken(sent, tmp_path, monkeypatch):
-    """No baseline is a reason not to compare, not a reason not to look."""
-    tiers(monkeypatch, plain=TIER_BROKEN, stealth=TIER_OFF, browser=TIER_OFF)
-
-    await acquire_smoke.run_acquire_smoke()
-
-    body = sent[0][1]
-    assert "plain: broken" in body
-    assert "stealth" not in body, "an uninstalled backend is not news"
-
-
-@pytest.mark.asyncio
-async def test_recovery_is_reported_too(sent, tmp_path, monkeypatch):
-    """Closing the loop matters: otherwise the last word on a tier is 'broken'."""
-    tiers(monkeypatch)
-    state_file(tmp_path).write_text(json.dumps({TIER_PLAIN: TIER_OK, TIER_STEALTH: TIER_BROKEN, TIER_BROWSER: TIER_OK}))
-
-    await acquire_smoke.run_acquire_smoke()
-
-    assert "stealth: broken → ok" in sent[0][1]
-
-
-@pytest.mark.asyncio
-async def test_a_loss_is_louder_than_a_recovery(sent, tmp_path, monkeypatch):
-    """A push that wakes someone should be reserved for something being wrong."""
-    priorities = []
-    monkeypatch.setattr(
-        acquire_smoke,
-        "send_ntfy",
-        lambda text, **kw: priorities.append(kw.get("priority")),
-    )
-
-    tiers(monkeypatch, browser=TIER_BROKEN)
-    state_file(tmp_path).write_text(json.dumps({TIER_PLAIN: TIER_OK, TIER_STEALTH: TIER_OK, TIER_BROWSER: TIER_OK}))
-    await acquire_smoke.run_acquire_smoke()
-
-    tiers(monkeypatch)
-    await acquire_smoke.run_acquire_smoke()
-
-    assert priorities == ["high", "default"]
-
-
-# --- remembering ---------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_the_result_is_remembered_so_it_is_said_once(sent, tmp_path, monkeypatch):
-    tiers(monkeypatch, browser=TIER_BROKEN)
-    state_file(tmp_path).write_text(json.dumps({TIER_BROWSER: TIER_OK}))
-
-    await acquire_smoke.run_acquire_smoke()
-    said_once = len(sent)
-    await acquire_smoke.run_acquire_smoke()
-
-    assert len(sent) == said_once, "a tier that is still broken is not new news"
-    assert json.loads(state_file(tmp_path).read_text())[TIER_BROWSER] == TIER_BROKEN
-
-
-@pytest.mark.asyncio
-async def test_an_unreadable_state_file_does_not_stop_the_probe(sent, tmp_path, monkeypatch):
-    """The check is the point; remembering it is the optimisation."""
-    tiers(monkeypatch, plain=TIER_BROKEN)
-    state_file(tmp_path).write_text("{not json")
-
-    await acquire_smoke.run_acquire_smoke()
-
-    assert "plain: broken" in sent[0][1]
-    assert json.loads(state_file(tmp_path).read_text())[TIER_PLAIN] == TIER_BROKEN
+    assert acquire_smoke._state_file() == tmp_path / "acquire_health.json"

--- a/tests/test_health_report.py
+++ b/tests/test_health_report.py
@@ -1,0 +1,203 @@
+"""When a health check speaks, and — mostly — when it does not.
+
+The rules are shared by the acquisition and sandbox probes, which is the point:
+they are the subtle part, and a second copy of them is a second thing to get
+wrong. Their whole value is in the silence. A checker that reports "everything
+is fine" every morning teaches its reader to skip it, and then the one morning
+it says something else gets skipped too — worse than no check at all, because it
+comes with the feeling of being covered.
+"""
+
+import json
+
+import pytest
+
+from kronos import health
+from kronos.health import STATUS_BROKEN, STATUS_OFF, STATUS_OK, HealthCheck, report_changes
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    """Capture both channels. report_changes imports them at call time."""
+    from kronos.cron import notify
+
+    messages: list[tuple[str, str, str]] = []
+    monkeypatch.setattr(notify, "send_webhook", lambda text, **kw: messages.append(("webhook", text, "")))
+    monkeypatch.setattr(
+        notify,
+        "send_ntfy",
+        lambda text, **kw: messages.append(("ntfy", text, kw.get("priority", ""))),
+    )
+    return messages
+
+
+@pytest.fixture
+def state(tmp_path):
+    return tmp_path / "health.json"
+
+
+def given(state_path, **statuses):
+    state_path.write_text(json.dumps(statuses))
+
+
+def probe(**statuses):
+    return [HealthCheck(name, status, "detail") for name, status in statuses.items()]
+
+
+def run(checks, state_path, consequence=""):
+    return report_changes(
+        subject="Widgets",
+        checks=checks,
+        state_path=state_path,
+        title="test",
+        consequence=consequence,
+    )
+
+
+# --- silence is the default ---------------------------------------------------
+
+
+def test_nothing_changed_means_nothing_said(sent, state):
+    given(state, a=STATUS_OK, b=STATUS_OK)
+
+    assert run(probe(a=STATUS_OK, b=STATUS_OK), state) is False
+    assert sent == []
+
+
+def test_a_first_run_does_not_announce_something_nobody_installed(sent, state):
+    """ "off" would be this job's first message and its least useful one."""
+    assert run(probe(a=STATUS_OFF, b=STATUS_OFF), state) is False
+    assert sent == []
+
+
+def test_a_first_run_still_reports_something_actually_broken(sent, state):
+    """No baseline is a reason not to compare, not a reason not to look."""
+    run(probe(a=STATUS_BROKEN, b=STATUS_OFF), state)
+
+    body = sent[0][1]
+    assert "a: broken" in body
+    assert "b:" not in body, "an uninstalled capability is not news"
+
+
+# --- but a change is always said ----------------------------------------------
+
+
+def test_something_that_broke_is_reported_on_both_channels(sent, state):
+    given(state, a=STATUS_OK, b=STATUS_OK)
+
+    run(probe(a=STATUS_OK, b=STATUS_BROKEN), state)
+
+    assert [channel for channel, _, _ in sent] == ["webhook", "ntfy"]
+    assert "b: ok → broken" in sent[0][1]
+    assert "Still working: a" in sent[0][1]
+
+
+def test_something_that_vanished_from_the_config_is_reported(sent, state):
+    """The host-rebuild case: nothing errors, the capability is simply gone."""
+    given(state, a=STATUS_OK)
+
+    run(probe(a=STATUS_OFF), state)
+
+    assert "a: ok → off" in sent[0][1]
+
+
+def test_recovery_is_reported_too(sent, state):
+    """Otherwise the last word on a capability stays 'broken' forever."""
+    given(state, a=STATUS_BROKEN)
+
+    run(probe(a=STATUS_OK), state)
+
+    assert "a: broken → ok" in sent[0][1]
+
+
+def test_a_first_run_finding_a_fault_still_carries_the_consequence(sent, state):
+    """There is no yesterday to have lost it from, but it is broken all the same."""
+    run(probe(a=STATUS_BROKEN), state, consequence="Widgets are unavailable.")
+
+    assert "Widgets are unavailable." in sent[0][1]
+    assert [p for c, _, p in sent if c == "ntfy"] == ["high"]
+
+
+def test_a_loss_is_louder_than_a_recovery(sent, state):
+    """A push that wakes someone is for something being wrong, not right."""
+    given(state, a=STATUS_OK)
+    run(probe(a=STATUS_BROKEN), state)
+    run(probe(a=STATUS_OK), state)
+
+    priorities = [priority for channel, _, priority in sent if channel == "ntfy"]
+    assert priorities == ["high", "default"]
+
+
+def test_the_consequence_is_spelled_out_only_while_something_is_broken(sent, state):
+    """On a recovery it would read as a warning about a problem that just ended."""
+    given(state, a=STATUS_OK)
+    run(probe(a=STATUS_BROKEN), state, consequence="Widgets are unavailable.")
+    assert "Widgets are unavailable." in sent[0][1]
+
+    sent.clear()
+    run(probe(a=STATUS_OK), state, consequence="Widgets are unavailable.")
+    assert "Widgets are unavailable." not in sent[0][1]
+
+
+# --- remembering ---------------------------------------------------------------
+
+
+def test_the_result_is_remembered_so_it_is_said_once(sent, state):
+    given(state, a=STATUS_OK)
+
+    run(probe(a=STATUS_BROKEN), state)
+    said_once = len(sent)
+    run(probe(a=STATUS_BROKEN), state)
+
+    assert len(sent) == said_once, "still broken is not new news"
+    assert json.loads(state.read_text())["a"] == STATUS_BROKEN
+
+
+def test_an_unreadable_state_file_does_not_stop_the_report(sent, state):
+    """The check is the point; remembering it is the optimisation."""
+    state.write_text("{not json")
+
+    run(probe(a=STATUS_BROKEN), state)
+
+    assert "a: broken" in sent[0][1]
+    assert json.loads(state.read_text())["a"] == STATUS_BROKEN
+
+
+def test_a_state_file_that_cannot_be_written_does_not_stop_the_report(sent, state, monkeypatch):
+    def _explode(*a, **kw):
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(health.Path, "mkdir", _explode)
+
+    run(probe(a=STATUS_BROKEN), state)
+
+    assert "a: broken" in sent[0][1]
+
+
+# --- what a probe could not determine ------------------------------------------
+
+
+def test_a_check_left_out_is_neither_compared_nor_remembered(sent, state):
+    """How a probe says "I could not tell" without inventing a status.
+
+    When the sandbox cannot run code at all, its containment guarantees are
+    absent from the list rather than reported broken — because nothing was
+    measured. Calling them broken would be a guess, and calling them ok a lie.
+    """
+    given(state, runs=STATUS_OK, contained=STATUS_OK)
+
+    run(probe(runs=STATUS_BROKEN), state)
+
+    assert "contained" not in sent[0][1]
+    assert "contained" not in json.loads(state.read_text())
+
+
+def test_a_dropped_check_is_reported_when_it_returns_broken(sent, state):
+    """The hole this could have left: a guarantee that quietly never comes back."""
+    given(state, runs=STATUS_OK, contained=STATUS_OK)
+    run(probe(runs=STATUS_BROKEN), state)
+    sent.clear()
+
+    run(probe(runs=STATUS_OK, contained=STATUS_BROKEN), state)
+
+    assert "contained: broken" in sent[0][1]

--- a/tests/test_sandbox_health.py
+++ b/tests/test_sandbox_health.py
@@ -30,8 +30,8 @@ from kronos.tools.sandbox import (
 )
 
 # What the container really answered on a live host, measured before this was
-# written: uid 1001, loopback only, root refusing a write.
-REAL_REPORT = f'{{"marker": "{PROBE_MARKER}", "uid": 1001, "interfaces": ["lo"], "root_writable": false}}'
+# written: uid 1001, an empty routing table, loopback only, root refusing a write.
+REAL_REPORT = f'{{"marker": "{PROBE_MARKER}", "uid": 1001, "routes": [], "interfaces": ["lo"], "root_writable": false}}'
 
 
 @pytest.fixture
@@ -176,11 +176,12 @@ async def test_chatter_before_the_report_does_not_break_parsing(docker, workspac
 
 
 @pytest.mark.asyncio
-async def test_a_container_with_a_network_is_reported(docker, workspace, monkeypatch):
+async def test_a_container_that_can_route_somewhere_is_reported(docker, workspace, monkeypatch):
     """--network=none quietly not applying is a sandbox that reaches the internet."""
     container(
         monkeypatch,
-        stdout=f'{{"marker": "{PROBE_MARKER}", "uid": 1001, "interfaces": ["eth0", "lo"], "root_writable": false}}',
+        stdout=f'{{"marker": "{PROBE_MARKER}", "uid": 1001, "routes": ["eth0", "eth0"], '
+        '"interfaces": ["eth0", "lo"], "root_writable": false}',
     )
 
     checks = by_name(await check_sandbox_health())
@@ -190,9 +191,31 @@ async def test_a_container_with_a_network_is_reported(docker, workspace, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_a_phantom_tunnel_interface_is_not_a_breach(docker, workspace, monkeypatch):
+    """Some kernels seed every new namespace with tunl0/sit0 stubs.
+
+    Judging on the interface list would call those hosts breached and be wrong,
+    and a checker that cries wolf is one people stop reading. A stub carries no
+    route; that is the difference that matters.
+    """
+    container(
+        monkeypatch,
+        stdout=f'{{"marker": "{PROBE_MARKER}", "uid": 1001, "routes": [], '
+        '"interfaces": ["lo", "sit0", "tunl0"], "root_writable": false}',
+    )
+
+    checks = by_name(await check_sandbox_health())
+
+    assert checks[CHECK_NO_NETWORK].status == STATUS_OK
+    assert "tunl0" in checks[CHECK_NO_NETWORK].detail, "still worth naming for diagnosis"
+
+
+@pytest.mark.asyncio
 async def test_a_writable_root_is_reported(docker, workspace, monkeypatch):
     container(
-        monkeypatch, stdout=f'{{"marker": "{PROBE_MARKER}", "uid": 1001, "interfaces": ["lo"], "root_writable": true}}'
+        monkeypatch,
+        stdout=f'{{"marker": "{PROBE_MARKER}", "uid": 1001, "routes": [], '
+        '"interfaces": ["lo"], "root_writable": true}',
     )
 
     checks = by_name(await check_sandbox_health())
@@ -203,7 +226,8 @@ async def test_a_writable_root_is_reported(docker, workspace, monkeypatch):
 @pytest.mark.asyncio
 async def test_running_as_root_is_reported(docker, workspace, monkeypatch):
     container(
-        monkeypatch, stdout=f'{{"marker": "{PROBE_MARKER}", "uid": 0, "interfaces": ["lo"], "root_writable": false}}'
+        monkeypatch,
+        stdout=f'{{"marker": "{PROBE_MARKER}", "uid": 0, "routes": [], "interfaces": ["lo"], "root_writable": false}}',
     )
 
     checks = by_name(await check_sandbox_health())
@@ -212,17 +236,18 @@ async def test_running_as_root_is_reported(docker, workspace, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_unreadable_interfaces_are_not_taken_for_containment(docker, workspace, monkeypatch):
-    """Failing to see the interfaces is not evidence there are none."""
+async def test_an_unreadable_routing_table_is_not_taken_for_containment(docker, workspace, monkeypatch):
+    """Failing to read the table is not evidence that it is empty."""
     container(
         monkeypatch,
-        stdout=f'{{"marker": "{PROBE_MARKER}", "uid": 1001, "interfaces": null, "interfaces_error": "no /sys", "root_writable": false}}',
+        stdout=f'{{"marker": "{PROBE_MARKER}", "uid": 1001, "routes": null, '
+        '"routes_error": "no /proc", "interfaces": ["lo"], "root_writable": false}',
     )
 
     checks = by_name(await check_sandbox_health())
 
     assert checks[CHECK_NO_NETWORK].status == STATUS_BROKEN
-    assert "no /sys" in checks[CHECK_NO_NETWORK].detail
+    assert "no /proc" in checks[CHECK_NO_NETWORK].detail
 
 
 # --- housekeeping ---------------------------------------------------------------

--- a/tests/test_sandbox_health.py
+++ b/tests/test_sandbox_health.py
@@ -1,0 +1,250 @@
+"""Proving the sandbox runs code — and still contains the code it runs.
+
+`sandbox_ready()` asks whether Docker and the image exist. Both of this
+subsystem's real bugs answered that question perfectly and failed everything
+after it: a temp directory at 0700 the container could not read, and a bind
+mount passed relatively, which Docker takes for a named volume. The sandbox
+called itself ready and every single run failed.
+
+So the probe runs code. And because a sandbox that runs without containing is
+worse than one that will not start, it also asks the container what it can see
+and touch. These tests pin the *reporting* of that — the container's real
+answers were measured against live Docker, which no test here can do.
+"""
+
+import pytest
+
+from kronos.health import STATUS_BROKEN, STATUS_OFF, STATUS_OK
+from kronos.tools import sandbox
+from kronos.tools.sandbox import (
+    CHECK_DOCKER,
+    CHECK_EXECUTION,
+    CHECK_IMAGE,
+    CHECK_NO_NETWORK,
+    CHECK_NON_ROOT,
+    CHECK_READONLY_ROOT,
+    CHECK_WORKSPACE,
+    CONTAINMENT_CHECKS,
+    PROBE_MARKER,
+    check_sandbox_health,
+)
+
+# What the container really answered on a live host, measured before this was
+# written: uid 1001, loopback only, root refusing a write.
+REAL_REPORT = f'{{"marker": "{PROBE_MARKER}", "uid": 1001, "interfaces": ["lo"], "root_writable": false}}'
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    files = tmp_path / "sandbox" / "health-check" / "files"
+    monkeypatch.setattr(sandbox, "_probe_workspace", lambda: files)
+    return files
+
+
+@pytest.fixture
+def docker(monkeypatch):
+    monkeypatch.setattr(sandbox, "_docker_available", lambda: True)
+    monkeypatch.setattr(sandbox, "_docker_image_available", lambda *a, **kw: True)
+
+
+def container(monkeypatch, *, stdout=REAL_REPORT, stderr="", writes_file=True):
+    """Stand in for a container: the probe run, then the workspace run."""
+
+    async def _run(code, timeout=None, memory_limit=None, network=False, files_dir=None, storage_mb=None):
+        if files_dir is None:
+            return stdout, stderr
+        if writes_file:
+            from pathlib import Path
+
+            (Path(files_dir) / f"{PROBE_MARKER}.txt").write_text("ok")
+            return "wrote", ""
+        return "", "docker: invalid characters for a local volume name"
+
+    monkeypatch.setattr(sandbox, "execute_sandboxed", _run)
+
+
+def by_name(checks):
+    return {c.name: c for c in checks}
+
+
+# --- what is missing rather than broken ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_host_without_docker_is_off_not_broken(monkeypatch):
+    """Opting out of running code is a choice, and alerting about it is noise."""
+    monkeypatch.setattr(sandbox, "_docker_available", lambda: False)
+
+    checks = await check_sandbox_health()
+
+    assert [c.name for c in checks] == [CHECK_DOCKER]
+    assert checks[0].status == STATUS_OFF
+
+
+@pytest.mark.asyncio
+async def test_a_missing_image_on_a_docker_host_is_broken(monkeypatch):
+    """deploy.sh builds it whenever docker exists, so its absence is drift."""
+    monkeypatch.setattr(sandbox, "_docker_available", lambda: True)
+    monkeypatch.setattr(sandbox, "_docker_image_available", lambda *a, **kw: False)
+
+    checks = by_name(await check_sandbox_health())
+
+    assert checks[CHECK_IMAGE].status == STATUS_BROKEN
+    assert "build-sandbox.sh" in checks[CHECK_IMAGE].detail
+    assert CHECK_EXECUTION not in checks, "nothing can be run, so nothing further is claimed"
+
+
+# --- running code is the check a readiness flag cannot be --------------------
+
+
+@pytest.mark.asyncio
+async def test_a_working_sandbox_reports_every_check(docker, workspace, monkeypatch):
+    container(monkeypatch)
+
+    checks = by_name(await check_sandbox_health())
+
+    assert {c: checks[c].status for c in checks} == {
+        CHECK_DOCKER: STATUS_OK,
+        CHECK_IMAGE: STATUS_OK,
+        CHECK_EXECUTION: STATUS_OK,
+        CHECK_NO_NETWORK: STATUS_OK,
+        CHECK_READONLY_ROOT: STATUS_OK,
+        CHECK_NON_ROOT: STATUS_OK,
+        CHECK_WORKSPACE: STATUS_OK,
+    }
+
+
+@pytest.mark.asyncio
+async def test_the_permission_failure_is_caught(docker, workspace, monkeypatch):
+    """The real bug: ready by every configuration measure, dead on every run."""
+    container(monkeypatch, stdout="", stderr="Error: [Errno 13] Permission denied: '/code/tool.py'")
+
+    checks = by_name(await check_sandbox_health())
+
+    assert checks[CHECK_EXECUTION].status == STATUS_BROKEN
+    assert "Permission denied" in checks[CHECK_EXECUTION].detail
+
+
+@pytest.mark.asyncio
+async def test_the_relative_mount_failure_is_caught(docker, workspace, monkeypatch):
+    """The other real bug: only reachable with a session directory attached."""
+    container(monkeypatch, writes_file=False)
+
+    checks = by_name(await check_sandbox_health())
+
+    assert checks[CHECK_EXECUTION].status == STATUS_OK, "code without files ran fine — that was the trap"
+    assert checks[CHECK_WORKSPACE].status == STATUS_BROKEN
+    assert "local volume name" in checks[CHECK_WORKSPACE].detail
+
+
+@pytest.mark.asyncio
+async def test_containment_is_not_claimed_when_nothing_ran(docker, workspace, monkeypatch):
+    """Absent, not broken: nothing was measured, so nothing is asserted.
+
+    Reporting them broken would be a guess and reporting them ok a lie. Leaving
+    them out is how the shared reporter learns to say "undetermined".
+    """
+    container(monkeypatch, stdout="", stderr="Error: something")
+
+    checks = by_name(await check_sandbox_health())
+
+    assert CONTAINMENT_CHECKS.isdisjoint(checks)
+    assert CHECK_WORKSPACE not in checks
+
+
+@pytest.mark.asyncio
+async def test_output_that_is_not_this_probe_is_not_trusted(docker, workspace, monkeypatch):
+    """A container answering with somebody else's JSON has not proved anything."""
+    container(monkeypatch, stdout='{"ok": true}')
+
+    checks = by_name(await check_sandbox_health())
+
+    assert checks[CHECK_EXECUTION].status == STATUS_BROKEN
+
+
+@pytest.mark.asyncio
+async def test_chatter_before_the_report_does_not_break_parsing(docker, workspace, monkeypatch):
+    """Something logging a line first should not read as a broken sandbox."""
+    container(monkeypatch, stdout=f"a warning from somewhere\n{REAL_REPORT}")
+
+    checks = by_name(await check_sandbox_health())
+
+    assert checks[CHECK_EXECUTION].status == STATUS_OK
+
+
+# --- the walls -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_container_with_a_network_is_reported(docker, workspace, monkeypatch):
+    """--network=none quietly not applying is a sandbox that reaches the internet."""
+    container(
+        monkeypatch,
+        stdout=f'{{"marker": "{PROBE_MARKER}", "uid": 1001, "interfaces": ["eth0", "lo"], "root_writable": false}}',
+    )
+
+    checks = by_name(await check_sandbox_health())
+
+    assert checks[CHECK_NO_NETWORK].status == STATUS_BROKEN
+    assert "eth0" in checks[CHECK_NO_NETWORK].detail
+
+
+@pytest.mark.asyncio
+async def test_a_writable_root_is_reported(docker, workspace, monkeypatch):
+    container(
+        monkeypatch, stdout=f'{{"marker": "{PROBE_MARKER}", "uid": 1001, "interfaces": ["lo"], "root_writable": true}}'
+    )
+
+    checks = by_name(await check_sandbox_health())
+
+    assert checks[CHECK_READONLY_ROOT].status == STATUS_BROKEN
+
+
+@pytest.mark.asyncio
+async def test_running_as_root_is_reported(docker, workspace, monkeypatch):
+    container(
+        monkeypatch, stdout=f'{{"marker": "{PROBE_MARKER}", "uid": 0, "interfaces": ["lo"], "root_writable": false}}'
+    )
+
+    checks = by_name(await check_sandbox_health())
+
+    assert checks[CHECK_NON_ROOT].status == STATUS_BROKEN
+
+
+@pytest.mark.asyncio
+async def test_unreadable_interfaces_are_not_taken_for_containment(docker, workspace, monkeypatch):
+    """Failing to see the interfaces is not evidence there are none."""
+    container(
+        monkeypatch,
+        stdout=f'{{"marker": "{PROBE_MARKER}", "uid": 1001, "interfaces": null, "interfaces_error": "no /sys", "root_writable": false}}',
+    )
+
+    checks = by_name(await check_sandbox_health())
+
+    assert checks[CHECK_NO_NETWORK].status == STATUS_BROKEN
+    assert "no /sys" in checks[CHECK_NO_NETWORK].detail
+
+
+# --- housekeeping ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_probe_leaves_no_file_behind(docker, workspace, monkeypatch):
+    """A daily job dropping a marker into a session directory is litter."""
+    container(monkeypatch)
+
+    await check_sandbox_health()
+
+    assert not (workspace / f"{PROBE_MARKER}.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_stale_marker_cannot_fake_a_pass(docker, workspace, monkeypatch):
+    """Otherwise a broken mount reads as working, forever, on one leftover file."""
+    workspace.mkdir(parents=True)
+    (workspace / f"{PROBE_MARKER}.txt").write_text("left over from last time")
+    container(monkeypatch, writes_file=False)
+
+    checks = by_name(await check_sandbox_health())
+
+    assert checks[CHECK_WORKSPACE].status == STATUS_BROKEN

--- a/tests/test_sandbox_smoke.py
+++ b/tests/test_sandbox_smoke.py
@@ -1,0 +1,103 @@
+"""The daily sandbox probe.
+
+Thin: probing lives in `kronos.tools.sandbox`, the rules about who hears what in
+`kronos.health`. What this module owns is that only one of six agents does the
+work, and which of two opposite things a failure means.
+"""
+
+import pytest
+
+from kronos.config import settings
+from kronos.cron import sandbox_smoke
+from kronos.health import STATUS_BROKEN, STATUS_OK, HealthCheck
+from kronos.tools.sandbox import CHECK_EXECUTION, CHECK_NO_NETWORK, CHECK_WORKSPACE
+
+
+@pytest.fixture
+def host(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "agent_name", sandbox_smoke.OWNER_AGENT)
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
+
+    sent: list[str] = []
+    from kronos.cron import notify
+
+    monkeypatch.setattr(notify, "send_webhook", lambda text, **kw: sent.append(text))
+    monkeypatch.setattr(notify, "send_ntfy", lambda text, **kw: None)
+    return sent
+
+
+def probing(monkeypatch, **statuses):
+    async def _check():
+        return [HealthCheck(name, status, "detail") for name, status in statuses.items()]
+
+    monkeypatch.setattr(sandbox_smoke, "check_sandbox_health", _check)
+
+
+@pytest.mark.asyncio
+async def test_only_the_owning_agent_probes(host, monkeypatch):
+    """One daemon and one image per host: six probes are ten wasted containers."""
+    monkeypatch.setattr(settings, "agent_name", "lacuna")
+    called = []
+
+    async def _check():
+        called.append(True)
+        return []
+
+    monkeypatch.setattr(sandbox_smoke, "check_sandbox_health", _check)
+
+    await sandbox_smoke.run_sandbox_smoke()
+
+    assert called == []
+    assert host == []
+
+
+@pytest.mark.asyncio
+async def test_losing_execution_is_reported_as_lost_capability(host, monkeypatch):
+    """Nothing runs, so nothing unsafe runs either — there is no fallback path."""
+    probing(monkeypatch, execution=STATUS_BROKEN)
+
+    await sandbox_smoke.run_sandbox_smoke()
+
+    assert "lost capability, not lost safety" in host[0]
+
+
+@pytest.mark.asyncio
+async def test_losing_containment_is_reported_as_the_opposite(host, monkeypatch):
+    """Code still runs, with a wall down. Saying "no safety was lost" here would
+    be exactly backwards, which is why the two messages are not one message."""
+    probing(monkeypatch, execution=STATUS_OK, no_network=STATUS_BROKEN)
+
+    await sandbox_smoke.run_sandbox_smoke()
+
+    assert "one of its walls down" in host[0]
+    assert "ENABLE_CODE_EXECUTION=false" in host[0], "the reader needs the off switch"
+    assert "lost capability" not in host[0]
+
+
+@pytest.mark.asyncio
+async def test_a_broken_workspace_is_not_mistaken_for_a_breach(host, monkeypatch):
+    """A mount that does not persist is lost capability, not a missing wall."""
+    probing(monkeypatch, execution=STATUS_OK, workspace=STATUS_BROKEN)
+
+    await sandbox_smoke.run_sandbox_smoke()
+
+    assert "lost capability, not lost safety" in host[0]
+
+
+@pytest.mark.asyncio
+async def test_the_containment_names_are_the_ones_the_probe_reports(monkeypatch):
+    """Guards the seam: a renamed check would silently stop counting as a breach."""
+    from kronos.tools.sandbox import CONTAINMENT_CHECKS
+
+    assert CHECK_NO_NETWORK in CONTAINMENT_CHECKS
+    assert CHECK_EXECUTION not in CONTAINMENT_CHECKS
+    assert CHECK_WORKSPACE not in CONTAINMENT_CHECKS
+
+
+@pytest.mark.asyncio
+async def test_state_lives_beside_this_agent_s_database(host, tmp_path, monkeypatch):
+    probing(monkeypatch, execution=STATUS_OK)
+
+    await sandbox_smoke.run_sandbox_smoke()
+
+    assert sandbox_smoke._state_file() == tmp_path / "sandbox_health.json"


### PR DESCRIPTION
`sandbox_ready()` asks whether Docker and the image exist. **Both of this
subsystem's real failures answered that question perfectly** and failed
everything after it:

- a temp directory created at `0700` and mounted into a container running as
  another user, so every run died on `Permission denied: '/code/tool.py'`;
- a bind mount passed relatively, which Docker reads as a *named volume* —
  broken on every host whose data directory is configured relatively, which is
  every real deployment and no test.

Neither raised at startup. Neither failed the suite. The sandbox reported itself
ready throughout. A configuration check cannot see either of these, so this one
runs a program and reads its output back, then writes a file at `/work` through
the same path a real run derives and checks it outlived the container.

## The half that matters more

A sandbox that will not start is a capability nobody has. A sandbox that runs
without containing is a capability *everybody* has, including whatever wrote the
code. So the same run asks the container what it can see and touch — loopback
only, a root filesystem that refuses a write, not uid 0 — turning three
documented guarantees into three checked ones.

Every answer comes from inside the container and none of it sends traffic: the
network question is settled by listing interfaces, because dialling out to prove
a call cannot be made would send the packet it is checking for.

**The two kinds of failure get opposite messages.** Losing execution costs a
capability and nothing falls back to running unsandboxed. Losing containment
means code still runs with a wall down — that message says so and names the off
switch. One sentence cannot carry both, and telling someone no safety was lost
about a container that just gained a network would be exactly backwards.

## Shared reporting, tested once

The sandbox needed the same policy the fetch tiers got, and that policy is the
subtle part: report only what moved, treat a first run as a reason not to
compare rather than a reason not to look, distinguish a capability nobody
installed from one that broke. Copying it would be copying four judgements that
then drift, so it moved to `kronos/health.py` and is tested in its own file.

Two corrections fell out of the move:

- **A check absent from the list is neither compared nor remembered** — how a
  probe says "I could not determine this" without inventing a status. The
  sandbox needs it: when nothing runs, nothing can be claimed about containment,
  and the guarantees return (reported if broken) as soon as execution does.
- **The consequence line and the urgent push now key off what is broken *now***
  rather than what was lost since yesterday. A fault found on a first run has no
  yesterday to have been lost from, and was being reported without either. Caught
  by a test, not by review.

## Verification

- **Measured against live Docker before any of this was written** — uid 1001,
  interfaces `["lo"]`, root refusing a write, and a file at `/work` surviving the
  run. The unit tests pin the reporting; that measurement is what says the probe
  asks the right questions.
- 25 new tests; `pytest -m "not integration"` (what CI runs): **1899 passed**.
- `kaos sandbox check` on a host without Docker correctly reports `[--] docker`
  and exits 0 — opting out is a choice, not a fault.
- Docs: [SANDBOX.md](docs/SANDBOX.md#checking-that-it-still-works), CRON-JOBS.md job 23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)