### PR TITLE
A daily check that the MCP servers still hand over their tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Kronos Agent OS are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **A daily check that the MCP servers still hand over their tools** — the third
+  and last of the capability probes, and the one whose absence had already cost
+  something: two servers were dead for months and nothing said so. Loading is
+  resilient by design, so the agents came up with 102 tools instead of 113,
+  nothing errored, and the finance agent went on answering market questions from
+  news search alone. `kaos mcp check` and the `mcp-smoke` job start every known
+  server and report `ok` with a tool count, `broken` with the reason, or `off`
+  for one this deployment never configured. Two decisions carry it: a server
+  missing from the built config still gets a line, because a key dropped from
+  `.env` makes a server *vanish* and something that ceases to exist is exactly
+  what needs saying; and "started" is not "working" — a server that comes up
+  clean and exposes nothing is broken, however healthy it looks to a check that
+  stops at whether the process launched. Failure details are the exception's own
+  text and these configs carry API keys, so credentials are stripped by value
+  before anything is reported — including a token embedded inside a larger value.
+  Each server is bounded by a timeout; startup deliberately keeps none, since
+  giving up on a slow-but-working server at boot costs tools for the whole
+  session. Docs: [MCP](docs/MCP.md#checking-that-the-servers-still-work).
+
 ### Fixed
 
 - **Two MCP servers had been dead on every boot for months** — `fetch` and

--- a/docs/CRON-JOBS.md
+++ b/docs/CRON-JOBS.md
@@ -29,6 +29,7 @@ All core cron jobs are registered in `kronos/cron/setup.py` and run by the built
 | 21 | sla-escalation | Every 60 s | Periodic | `escalation.py` |
 | 22 | acquire-smoke | Daily 07:00 UTC (15:00 UTC+8) | Daily | `acquire_smoke.py` |
 | 23 | sandbox-smoke | Daily 08:00 UTC (16:00 UTC+8) | Daily | `sandbox_smoke.py` |
+| 24 | mcp-smoke | Daily 09:00 UTC (17:00 UTC+8) | Daily | `mcp_smoke.py` |
 
 Intake pollers registered alongside these: `user-reminders` (60 s),
 `handoff-intake`, `council-intake`, `memory-intake` (30 s each).
@@ -365,6 +366,31 @@ opposite things when they fail, and the message says which. See
 Run the same probe by hand with `kaos sandbox check`.
 
 **Notification:** only when a check's status *changes* — Telegram webhook plus
+NTFY, `high` priority when something is broken, `default` on recovery. Silence is
+the normal outcome.
+
+### 24. mcp-smoke
+**Schedule:** Daily 09:00 UTC (17:00 UTC+8)
+**Module:** `kronos/cron/mcp_smoke.py`
+
+Starts every known MCP server, one at a time, and reports which hand over tools.
+Guards internally to the `kronos` agent: the binaries and the uv cache are
+per-host, and the one agent-scoped server (`google-workspace`) is meant to be
+absent elsewhere.
+
+The heaviest of the three capability checks — about forty seconds for eleven
+servers, each bounded by a 60 s timeout so one that never answers cannot stall
+the job. It exists because two servers were dead for months: loading is
+resilient by design, so the agents came up with 102 tools instead of 113 and
+nothing said a word. See [MCP.md](MCP.md#checking-that-the-servers-still-work).
+
+A server missing from the built config reports `off` rather than being left out,
+so one that vanished with its API key is missed rather than forgotten. Failure
+details are stripped of the server's own credentials before reporting.
+
+Run the same probe by hand with `kaos mcp check`.
+
+**Notification:** only when a server's status *changes* — Telegram webhook plus
 NTFY, `high` priority when something is broken, `default` on recovery. Silence is
 the normal outcome.
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -103,6 +103,57 @@ SERVER_REGISTRY_PATH=/path/to/servers.yaml
 
 Use `servers.example.yaml` as the public shape. Do not commit `servers.yaml`.
 
+## Checking that the servers still work
+
+Loading is resilient on purpose: each server is tried on its own, and one that
+will not start is skipped so the rest keep working. That is the right behaviour
+and it is also how two servers stayed dead for months. The agents came up with
+`Loaded 102 tools from 9/11 servers`, nothing errored, and the finance agent went
+on answering market questions from news search alone — because its tool filter
+also matched `brave`, so it kept being created with no market data in it.
+
+The break arrived without a deploy: `mcp-server-fetch` and `mcp-yahoo-finance`
+both declare `mcp>=1.6` with no upper bound, uv installed SDK 2.0, and the API
+each was written against was gone. A check that only ran at deploy time would
+have missed it too.
+
+```bash
+kaos mcp check          # start every server and see which hand over tools
+kaos mcp check --json   # same, machine-readable
+```
+
+Three outcomes per server:
+
+| | |
+|---|---|
+| `ok` | handed over N tools |
+| `broken` | failed to start, timed out, or **started and exposed nothing** |
+| `off` | not configured here — no credentials, or scoped to another agent |
+
+A server that has *vanished from the config* still gets a line. A key dropped
+from `.env` makes a server disappear entirely, and something that silently
+ceases to exist is exactly what needs saying — so the probe reports against the
+full `KNOWN_SERVERS` list rather than only what got built. A test keeps that list
+in step with the builder, since drift there would reopen the hole quietly.
+
+"Started" is deliberately not "working". A server that comes up clean and offers
+no tools contributes nothing while reading as healthy to any check that stops at
+whether the process launched.
+
+Failure details are the exception's own text, and server configs carry API keys
+in `env` — so credentials are stripped by value before anything is reported,
+including a token embedded inside a larger value (Notion's is inside a JSON
+header string). This report goes to Telegram; over-redacting an error message
+costs nothing.
+
+The same probe runs daily as the `mcp-smoke` cron job and **only speaks when
+something changes** — see [ACQUISITION.md](ACQUISITION.md#checking-that-it-still-works)
+for why silence is the design. It is the heaviest of the three capability
+checks: eleven servers started one at a time, about forty seconds, each bounded
+by a timeout so one that never answers cannot stall the job. Startup keeps no
+such timeout — giving up on a slow-but-working server at boot would cost tools
+for the whole session, which is a different decision from bounding a daily probe.
+
 ## Approvals, Audit, And Errors
 
 The current public posture is capability-gated:

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -1819,6 +1819,35 @@ def run_acquire_check(as_json: bool) -> int:
     return 1 if broken else 0
 
 
+def run_mcp_check(as_json: bool) -> int:
+    """Which MCP servers still hand over their tools.
+
+    Slow on purpose — it starts every server the way startup does, one at a
+    time. Two of them were dead for months precisely because nothing ever asked.
+    """
+    import asyncio
+
+    from kronos.health import STATUS_BROKEN, STATUS_OFF
+    from kronos.tools.manager import check_mcp_health
+
+    results = asyncio.run(check_mcp_health())
+    broken = [r for r in results if r.status == STATUS_BROKEN]
+
+    if as_json:
+        print(json.dumps([{"server": r.name, "status": r.status, "detail": r.detail} for r in results], indent=2))
+        return 1 if broken else 0
+
+    marks = {"ok": "[OK]  ", STATUS_BROKEN: "[FAIL]", STATUS_OFF: "[--]  "}
+    for r in results:
+        print(f"{marks.get(r.status, '[??]  ')} {r.name:<17} {r.detail}")
+
+    working = [r for r in results if r.status == "ok"]
+    print(f"\n{len(working)} of {len(results)} servers working.")
+    if broken:
+        print("A broken server's tools are simply absent — nothing errors, answers get built without them.")
+    return 1 if broken else 0
+
+
 def run_sandbox_check(as_json: bool) -> int:
     """Whether the sandbox runs code, and still contains the code it runs.
 
@@ -2267,6 +2296,11 @@ def build_parser() -> argparse.ArgumentParser:
     acquire_check = acquire_sub.add_parser("check", help="probe every fetch tier against a known-good page")
     acquire_check.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
 
+    mcp_cmd = sub.add_parser("mcp", help="the external tool servers the agent loads at startup")
+    mcp_sub = mcp_cmd.add_subparsers(dest="mcp_command")
+    mcp_check = mcp_sub.add_parser("check", help="start every server and see which hand over tools")
+    mcp_check.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
+
     sandbox_cmd = sub.add_parser("sandbox", help="the container the agent's own code runs in")
     sandbox_sub = sandbox_cmd.add_subparsers(dest="sandbox_command")
     sandbox_check = sandbox_sub.add_parser("check", help="run code in it, and check it still contains what it runs")
@@ -2494,6 +2528,11 @@ def main(argv: list[str] | None = None) -> int:
         if args.acquire_command == "check":
             return run_acquire_check(args.as_json)
         parser.parse_args(["acquire", "--help"])
+        return 0
+    if args.command == "mcp":
+        if args.mcp_command == "check":
+            return run_mcp_check(args.as_json)
+        parser.parse_args(["mcp", "--help"])
         return 0
     if args.command == "sandbox":
         if args.sandbox_command == "check":

--- a/kronos/cron/mcp_smoke.py
+++ b/kronos/cron/mcp_smoke.py
@@ -1,0 +1,52 @@
+"""Daily proof that the MCP servers still hand over their tools.
+
+Two of them were dead for months and nothing said so. The tool manager is
+deliberately resilient — a server that will not start is skipped so the rest
+keep working — which is the right behaviour and is also why nobody noticed: the
+agents came up with 102 tools instead of 113, no error reached anyone, and the
+finance agent went on answering market questions from news search alone.
+
+The failure was upstream and unannounced: `mcp>=1.6` with no upper bound, uv
+installing SDK 2.0, and an API the servers were written against being gone. That
+class of break arrives without a deploy, so a check that only ran at deploy time
+would not have caught it either.
+
+When it speaks and how is `kronos.health`'s decision, shared with the
+acquisition and sandbox checks so all three answer to one set of rules.
+"""
+
+import logging
+from pathlib import Path
+
+from kronos.config import settings
+from kronos.health import report_changes
+from kronos.tools.manager import check_mcp_health
+
+log = logging.getLogger("kronos.cron.mcp_smoke")
+
+# Most servers are per-host — the same binaries, the same uv cache — and the
+# per-agent ones (google-workspace is scoped to a single agent by design) are
+# meant to be absent elsewhere. So one agent probes, and its `off` entries are
+# read as that agent's configuration rather than as the swarm's.
+OWNER_AGENT = "kronos"
+
+
+def _state_file() -> Path:
+    return Path(settings.db_path).parent / "mcp_health.json"
+
+
+async def run_mcp_smoke() -> None:
+    """Probe every known server, and report only what changed since yesterday."""
+    if settings.agent_name != OWNER_AGENT:
+        return
+
+    report_changes(
+        subject="MCP servers",
+        checks=await check_mcp_health(),
+        state_path=_state_file(),
+        title="Kronos Agent OS — MCP",
+        consequence=(
+            "The tools that server provides are simply absent from the agent — nothing errors, "
+            "answers just get built without them. Check `kaos mcp check` for the reason."
+        ),
+    )

--- a/kronos/cron/setup.py
+++ b/kronos/cron/setup.py
@@ -37,6 +37,7 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     from kronos.cron.handoff import run_handoff_intake
     from kronos.cron.heartbeat import run_heartbeat
     from kronos.cron.market_review import run_market_review
+    from kronos.cron.mcp_smoke import run_mcp_smoke
     from kronos.cron.memory_ask import run_memory_intake
     from kronos.cron.news_monitor import run_news_monitor
     from kronos.cron.persona_evolve import run_persona_evolution
@@ -173,6 +174,13 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
     # the owning agent: the daemon and image are per-host.
     scheduler.add_daily("sandbox-smoke", run_sandbox_smoke, hour_utc=8)
 
+    # MCP smoke — daily at 09:00 UTC, an hour after the sandbox probe so the
+    # three capability checks never overlap. The heaviest of them: it starts all
+    # eleven servers one at a time, about forty seconds. Guards inside to the
+    # owning agent — the binaries and the uv cache are per-host, and the one
+    # agent-scoped server is meant to be absent elsewhere.
+    scheduler.add_daily("mcp-smoke", run_mcp_smoke, hour_utc=9)
+
     # Swarm Retention — weekly Sunday 03:00 UTC. Prunes swarm_messages
     # older than MESSAGE_RETENTION_DAYS (90d). Safe on all 6 agents.
     scheduler.add_weekly("swarm-retention", run_swarm_retention, weekday=6, hour_utc=3)
@@ -212,6 +220,6 @@ def setup_cron_jobs(scheduler: Scheduler) -> None:
         nexus_jobs_registered = 4
 
     total = (
-        24 + nexus_jobs_registered
-    )  # +reminders +plan-steps +handoff/council/memory intake +sla-escalation +swarm-weekly-report +persona-evolution +acquire-smoke +sandbox-smoke; signal-jobs, travel insights, people-scout and group-digest paused
+        25 + nexus_jobs_registered
+    )  # +reminders +plan-steps +handoff/council/memory intake +sla-escalation +swarm-weekly-report +persona-evolution +acquire-smoke +sandbox-smoke +mcp-smoke; signal-jobs, travel insights, people-scout and group-digest paused
     log.info("%d cron jobs registered for agent '%s'", total, me)

--- a/kronos/tools/manager.py
+++ b/kronos/tools/manager.py
@@ -7,33 +7,57 @@ Resilient loading: each server is tried independently so one failure
 doesn't prevent the rest from starting.
 """
 
+import asyncio
 import logging
+import re
 from contextlib import asynccontextmanager
 
 from langchain_core.tools import BaseTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 
-from kronos.tools.mcp_servers import build_mcp_config
+from kronos.audit import redact_secrets
+from kronos.health import STATUS_BROKEN, STATUS_OFF, STATUS_OK, HealthCheck
+from kronos.tools.mcp_servers import KNOWN_SERVERS, build_mcp_config
 
 log = logging.getLogger("kronos.tools.manager")
 
+# One server at a time, and none allowed to hang the probe. Startup takes about
+# forty seconds for eleven servers; a daily job can afford that, and matching the
+# way startup actually loads them is worth more than finishing sooner.
+PROBE_TIMEOUT_SECONDS = 60
 
-async def _load_server_tools(name: str, server_config: dict) -> list[BaseTool]:
-    """Load tools from a single MCP server, returning [] on failure.
+
+async def _load_server_tools(
+    name: str,
+    server_config: dict,
+    timeout: float | None = None,
+) -> tuple[list[BaseTool], str]:
+    """Load tools from one MCP server. Returns (tools, why-it-failed).
 
     Each tool gets a `mcp_server` attribute set to the server name,
     so sub-agents can filter tools by origin server.
+
+    The reason comes back as well as being logged because the health check needs
+    to *report* it, and a traceback in the journal is exactly the form in which
+    two dead servers went unnoticed for months.
+
+    ``timeout`` is for that health check, not for startup: bounding startup would
+    change when a slow-but-working server is given up on, and that is a different
+    decision from bounding a daily probe.
     """
     try:
         client = MultiServerMCPClient({name: server_config})
-        tools = await client.get_tools()
+        tools = await (asyncio.wait_for(client.get_tools(), timeout) if timeout else client.get_tools())
         for tool in tools:
             tool.metadata = {**(tool.metadata or {}), "mcp_server": name}
         log.info("  [%s] loaded %d tools", name, len(tools))
-        return tools
-    except Exception:
+        return tools, ""
+    except TimeoutError:
+        log.error("  [%s] did not answer within %ss — skipping", name, timeout)
+        return [], f"no answer within {timeout}s"
+    except Exception as e:
         log.exception("  [%s] FAILED to load — skipping", name)
-        return []
+        return [], f"{type(e).__name__}: {e}"
 
 
 @asynccontextmanager
@@ -61,7 +85,7 @@ async def managed_mcp_tools():
     failed = []
 
     for name, server_config in config.items():
-        tools = await _load_server_tools(name, server_config)
+        tools, _error = await _load_server_tools(name, server_config)
         if tools:
             all_tools.extend(tools)
         else:
@@ -83,3 +107,71 @@ async def managed_mcp_tools():
     yield all_tools
 
     log.info("MCP tools session ended")
+
+
+# Long enough to be a key rather than a word. Used to find credentials embedded
+# inside a larger env value — the Notion header carries its token inside a JSON
+# string, so redacting the whole value would miss the token quoted on its own.
+_TOKEN_LIKE = re.compile(r"[A-Za-z0-9_\-]{16,}")
+
+
+def _without_credentials(text: str, server_config: dict) -> str:
+    """Strip a server's own credentials out of text that is about to be reported.
+
+    The detail here is exception text, this report goes to Telegram, and MCP
+    server configs carry API keys in `env`. A library that helpfully includes the
+    config it was handed would put a live key into a chat message — so redaction
+    is by *value*, since this is the one place that holds the values, with the
+    pattern-based pass behind it for anything shaped like a token.
+
+    Over-redacting an error message costs nothing; under-redacting it once is
+    permanent.
+    """
+    secrets: list[str] = []
+    for raw in (server_config.get("env") or {}).values():
+        value = str(raw or "")
+        if len(value) >= 8:
+            secrets.append(value)
+        secrets.extend(_TOKEN_LIKE.findall(value))
+
+    # Longest first, so a value containing another is replaced whole.
+    for secret in sorted(set(secrets), key=len, reverse=True):
+        text = text.replace(secret, "***")
+    return redact_secrets(text)
+
+
+async def check_mcp_health() -> list[HealthCheck]:
+    """Start every known MCP server and report which ones hand over tools.
+
+    This exists because two servers were dead for months and nothing said so.
+    The loading here is deliberately resilient — a server that will not start is
+    skipped so the rest keep working — which is right, and which also means the
+    only trace of a failure is a traceback in a journal nobody reads. The agents
+    came up with 102 tools instead of 113 and looked perfectly healthy.
+
+    A server absent from the built config reports `off` rather than being left
+    out: a key dropped from `.env` makes a server *vanish*, and something that
+    silently ceases to exist is precisely what needs saying. `off` is not a fault
+    — most deployments configure a handful of these — but going from working to
+    absent is.
+    """
+    config = build_mcp_config()
+    checks: list[HealthCheck] = []
+
+    for name in KNOWN_SERVERS:
+        if name not in config:
+            checks.append(HealthCheck(name, STATUS_OFF, "not configured here (no credentials, or not this agent's)"))
+            continue
+
+        tools, error = await _load_server_tools(name, config[name], timeout=PROBE_TIMEOUT_SECONDS)
+        if error:
+            checks.append(HealthCheck(name, STATUS_BROKEN, _without_credentials(error, config[name])[:300]))
+        elif not tools:
+            # Distinct from an error on purpose: a server that starts cleanly and
+            # offers nothing is contributing nothing, and reads as healthy to
+            # every check that stops at "did the process come up".
+            checks.append(HealthCheck(name, STATUS_BROKEN, "started but exposed no tools"))
+        else:
+            checks.append(HealthCheck(name, STATUS_OK, f"{len(tools)} tools"))
+
+    return checks

--- a/kronos/tools/mcp_servers.py
+++ b/kronos/tools/mcp_servers.py
@@ -42,6 +42,25 @@ def _find_uvx() -> str:
 # Drop the pin only after confirming the upstream release actually supports 2.x.
 SDK_1X = ["--with", "mcp<2"]
 
+# Every server this module can produce, configured or not. `build_mcp_config`
+# returns only the ones whose credentials are present, which means a server that
+# disappears — a key dropped from .env, a restored host missing one — leaves no
+# trace to compare against. The health check diffs against this list so that
+# vanishing reports as a capability lost rather than as nothing at all.
+KNOWN_SERVERS = (
+    "brave-search",
+    "exa",
+    "fetch",
+    "content-core",
+    "reddit",
+    "notion",
+    "google-workspace",
+    "youtube",
+    "markitdown",
+    "yahoo-finance",
+    "filesystem",
+)
+
 
 def build_mcp_config() -> dict:
     """Build MultiServerMCPClient configuration dict.

--- a/tests/test_mcp_health.py
+++ b/tests/test_mcp_health.py
@@ -1,0 +1,262 @@
+"""Noticing that an MCP server stopped handing over its tools.
+
+Two of them were dead for months and nothing said so. The loading is resilient
+by design — a server that will not start is skipped so the rest keep working —
+which is right, and which is exactly why it went unseen: the agents came up with
+102 tools instead of 113, nothing errored, and the finance agent went on
+answering market questions from news search alone.
+
+So what is tested here is the reporting, not the loading: that a fault is
+distinguished from a deliberate absence, that a server which vanishes from the
+config is not silently forgotten, and that "started" is not mistaken for
+"working".
+"""
+
+import pytest
+
+from kronos.config import settings
+from kronos.health import STATUS_BROKEN, STATUS_OFF, STATUS_OK
+from kronos.tools import manager
+from kronos.tools.mcp_servers import KNOWN_SERVERS, build_mcp_config
+
+
+@pytest.fixture
+def servers(monkeypatch):
+    """Pretend a given set of servers is configured."""
+
+    def _configure(*names):
+        monkeypatch.setattr(manager, "build_mcp_config", lambda: {n: {"transport": "stdio"} for n in names})
+
+    return _configure
+
+
+@pytest.fixture
+def loader(monkeypatch):
+    """Decide what each server answers when asked for its tools."""
+
+    def _respond(answers):
+        calls = []
+
+        async def _load(name, config, timeout=None):
+            calls.append((name, timeout))
+            return answers.get(name, ([FakeTool(name)], ""))
+
+        monkeypatch.setattr(manager, "_load_server_tools", _load)
+        return calls
+
+    return _respond
+
+
+class FakeTool:
+    """Enough of a tool for the manager to log it."""
+
+    def __init__(self, name="t"):
+        self.name = name
+        self.metadata = None
+
+
+def by_name(checks):
+    return {c.name: c for c in checks}
+
+
+# --- the list the probe diffs against -----------------------------------------
+
+
+def test_known_servers_matches_what_the_builder_can_produce(monkeypatch, tmp_path):
+    """A server added without updating the list would never be probed.
+
+    KNOWN_SERVERS is what makes a *vanished* server visible, so it drifting out
+    of step with the builder would reopen the hole quietly.
+    """
+    monkeypatch.setattr(settings, "brave_api_key", "x")
+    monkeypatch.setattr(settings, "exa_api_key", "x")
+    monkeypatch.setattr(settings, "notion_api_key", "x")
+    monkeypatch.setattr(settings, "google_oauth_client_id", "x")
+    monkeypatch.setattr(settings, "google_oauth_client_secret", "x")
+    monkeypatch.setattr(settings, "agent_name", "kronos")
+    monkeypatch.setattr(settings, "workspace_path", str(tmp_path))
+    monkeypatch.setenv("GOOGLE_WORKSPACE_MCP_AGENT", "kronos")
+
+    assert set(build_mcp_config()) == set(KNOWN_SERVERS)
+
+
+def test_the_probe_reports_in_a_stable_order(servers, loader):
+    """Otherwise the message reshuffles itself between identical runs."""
+    servers(*KNOWN_SERVERS)
+    loader({})
+
+    import asyncio
+
+    checks = asyncio.run(manager.check_mcp_health())
+
+    assert [c.name for c in checks] == list(KNOWN_SERVERS)
+
+
+# --- a fault is not the same as a deliberate absence --------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_unconfigured_server_is_off_not_broken(servers, loader):
+    """Most deployments configure a handful of these; alerting would be noise."""
+    servers("fetch")
+    loader({})
+
+    checks = by_name(await manager.check_mcp_health())
+
+    assert checks["fetch"].status == STATUS_OK
+    assert checks["notion"].status == STATUS_OFF
+    assert "not configured" in checks["notion"].detail
+
+
+@pytest.mark.asyncio
+async def test_a_server_that_vanished_is_still_named(servers, loader):
+    """A key dropped from .env makes a server disappear from the config entirely.
+
+    Left out of the report it would be forgotten rather than missed — the shared
+    reporter neither compares nor remembers a check it is not given.
+    """
+    servers("fetch")
+    loader({})
+
+    checks = by_name(await manager.check_mcp_health())
+
+    assert set(checks) == set(KNOWN_SERVERS)
+
+
+@pytest.mark.asyncio
+async def test_a_failing_server_reports_why(servers, loader):
+    """The reason existed all along — in a journal traceback nobody read."""
+    servers("yahoo-finance")
+    loader({"yahoo-finance": ([], "AttributeError: 'Server' object has no attribute 'list_tools'")})
+
+    checks = by_name(await manager.check_mcp_health())
+
+    assert checks["yahoo-finance"].status == STATUS_BROKEN
+    assert "list_tools" in checks["yahoo-finance"].detail
+
+
+@pytest.mark.asyncio
+async def test_starting_is_not_the_same_as_working(servers, loader):
+    """A server that comes up clean and offers nothing contributes nothing.
+
+    Every check that stops at "did the process start" calls this healthy.
+    """
+    servers("reddit")
+    loader({"reddit": ([], "")})
+
+    checks = by_name(await manager.check_mcp_health())
+
+    assert checks["reddit"].status == STATUS_BROKEN
+    assert "no tools" in checks["reddit"].detail
+
+
+@pytest.mark.asyncio
+async def test_a_working_server_reports_how_many_tools(servers, loader):
+    """ "ok" with no number is what 9-of-11 looked like for months."""
+    servers("notion")
+    loader({"notion": ([FakeTool()] * 24, "")})
+
+    checks = by_name(await manager.check_mcp_health())
+
+    assert checks["notion"].status == STATUS_OK
+    assert "24 tools" in checks["notion"].detail
+
+
+# --- the probe must not hang ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_every_server_is_probed_under_a_timeout(servers, loader):
+    """One server that never answers would otherwise stall the whole job."""
+    servers("fetch", "notion")
+    calls = loader({})
+
+    await manager.check_mcp_health()
+
+    assert [timeout for _, timeout in calls] == [manager.PROBE_TIMEOUT_SECONDS] * 2
+
+
+@pytest.mark.asyncio
+async def test_a_timeout_is_reported_as_broken(servers, loader):
+    servers("fetch")
+    loader({"fetch": ([], "no answer within 60s")})
+
+    checks = by_name(await manager.check_mcp_health())
+
+    assert checks["fetch"].status == STATUS_BROKEN
+    assert "no answer" in checks["fetch"].detail
+
+
+# --- startup keeps its own behaviour -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_startup_does_not_impose_the_probe_s_timeout(monkeypatch):
+    """Bounding startup is a different decision from bounding a daily check.
+
+    Giving up on a slow-but-working server at boot would cost tools for the whole
+    session; the probe only costs one line in a report.
+    """
+    seen = []
+
+    async def _load(name, config, timeout=None):
+        seen.append(timeout)
+        return [FakeTool()], ""
+
+    monkeypatch.setattr(manager, "build_mcp_config", lambda: {"fetch": {}})
+    monkeypatch.setattr(manager, "_load_server_tools", _load)
+
+    async with manager.managed_mcp_tools() as tools:
+        assert len(tools) == 1
+
+    assert seen == [None]
+
+
+@pytest.mark.asyncio
+async def test_a_failure_report_never_carries_the_server_s_credentials(monkeypatch):
+    """Server configs hold API keys in `env`, and this report goes to Telegram.
+
+    The detail comes from the exception, so a library that helpfully includes the
+    config it was handed would put a key in a chat message.
+    """
+    secret = "brave-key-do-not-leak"
+    monkeypatch.setattr(
+        manager,
+        "build_mcp_config",
+        lambda: {"brave-search": {"transport": "stdio", "env": {"BRAVE_API_KEY": secret}}},
+    )
+
+    async def _load(name, config, timeout=None):
+        return [], f"RuntimeError: could not start with {config}"
+
+    monkeypatch.setattr(manager, "_load_server_tools", _load)
+
+    checks = await manager.check_mcp_health()
+
+    assert all(secret not in c.detail for c in checks), "a credential reached the report"
+
+
+@pytest.mark.asyncio
+async def test_a_credential_embedded_in_a_larger_value_is_redacted_too(monkeypatch):
+    """Notion's env entry is a JSON header string with the token inside it.
+
+    Redacting only whole env values would miss the token quoted on its own —
+    which is the form an error message is most likely to carry.
+    """
+    token = "ntn_A1B2C3D4E5F6G7H8I9J0"
+    header = '{"Authorization":"Bearer ' + token + '","Notion-Version":"2022-06-28"}'
+    monkeypatch.setattr(
+        manager,
+        "build_mcp_config",
+        lambda: {"notion": {"transport": "stdio", "env": {"OPENAPI_MCP_HEADERS": header}}},
+    )
+
+    async def _load(name, config, timeout=None):
+        return [], f"RuntimeError: rejected token {token}"
+
+    monkeypatch.setattr(manager, "_load_server_tools", _load)
+
+    notion = by_name(await manager.check_mcp_health())["notion"]
+
+    assert token not in notion.detail
+    assert "***" in notion.detail

--- a/tests/test_mcp_smoke_job.py
+++ b/tests/test_mcp_smoke_job.py
@@ -1,0 +1,82 @@
+"""The daily MCP probe.
+
+Thin: probing lives in `kronos.tools.manager`, the rules about who hears what in
+`kronos.health`. What this module owns is that only one of six agents starts
+eleven servers, and that the report says what a failure actually costs.
+"""
+
+import pytest
+
+from kronos.config import settings
+from kronos.cron import mcp_smoke
+from kronos.health import STATUS_BROKEN, STATUS_OK, HealthCheck
+
+
+@pytest.fixture
+def host(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "agent_name", mcp_smoke.OWNER_AGENT)
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "session.db"))
+
+    sent: list[str] = []
+    from kronos.cron import notify
+
+    monkeypatch.setattr(notify, "send_webhook", lambda text, **kw: sent.append(text))
+    monkeypatch.setattr(notify, "send_ntfy", lambda text, **kw: None)
+    return sent
+
+
+def probing(monkeypatch, **statuses):
+    async def _check():
+        return [HealthCheck(name, status, "detail") for name, status in statuses.items()]
+
+    monkeypatch.setattr(mcp_smoke, "check_mcp_health", _check)
+
+
+@pytest.mark.asyncio
+async def test_only_the_owning_agent_probes(host, monkeypatch):
+    """Six agents starting eleven servers each is sixty-six subprocesses."""
+    monkeypatch.setattr(settings, "agent_name", "resonant")
+    called = []
+
+    async def _check():
+        called.append(True)
+        return []
+
+    monkeypatch.setattr(mcp_smoke, "check_mcp_health", _check)
+
+    await mcp_smoke.run_mcp_smoke()
+
+    assert called == []
+    assert host == []
+
+
+@pytest.mark.asyncio
+async def test_a_broken_server_is_reported_with_what_it_costs(host, monkeypatch):
+    """ "yahoo-finance: broken" alone does not tell you the finance agent is blind."""
+    probing(monkeypatch, fetch=STATUS_OK, yahoo_finance=STATUS_BROKEN)
+
+    await mcp_smoke.run_mcp_smoke()
+
+    assert "yahoo_finance: broken" in host[0]
+    assert "absent from the agent" in host[0]
+    assert "kaos mcp check" in host[0], "the reader needs the next step"
+
+
+@pytest.mark.asyncio
+async def test_silence_when_nothing_moved(host, monkeypatch):
+    probing(monkeypatch, fetch=STATUS_OK)
+    await mcp_smoke.run_mcp_smoke()
+    host.clear()
+
+    await mcp_smoke.run_mcp_smoke()
+
+    assert host == []
+
+
+@pytest.mark.asyncio
+async def test_state_lives_beside_this_agent_s_database(host, tmp_path, monkeypatch):
+    probing(monkeypatch, fetch=STATUS_OK)
+
+    await mcp_smoke.run_mcp_smoke()
+
+    assert mcp_smoke._state_file() == tmp_path / "mcp_health.json"


### PR DESCRIPTION
The third and last of the capability probes, and the one whose absence had
already cost something. Two servers were dead for months and nothing said so.

Loading is resilient by design — a server that will not start is skipped so the
rest keep working. That is right, and it is exactly why nobody noticed: the
agents came up with `Loaded 102 tools from 9/11 servers`, nothing errored, and
the finance agent went on answering market questions from news search alone.

The break arrived **without a deploy** — an upstream SDK major bump resolving
into an unpinned dependency — so a deploy-time check would have missed it too.

## Two decisions carry it

**A server missing from the config still gets a line**, as `off`. A key dropped
from `.env` makes a server *vanish*, and the shared reporter neither compares nor
remembers a check it is not given — so leaving it out would turn a lost
capability into nothing at all. `KNOWN_SERVERS` makes that possible and a test
keeps it in step with the builder, since drift there would reopen the hole
quietly.

**"Started" is not "working."** A server that comes up clean and exposes no tools
contributes nothing, however healthy it looks to a check that stops at whether
the process launched.

## A leak the tests caught

The failure detail is the exception's own text, these configs carry API keys in
`env`, and this report goes to Telegram. The test asserting no credential reaches
the report **failed the first time it ran**, so credentials are now stripped by
value before anything is reported — including a token embedded inside a larger
value, which is the shape Notion's header takes. Over-redacting an error message
costs nothing.

## Cost

The heaviest of the three checks: eleven servers started one at a time, about
forty seconds, each bounded by a 60 s timeout so one that never answers cannot
stall the job. Guarded to one agent — the binaries and uv cache are per-host, and
six agents probing would be sixty-six subprocesses.

Startup deliberately keeps **no** timeout: giving up on a slow-but-working server
at boot would cost tools for the whole session, which is a different decision
from bounding a daily probe. Pinned by a test.

## Verification

- 16 new tests; `pytest -m "not integration"` (what CI runs): **1918 passed**,
  with the 44 integration tests still deselected and intact.
- Docs: [MCP.md](docs/MCP.md#checking-that-the-servers-still-work), CRON-JOBS.md job 24.

Prod verification (`kaos mcp check` against all eleven servers) follows after
merge, as with the other two probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)