### PR TITLE
Let kaos mcp check be readable, without losing the diagnosis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Kronos Agent OS are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`kaos mcp check` drowned its own report** — the servers are chatty on the
+  stderr this process inherits: node deprecation warnings, a startup banner in
+  ASCII art, 41 lines of it around a 12-line table. Silencing the stream would
+  have been the wrong fix, because when a server dies that stream is the *only*
+  thing that says why: the protocol reports `Connection closed` and no more, and
+  anyio wraps even that in `ExceptionGroup: unhandled errors in a TaskGroup`. So
+  the wrapper is now unwrapped to the real exception, and the stream is captured
+  rather than discarded — noise from a server that worked is dropped, last words
+  from one that did not are printed with its failure. The historical
+  yahoo-finance break now reads `McpError: Connection closed — server said:
+  AttributeError: 'Server' object has no attribute 'list_tools'` instead of a
+  wrapper and a wall of text. Capture is at the file-descriptor level and **only
+  the CLI opts in**: fd 2 belongs to the whole process, so doing it inside a
+  running agent would swallow every other task's logging. `--verbose` leaves the
+  stream alone. Measured on prod: stderr 41 lines → 0.
+
 ### Added
 
 - **A daily check that the MCP servers still hand over their tools** — the third

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -140,11 +140,39 @@ in step with the builder, since drift there would reopen the hole quietly.
 no tools contributes nothing while reading as healthy to any check that stops at
 whether the process launched.
 
-Failure details are the exception's own text, and server configs carry API keys
-in `env` — so credentials are stripped by value before anything is reported,
-including a token embedded inside a larger value (Notion's is inside a JSON
-header string). This report goes to Telegram; over-redacting an error message
-costs nothing.
+### Saying why, not just that
+
+Two things had to be dug out before a failure line was worth reading.
+
+**The wrapper is not the cause.** anyio delivers a dead stdio server as
+`ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)` — true, and
+useless. The real exception sits nested inside, sometimes two groups deep, and
+it is unwrapped before being reported.
+
+**The protocol only knows "Connection closed".** When a server starts and then
+dies, the traceback explaining it goes to the server's own stderr, which this
+process inherits. That stream is therefore *captured*, not silenced: noise from
+a server that worked is dropped, and the last words of one that did not are
+printed with its failure. A real example, the historical yahoo-finance break:
+
+```
+[FAIL] yahoo-finance    McpError: Connection closed — server said:
+                        @server.list_tools() / AttributeError: 'Server' object
+                        has no attribute 'list_tools'
+```
+
+Capturing is at the file-descriptor level, because that is what a child
+inherits, and **only the CLI opts in**. fd 2 belongs to the whole process, so
+doing it inside a running agent would swallow every other task's logging for
+forty seconds a day. `kaos mcp check --verbose` leaves the stream alone for
+anyone who wants all of it; the daily job leaves server output in the journal
+where it belongs.
+
+Failure details are the exception's own text plus that captured tail, and server
+configs carry API keys in `env` — so credentials are stripped by value before
+anything is reported, including a token embedded inside a larger value (Notion's
+is inside a JSON header string). This report goes to Telegram; over-redacting an
+error message costs nothing.
 
 The same probe runs daily as the `mcp-smoke` cron job and **only speaks when
 something changes** — see [ACQUISITION.md](ACQUISITION.md#checking-that-it-still-works)

--- a/kronos/cli.py
+++ b/kronos/cli.py
@@ -1819,18 +1819,26 @@ def run_acquire_check(as_json: bool) -> int:
     return 1 if broken else 0
 
 
-def run_mcp_check(as_json: bool) -> int:
+def run_mcp_check(as_json: bool, verbose: bool = False) -> int:
     """Which MCP servers still hand over their tools.
 
     Slow on purpose — it starts every server the way startup does, one at a
     time. Two of them were dead for months precisely because nothing ever asked.
+
+    The servers are chatty on stderr: node deprecation warnings, a startup banner
+    in ASCII art, forty-one lines of it around a twelve-line table. That stream
+    is taken rather than silenced, because when a server dies it is the only
+    thing that says why — the protocol reports "Connection closed" and no more.
+    Noise from a server that worked is dropped; last words from one that did not
+    are printed with it. `--verbose` leaves the stream alone for anyone who wants
+    all of it.
     """
     import asyncio
 
     from kronos.health import STATUS_BROKEN, STATUS_OFF
     from kronos.tools.manager import check_mcp_health
 
-    results = asyncio.run(check_mcp_health())
+    results = asyncio.run(check_mcp_health(capture_stderr=not verbose))
     broken = [r for r in results if r.status == STATUS_BROKEN]
 
     if as_json:
@@ -2300,6 +2308,11 @@ def build_parser() -> argparse.ArgumentParser:
     mcp_sub = mcp_cmd.add_subparsers(dest="mcp_command")
     mcp_check = mcp_sub.add_parser("check", help="start every server and see which hand over tools")
     mcp_check.add_argument("--json", dest="as_json", action="store_true", help="machine-readable output")
+    mcp_check.add_argument(
+        "--verbose",
+        action="store_true",
+        help="let the servers' own stderr through instead of folding it into the report",
+    )
 
     sandbox_cmd = sub.add_parser("sandbox", help="the container the agent's own code runs in")
     sandbox_sub = sandbox_cmd.add_subparsers(dest="sandbox_command")
@@ -2531,7 +2544,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     if args.command == "mcp":
         if args.mcp_command == "check":
-            return run_mcp_check(args.as_json)
+            return run_mcp_check(args.as_json, args.verbose)
         parser.parse_args(["mcp", "--help"])
         return 0
     if args.command == "sandbox":

--- a/kronos/tools/manager.py
+++ b/kronos/tools/manager.py
@@ -9,8 +9,10 @@ doesn't prevent the rest from starting.
 
 import asyncio
 import logging
+import os
 import re
-from contextlib import asynccontextmanager
+import tempfile
+from contextlib import asynccontextmanager, contextmanager
 
 from langchain_core.tools import BaseTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
@@ -27,10 +29,105 @@ log = logging.getLogger("kronos.tools.manager")
 PROBE_TIMEOUT_SECONDS = 60
 
 
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+# How much of a dying server's last words to carry into the report.
+STDERR_TAIL_LINES = 2
+STDERR_TAIL_CHARS = 200
+
+
+@contextmanager
+def _child_stderr(capture: bool):
+    """Take the subprocess stderr this process would otherwise inherit.
+
+    MCP servers write to fd 2 directly, and two different things arrive there:
+    noise nobody asked for — node deprecation warnings, a startup banner in
+    ASCII art, forty-one lines of it around a twelve-line table — and, when a
+    server dies, the traceback saying why. The protocol's own view of that death
+    is only "Connection closed", so this stream cannot simply be silenced: it is
+    the diagnosis.
+
+    Redirected at the file descriptor because that is what a child inherits.
+    ``errlog`` on the SDK's stdio client would be tidier, but
+    langchain-mcp-adapters does not pass it through.
+
+    **Only for short-lived callers.** fd 2 belongs to the whole process, so doing
+    this inside a running agent would swallow every other task's logging for the
+    duration. The CLI opts in; the daily job does not.
+    """
+    if not capture:
+        yield lambda: ""
+        return
+
+    saved = os.dup(2)
+    handle = tempfile.TemporaryFile(mode="w+")
+
+    def read_back() -> str:
+        try:
+            handle.flush()
+            os.fsync(handle.fileno())
+            handle.seek(0)
+            return handle.read()
+        except OSError:
+            return ""
+
+    try:
+        os.dup2(handle.fileno(), 2)
+        yield read_back
+    finally:
+        os.dup2(saved, 2)
+        os.close(saved)
+        handle.close()
+
+
+def _with_last_words(reason: str, stderr_text: str) -> str:
+    """Append what the server said on its way out, when it said anything.
+
+    "Connection closed" is the whole of what the protocol knows about a server
+    that started and then died — which is exactly how the two servers that were
+    broken for months looked from this side.
+    """
+    lines = [_ANSI.sub("", line).strip() for line in stderr_text.splitlines()]
+    lines = [line for line in lines if line]
+    if not lines:
+        return reason
+    tail = " / ".join(lines[-STDERR_TAIL_LINES:])[:STDERR_TAIL_CHARS]
+    return f"{reason} — server said: {tail}"
+
+
+def describe_failure(error: BaseException) -> str:
+    """The cause a reader can act on, not the wrapper it arrived in.
+
+    A stdio server that starts and then dies surfaces through anyio as
+    ``ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)`` — true,
+    and useless. The real reason sits nested inside, sometimes two groups deep,
+    and for the two servers that were dead for months it was the only thing that
+    ever said ``AttributeError: 'Server' object has no attribute 'list_tools'``.
+
+    That mattered more than it looks: until this unwrapping, the actionable text
+    existed only in the subprocess's stderr, which is why quietening that stream
+    had to wait for this.
+    """
+    causes = []
+    for leaf in _leaf_causes(error):
+        text = f"{type(leaf).__name__}: {leaf}".strip().rstrip(":")
+        if text not in causes:
+            causes.append(text)
+    return "; ".join(causes)
+
+
+def _leaf_causes(error: BaseException) -> list[BaseException]:
+    """Flatten nested exception groups down to the exceptions that say something."""
+    if isinstance(error, BaseExceptionGroup):
+        return [leaf for sub in error.exceptions for leaf in _leaf_causes(sub)]
+    return [error]
+
+
 async def _load_server_tools(
     name: str,
     server_config: dict,
     timeout: float | None = None,
+    capture_stderr: bool = False,
 ) -> tuple[list[BaseTool], str]:
     """Load tools from one MCP server. Returns (tools, why-it-failed).
 
@@ -45,19 +142,26 @@ async def _load_server_tools(
     change when a slow-but-working server is given up on, and that is a different
     decision from bounding a daily probe.
     """
+    said = ""
     try:
-        client = MultiServerMCPClient({name: server_config})
-        tools = await (asyncio.wait_for(client.get_tools(), timeout) if timeout else client.get_tools())
+        # The capture window is exactly the child's lifetime: our own logging
+        # below must not land in what we report back as the server's words.
+        with _child_stderr(capture_stderr) as read_back:
+            try:
+                client = MultiServerMCPClient({name: server_config})
+                tools = await (asyncio.wait_for(client.get_tools(), timeout) if timeout else client.get_tools())
+            finally:
+                said = read_back()
         for tool in tools:
             tool.metadata = {**(tool.metadata or {}), "mcp_server": name}
         log.info("  [%s] loaded %d tools", name, len(tools))
         return tools, ""
     except TimeoutError:
         log.error("  [%s] did not answer within %ss — skipping", name, timeout)
-        return [], f"no answer within {timeout}s"
+        return [], _with_last_words(f"no answer within {timeout}s", said)
     except Exception as e:
         log.exception("  [%s] FAILED to load — skipping", name)
-        return [], f"{type(e).__name__}: {e}"
+        return [], _with_last_words(describe_failure(e), said)
 
 
 @asynccontextmanager
@@ -140,7 +244,7 @@ def _without_credentials(text: str, server_config: dict) -> str:
     return redact_secrets(text)
 
 
-async def check_mcp_health() -> list[HealthCheck]:
+async def check_mcp_health(capture_stderr: bool = False) -> list[HealthCheck]:
     """Start every known MCP server and report which ones hand over tools.
 
     This exists because two servers were dead for months and nothing said so.
@@ -163,7 +267,9 @@ async def check_mcp_health() -> list[HealthCheck]:
             checks.append(HealthCheck(name, STATUS_OFF, "not configured here (no credentials, or not this agent's)"))
             continue
 
-        tools, error = await _load_server_tools(name, config[name], timeout=PROBE_TIMEOUT_SECONDS)
+        tools, error = await _load_server_tools(
+            name, config[name], timeout=PROBE_TIMEOUT_SECONDS, capture_stderr=capture_stderr
+        )
         if error:
             checks.append(HealthCheck(name, STATUS_BROKEN, _without_credentials(error, config[name])[:300]))
         elif not tools:

--- a/tests/test_mcp_health.py
+++ b/tests/test_mcp_health.py
@@ -37,7 +37,7 @@ def loader(monkeypatch):
     def _respond(answers):
         calls = []
 
-        async def _load(name, config, timeout=None):
+        async def _load(name, config, timeout=None, capture_stderr=False):
             calls.append((name, timeout))
             return answers.get(name, ([FakeTool(name)], ""))
 
@@ -187,6 +187,85 @@ async def test_a_timeout_is_reported_as_broken(servers, loader):
     assert "no answer" in checks["fetch"].detail
 
 
+# --- saying why, not just that ------------------------------------------------
+
+
+def test_a_wrapper_exception_is_unwrapped_to_the_real_cause():
+    """anyio delivers a dead server as a TaskGroup ExceptionGroup.
+
+    "unhandled errors in a TaskGroup (1 sub-exception)" is true and useless, and
+    it is what this reported until the cause was dug out — the same cause that
+    only ever appeared in a journal traceback nobody read.
+    """
+    inner = AttributeError("'Server' object has no attribute 'list_tools'")
+    wrapped = BaseExceptionGroup("outer", [BaseExceptionGroup("inner", [inner])])
+
+    assert manager.describe_failure(wrapped) == "AttributeError: 'Server' object has no attribute 'list_tools'"
+
+
+def test_several_distinct_causes_are_all_named_once():
+    group = BaseExceptionGroup("outer", [ValueError("a"), ValueError("a"), KeyError("b")])
+
+    described = manager.describe_failure(group)
+
+    assert described.count("ValueError: a") == 1
+    assert "KeyError: 'b'" in described
+
+
+def test_a_plain_exception_is_left_alone():
+    assert manager.describe_failure(RuntimeError("boom")) == "RuntimeError: boom"
+
+
+def test_a_dying_server_s_last_words_reach_the_report():
+    """The protocol only knows "Connection closed"; the reason went to stderr.
+
+    Silencing that stream to clean up the table would have thrown away the one
+    thing worth reading, which is why it is captured rather than discarded.
+    """
+    said = "Traceback (most recent call last):\n  File x\nAttributeError: no attribute 'list_tools'\n"
+
+    detail = manager._with_last_words("McpError: Connection closed", said)
+
+    assert "Connection closed" in detail
+    assert "list_tools" in detail
+
+
+def test_last_words_are_stripped_of_terminal_colours():
+    """One server writes green ANSI codes; they are noise in a chat message."""
+    detail = manager._with_last_words("failed", "\x1b[32mProcessing request\x1b[0m\n")
+
+    assert "\x1b" not in detail
+    assert "Processing request" in detail
+
+
+def test_a_server_that_died_silently_gets_nothing_appended():
+    """No last words is not a reason to invent a dangling "server said:"."""
+    assert manager._with_last_words("McpError: Connection closed", "   \n\n") == "McpError: Connection closed"
+
+
+@pytest.mark.asyncio
+async def test_capture_is_off_unless_asked_for(monkeypatch):
+    """fd 2 belongs to the whole process.
+
+    Capturing it inside a running agent would swallow every other task's logging
+    for forty seconds a day, so the long-lived caller does not opt in.
+    """
+    seen = []
+
+    async def _load(name, config, timeout=None, capture_stderr=False):
+        seen.append(capture_stderr)
+        return [FakeTool()], ""
+
+    monkeypatch.setattr(manager, "build_mcp_config", lambda: {"fetch": {}})
+    monkeypatch.setattr(manager, "_load_server_tools", _load)
+
+    await manager.check_mcp_health()
+    async with manager.managed_mcp_tools():
+        pass
+
+    assert seen == [False, False]
+
+
 # --- startup keeps its own behaviour -------------------------------------------
 
 
@@ -199,7 +278,7 @@ async def test_startup_does_not_impose_the_probe_s_timeout(monkeypatch):
     """
     seen = []
 
-    async def _load(name, config, timeout=None):
+    async def _load(name, config, timeout=None, capture_stderr=False):
         seen.append(timeout)
         return [FakeTool()], ""
 
@@ -226,7 +305,7 @@ async def test_a_failure_report_never_carries_the_server_s_credentials(monkeypat
         lambda: {"brave-search": {"transport": "stdio", "env": {"BRAVE_API_KEY": secret}}},
     )
 
-    async def _load(name, config, timeout=None):
+    async def _load(name, config, timeout=None, capture_stderr=False):
         return [], f"RuntimeError: could not start with {config}"
 
     monkeypatch.setattr(manager, "_load_server_tools", _load)
@@ -251,7 +330,7 @@ async def test_a_credential_embedded_in_a_larger_value_is_redacted_too(monkeypat
         lambda: {"notion": {"transport": "stdio", "env": {"OPENAPI_MCP_HEADERS": header}}},
     )
 
-    async def _load(name, config, timeout=None):
+    async def _load(name, config, timeout=None, capture_stderr=False):
         return [], f"RuntimeError: rejected token {token}"
 
     monkeypatch.setattr(manager, "_load_server_tools", _load)


### PR DESCRIPTION
The servers are chatty on the stderr this process inherits — node deprecation
warnings, a startup banner in ASCII art, **41 lines** of it wrapped around a
12-line table.

Silencing that stream was the obvious fix and the wrong one. When a server starts
and then dies, it is the *only* thing that says why: the protocol knows
`Connection closed` and no more, and anyio wraps even that in
`ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)`. Quietening
stderr on top of that would have produced a clean report that says nothing —
worse than the noise it replaced.

So two changes, and the order matters:

1. **The wrapper is unwrapped** to the real exception, however many groups deep.
2. **The stream is captured, not discarded** — dropped when the server worked,
   its last lines appended when it did not.

The historical yahoo-finance failure now reads:

```
McpError: Connection closed — server said: @server.list_tools() /
AttributeError: 'Server' object has no attribute 'list_tools'
```

That sentence existed only in a journal traceback for months.

## Scope of the capture

At the file-descriptor level, because that is what a child inherits — `errlog` on
the SDK's stdio client would be tidier, but langchain-mcp-adapters does not pass
it through.

**Only the CLI opts in.** fd 2 belongs to the whole process, so capturing inside
a running agent would swallow every other task's logging for forty seconds a day.
The daily job leaves server output in the journal where it belongs, and a test
pins that both callers keep their own behaviour. `--verbose` leaves the stream
alone for anyone who wants all of it.

## Verification

Measured against the real eleven servers on the host:

| | before | after |
|---|---|---|
| stderr lines | 41 | **0** |
| stdout | the table (already clean) | unchanged |

Failure path checked against the real thing — yahoo-finance with its SDK pin
removed — not a synthetic stand-in.

7 new tests; `pytest -m "not integration"`: **1925 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)