### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Kronos Agent OS are documented here.
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-18
+
 ### Added
 
 - **A daily check that the MCP servers still hand over their tools** — the third

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kronos-agent-os"
-version = "0.2.0"
+version = "0.3.0"
 description = "Kronos Agent OS (KAOS): self-hosted runtime for durable AI agents with memory, skills, MCP tools, automations, and sub-agent coordination"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1391,7 +1391,7 @@ wheels = [
 
 [[package]]
 name = "kronos-agent-os"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Closes everything accumulated since 0.2.0 (May) as a release rather than leaving
it in `[Unreleased]`.

**The seven-item agentic capability map**, complete: parallel tool calls, tiered
web acquisition, site accounts with an AES-GCM vault, plans that outlive a turn,
`compare_offers` on a real sandbox, context managed by token budget, repository
reading — plus the marketplace skill pack the tools were built for.

**Three daily capability checks**, which exist because this cycle found three
subsystems degraded in silence: a stealth backend that lived only on one host, a
sandbox whose readiness flag could not see either of its real failures, and two
MCP servers dead on every boot for months, costing 11 tools including every
market-data tool the finance agent has.

**Minor, not major.** This adds a great deal and stabilises nothing that was not
already stable; 1.0 would claim an API promise the project has not made.

## Mechanics

The version lives in exactly one place — `pyproject.toml`; `kronos/__init__.py`
reads it from package metadata — plus `uv.lock`, which the `lockfile` CI job
compares. Regenerating the lock changed one line and touched no dependency.

Nothing here publishes anything: no workflow triggers on tags and CI has no PyPI
step, so `v0.3.0` marks the commit and does nothing else.

## Verification

- `kaos --version` reports `0.3.0` after reinstall.
- `pytest -m "not integration"`: **1936 passed**.
- Lock diff: one line, `0.2.0` → `0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)