### PR TITLE
ci: keep the merge push to the quality snapshot only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,11 @@
+# CI
+#
+# The PR is the gate; the merge push only produces the quality snapshot.
+# lockfile, evals and dashboard-ui are pull_request-only — re-running them on
+# the merge commit repeats checks the PR just passed (Actions quota, Sep 2026).
+# lint -> test -> quality-report stays on push: quality-report dispatches the
+# report to the FutureCraft dashboard, and it needs both as `needs`.
+
 name: CI
 
 on:
@@ -22,6 +30,7 @@ jobs:
 
   lockfile:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
@@ -55,6 +64,7 @@ jobs:
 
   evals:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     needs: lint
     steps:
       - uses: actions/checkout@v7
@@ -158,6 +168,7 @@ jobs:
 
   dashboard-ui:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7


### PR DESCRIPTION
Продолжение чистки после [journeybay-application#130](https://github.com/spyrae/journeybay-application/pull/130). В Kronos тот же дубль: PR прогонял все шесть джобов, после мержа те же шесть бежали заново по уже проверенным коммитам. 68 прогонов CI за месяц, 25 из них на push.

## Что меняется

`lockfile`, `evals` и `dashboard-ui` становятся pull_request-only. `evals` и `dashboard-ui` — два самых тяжёлых джоба (checkout с полной историей + прогон `pytest -m eval`; `npm ci` + сборка Vite), а ключевой шаг evals — «Behaviour diff vs base» — и так был закрыт условием `github.event_name == 'pull_request'`.

## Что остаётся на push

Цепочка `lint` → `test` → `quality-report`. Джоб `quality-report` шлёт отчёт в `spyrae/futurecraft-blog-v2` и держит оба в `needs` — сняв любой из них, мы получили бы пропуск снапшота и молча замороженный дашборд.

На push в main: 6 джобов → 3.

## Что не тронуто

`security-audit.yml` уже недельный и стоит один джоб — резать нечего. `deploy.yml` только вручную. Dependabot настроен корректно: weekly + группировка minor/patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)