### PR TITLE
cron: give the scheduler spies the jobs attribute setup counts

### DIFF
--- a/tests/test_cron_setup.py
+++ b/tests/test_cron_setup.py
@@ -11,16 +11,21 @@ from kronos.cron.signal_travel import run_travel_insights_digest
 
 class _SchedulerSpy:
     def __init__(self) -> None:
-        self.names: list[str] = []
+        # Mirrors Scheduler.jobs — setup_cron_jobs logs len(scheduler.jobs).
+        self.jobs: dict[str, object] = {}
 
-    def add_periodic(self, name, _func, interval_seconds):
-        self.names.append(name)
+    @property
+    def names(self) -> list[str]:
+        return list(self.jobs)
 
-    def add_daily(self, name, _func, hour_utc):
-        self.names.append(name)
+    def add_periodic(self, name, func, interval_seconds):
+        self.jobs[name] = func
 
-    def add_weekly(self, name, _func, weekday, hour_utc):
-        self.names.append(name)
+    def add_daily(self, name, func, hour_utc):
+        self.jobs[name] = func
+
+    def add_weekly(self, name, func, weekday, hour_utc):
+        self.jobs[name] = func
 
 
 def test_nexus_exclusive_reports_register_only_enabled_jobs_on_nexus(monkeypatch):

--- a/tests/test_personal_observer_cron.py
+++ b/tests/test_personal_observer_cron.py
@@ -10,16 +10,19 @@ from kronos.workspace import Workspace
 
 class SchedulerSpy:
     def __init__(self):
+        # jobs mirrors Scheduler.jobs — setup_cron_jobs logs len(scheduler.jobs).
+        self.jobs = {}
         self.daily = {}
 
-    def add_periodic(self, name, _func, interval_seconds):
-        pass
+    def add_periodic(self, name, func, interval_seconds):
+        self.jobs[name] = func
 
     def add_daily(self, name, func, hour_utc):
+        self.jobs[name] = func
         self.daily[name] = (func, hour_utc)
 
-    def add_weekly(self, name, _func, weekday, hour_utc):
-        pass
+    def add_weekly(self, name, func, weekday, hour_utc):
+        self.jobs[name] = func
 
 
 async def test_personal_observer_cron_scans_renders_and_sends(monkeypatch, tmp_path):


### PR DESCRIPTION
Чинит красный main.

`setup_cron_jobs` теперь логирует `len(scheduler.jobs)` вместо литерала `24 + nexus_jobs_registered`, но тестовые дублёры планировщика в `test_cron_setup.py` и `test_personal_observer_cron.py` не имели атрибута `jobs` — отсюда четыре падения:

```
AttributeError: 'SchedulerSpy' object has no attribute 'jobs'
4 failed, 1938 passed
```

Правка самого `setup.py` уехала в main раньше, в составе #72; фикс спаев в тот коммит не попал, потому что был написан несколькими минутами позже. Здесь он и приезжает — больше в PR ничего нет, только два тестовых файла.

Проверено локально на этой ветке: `pytest -m "not integration"` — 1942 passed, `ruff check` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)