### PR TITLE
fix(analytics): stop the daily pulse inventing its numbers

### DIFF
--- a/.truthguard.yml
+++ b/.truthguard.yml
@@ -1,0 +1,5 @@
+# TruthGuard test configuration
+# The default "python -m pytest" assumes an activated virtualenv; hooks run
+# without one, and macOS has no bare `python`, so the check failed to start
+# (exit 127) and read as a test failure. Point it at the project venv.
+test_command: .venv/bin/python -m pytest -q

--- a/kronos/analytics/pulse.py
+++ b/kronos/analytics/pulse.py
@@ -71,7 +71,18 @@ Generate a concise daily pulse:
 9. ⚠️ Issues requiring attention (if any)
 10. 💡 One actionable insight based on the data
 
-If a data source returned an error, note it as "⚠️ Source unavailable" — don't skip the section.
+If a data source returned an error, you MUST write "⚠️ Source unavailable" for that
+section. Never invent, estimate or carry over numbers for a source that errored — a
+fabricated figure is worse than an admitted gap, because it gets acted on. This is not
+optional formatting advice: on 2026-09-01 ten of eleven sources were misconfigured and
+returned errors, and the pulse had been publishing plausible invented numbers for every
+section daily.
+
+Note: subscriptions and trials come from Supabase — `db_active_subscriptions`, `db_trial_subscriptions` and `db_active_trials` — and that is the source of truth. RevenueCat
+reports 0 active because the records were never mirrored into it; use RevenueCat only for
+MRR/revenue/new_customers, and never state "0 active subscriptions" on its authority.
+
+Note: report only fields that are actually present in the payload above. A field that is absent or null is unknown, not zero — write "n/a" for it. Do not derive DAU, trip counts, message counts or saved places from anything other than the matching `dau_24h`, `trips_24h`, `ai_messages_24h` and `saved_places_24h` fields, and never reuse a number from another section to fill a gap.
 
 Note: Zabbix `updates_available` = count of pending Docker image updates. It is informational ONLY — never treat it as a 🔴/🟡 signal, never list it under "Issues requiring attention", and never let it affect the overall status. Mention it at most as a neutral one-liner under Infrastructure.
 

--- a/kronos/analytics/sources/app_store.py
+++ b/kronos/analytics/sources/app_store.py
@@ -55,8 +55,17 @@ def _fetch_android() -> dict:
     except ImportError:
         return {"error": "google-play-scraper not installed"}
 
+    # Read the package at call time, not at import. Module-level
+    # os.environ.get() runs before kronos.config's load_dotenv() has populated
+    # the environment, so the package came out empty and google-play-scraper
+    # answered the empty id with "App not found(404)" — which then suppressed
+    # the whole App Store section of the pulse.
+    package = os.environ.get("ANDROID_PACKAGE", "") or _ANDROID_PACKAGE
+    if not package:
+        return {"error": "ANDROID_PACKAGE not configured"}
+
     try:
-        data = gplay_app(_ANDROID_PACKAGE, lang="en", country="us")
+        data = gplay_app(package, lang="en", country="us")
         return {
             "android_rating": round(data.get("score", 0), 2) if data.get("score") else None,
             "android_reviews_count": data.get("reviews"),

--- a/kronos/analytics/sources/langfuse_stats.py
+++ b/kronos/analytics/sources/langfuse_stats.py
@@ -81,9 +81,28 @@ def collect() -> dict:
         latencies = [o.get("latency", 0) or 0 for o in obs_list if o.get("latency")]
         avg_latency_ms = round(sum(latencies) / len(latencies)) if latencies else None
 
-        # Error rate
-        errors = sum(1 for o in obs_list if o.get("level") == "ERROR")
-        error_rate = round(errors / len(obs_list) * 100, 1) if obs_list else 0
+        # Error rate over real model calls only.
+        #
+        # Two kinds of rows reach Langfuse without ever invoking a model, and
+        # counting them put the rate at 42.6% on a day with no product errors:
+        #   - requests the LiteLLM gateway rejected for having no API key —
+        #     scanners probing /azure/.env, /v1/models and friends;
+        #   - gateway probes (/health, /model/info), which arrive with no model
+        #     and the literal placeholder "default-message-value".
+        # They are reported separately so the scanning stays visible instead of
+        # masquerading as LLM quality.
+        def _is_unauthenticated(o: dict) -> bool:
+            return "no api key passed in" in str(o.get("statusMessage", "")).lower()
+
+        def _is_probe(o: dict) -> bool:
+            if o.get("model"):
+                return False
+            return "default-message-value" in str(o.get("input", ""))
+
+        scored = [o for o in obs_list if not _is_unauthenticated(o) and not _is_probe(o)]
+        unauthenticated = sum(1 for o in obs_list if _is_unauthenticated(o))
+        errors = sum(1 for o in scored if o.get("level") == "ERROR")
+        error_rate = round(errors / len(scored) * 100, 1) if scored else 0
 
         return {
             "traces_24h": total_traces,
@@ -91,6 +110,8 @@ def collect() -> dict:
             "sample_cost_usd": round(total_cost, 4),
             "avg_latency_ms": avg_latency_ms,
             "error_rate_pct": error_rate,
+            "error_sample_size": len(scored),
+            "unauthenticated_requests": unauthenticated,
         }
 
     except Exception as e:

--- a/kronos/analytics/sources/sentry.py
+++ b/kronos/analytics/sources/sentry.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import time
 import urllib.parse
 import urllib.request
 
@@ -51,12 +52,18 @@ def collect() -> dict:
             {"query": "is:unresolved lastSeen:-24h", "sort": "freq", "limit": "10"},
         )
 
-        # Project stats (events received in last 24h)
+        # Project stats (events received in last 24h).
+        #
+        # Hourly resolution, summed. At "1d" the endpoint returns a single
+        # bucket for the calendar day that has just begun, so anything that
+        # happened yesterday evening reads as zero — the pulse reported
+        # "events_24h: 0" next to an issue it had just listed as active.
         stats = _api_get(
             f"/projects/{org}/{project}/stats/",
-            {"stat": "received", "resolution": "1d"},
+            {"stat": "received", "resolution": "1h"},
         )
-        events_24h = stats[-1][1] if stats else 0
+        cutoff = time.time() - 24 * 3600
+        events_24h = sum(count for ts, count in stats if ts >= cutoff) if stats else 0
 
         # Top issues limited to those ACTIVE in the last 24h (a 9-day-dead issue
         # with a large all-time count must not surface as a fresh spike).

--- a/kronos/analytics/sources/supabase_stats.py
+++ b/kronos/analytics/sources/supabase_stats.py
@@ -4,6 +4,7 @@ import json
 import logging
 import urllib.parse
 import urllib.request
+from datetime import datetime, timedelta, timezone
 
 from kronos.config import settings
 
@@ -83,39 +84,86 @@ def _rpc(function: str, params: dict | None = None) -> dict | list:
     return json.loads(resp.read())
 
 
+def _distinct_users(table: str, column: str, since: str) -> set[str] | None:
+    """Distinct user ids that touched `table` since `since`.
+
+    PostgREST cannot do COUNT(DISTINCT), so the ids are fetched and
+    de-duplicated here. Returns None — not an empty set — when the request
+    fails, so an outage stays distinguishable from a genuinely quiet day.
+    """
+    try:
+        rows = _rest_get(table, {"select": column, "created_at": f"gte.{since}", "limit": "10000"})
+        if not isinstance(rows, list):
+            return None
+        return {row[column] for row in rows if row.get(column)}
+    except Exception as e:
+        log.debug("Distinct users for %s failed: %s", table, e)
+        return None
+
+
 def collect() -> dict:
     """Collect Supabase product stats for daily pulse."""
     if not settings.supabase_url or not settings.supabase_service_role_key:
         return {"error": "Supabase not configured"}
 
     try:
-        # Total users
+        # PostgREST evaluates filter values as literals, not SQL — passing
+        # "now()-interval'24 hours'" made the request fail and the field come
+        # back null, so the pulse reported no signups regardless of reality.
+        since = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+
         total_users = _count("global_users")
+        new_users = _count("global_users", {"created_at": f"gte.{since}"})
 
-        # New users in last 24h (using created_at filter)
-        new_users = _count(
-            "global_users",
-            {
-                "created_at": "gte.now()-interval'24 hours'",
-            },
-        )
-
-        # Active trips (not archived)
-        active_trips = _count(
-            "trip",
-            {
-                "is_archived": "eq.false",
-            },
-        )
-
-        # Total trips
+        active_trips = _count("trip", {"is_archived": "eq.false"})
         total_trips = _count("trip")
+
+        # Daily activity. These four fields did not exist before: the prompt
+        # asks for DAU and key feature usage, the payload carried neither, and
+        # the model filled the gap with invented figures every single day.
+        trips_24h = _count("trip", {"created_at": f"gte.{since}"})
+        activities_24h = _count("day_activities", {"created_at": f"gte.{since}"})
+        ai_messages_24h = _count("ai_chat_messages", {"created_at": f"gte.{since}"})
+        saved_places_24h = _count("user_poi", {"created_at": f"gte.{since}"})
+
+        # DAU spans every table that records a user action, because
+        # behavior_events alone has been near-empty since the analytics
+        # regression and would understate a working product.
+        actors: set[str] = set()
+        sources_ok = False
+        for table, column in (
+            ("trip", "global_user_id"),
+            ("day_activities", "global_user_id"),
+            ("user_poi", "global_user_id"),
+            ("behavior_events", "user_id"),
+        ):
+            ids = _distinct_users(table, column, since)
+            if ids is not None:
+                sources_ok = True
+                actors |= ids
+        dau_24h = len(actors) if sources_ok else None
+
+        # Subscriptions live here, not in RevenueCat: the RevenueCat source
+        # reports 0 active because the records were never mirrored there, and
+        # the pulse repeated that zero while the database held active and
+        # trialling users.
+        active_subscriptions = _count("subscriptions", {"status": "eq.active"})
+        trial_subscriptions = _count("subscriptions", {"status": "eq.trial"})
+        active_trials = _count("user_trials", {"status": "eq.active"})
 
         return {
             "total_users": total_users,
             "new_users_24h": new_users,
+            "dau_24h": dau_24h,
             "active_trips": active_trips,
             "total_trips": total_trips,
+            "trips_24h": trips_24h,
+            "activities_24h": activities_24h,
+            "ai_messages_24h": ai_messages_24h,
+            "saved_places_24h": saved_places_24h,
+            "db_active_subscriptions": active_subscriptions,
+            "db_trial_subscriptions": trial_subscriptions,
+            "db_active_trials": active_trials,
         }
 
     except Exception as e:

--- a/kronos/analytics/sources/supabase_stats.py
+++ b/kronos/analytics/sources/supabase_stats.py
@@ -4,7 +4,7 @@ import json
 import logging
 import urllib.parse
 import urllib.request
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from kronos.config import settings
 
@@ -110,7 +110,7 @@ def collect() -> dict:
         # PostgREST evaluates filter values as literals, not SQL — passing
         # "now()-interval'24 hours'" made the request fail and the field come
         # back null, so the pulse reported no signups regardless of reality.
-        since = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+        since = (datetime.now(UTC) - timedelta(hours=24)).isoformat()
 
         total_users = _count("global_users")
         new_users = _count("global_users", {"created_at": f"gte.{since}"})

--- a/kronos/config.py
+++ b/kronos/config.py
@@ -19,8 +19,8 @@ class Settings(BaseSettings):
     kaos_lite_provider_chain: str = "deepseek"
     kaos_orchestrator_provider_chain: str = ""  # empty = standard tier
     kaos_vision_provider: str = "codex-cli"  # codex-cli | openai-api
-    kaos_codex_model: str = "gpt-5.5"
-    kaos_vision_model: str = "gpt-5.5"
+    kaos_codex_model: str = "gpt-5.6-terra"
+    kaos_vision_model: str = "gpt-5.6-terra"
     kaos_codex_command: str = "codex"
     kaos_codex_timeout_seconds: int = 180
     kaos_vision_timeout_seconds: int = 120

--- a/kronos/llm.py
+++ b/kronos/llm.py
@@ -33,6 +33,16 @@ log = logging.getLogger("kronos.llm")
 COOLDOWN_SECONDS = 300  # 5 minutes
 RETRIABLE_STATUS_CODES = {408, 409, 425, 429}
 
+# A model the provider no longer serves is a fault of that provider, not of the
+# request, so the next provider in the chain should get a turn.
+MODEL_UNAVAILABLE_MARKERS = (
+    "model not found",
+    "model_not_found",
+    "does not exist or you do not have access",
+    "inaccessible",
+    "not deployed",
+)
+
 
 class ModelTier(str, Enum):
     LITE = "lite"
@@ -599,15 +609,7 @@ def is_retriable_llm_error(error: BaseException) -> bool:
             return True
         if status_code in RETRIABLE_STATUS_CODES:
             return True
-        if status_code == 404 and any(
-            marker in message
-            for marker in (
-                "model not found",
-                "model_not_found",
-                "inaccessible",
-                "not deployed",
-            )
-        ):
+        if status_code == 404 and any(marker in message for marker in MODEL_UNAVAILABLE_MARKERS):
             return True
         if 400 <= status_code < 500:
             return False
@@ -636,6 +638,12 @@ def is_retriable_llm_error(error: BaseException) -> bool:
         "blocked by shield",
         "content policy",
     )
+    # Checked before the generic markers: a retired model reports "404 Not
+    # Found", and the bare "not found" below would otherwise class it as
+    # non-retriable — leaving a dead first provider to fail the whole chain
+    # while a healthy fallback sat unused.
+    if any(marker in message for marker in MODEL_UNAVAILABLE_MARKERS):
+        return True
     if any(marker in message for marker in non_retriable_markers):
         return False
     return any(marker in message for marker in retriable_markers)

--- a/kronos/llm.py
+++ b/kronos/llm.py
@@ -1,7 +1,7 @@
 """LLM factory with configurable provider chains and cooldown tracking.
 
 Default resolution order:
-  orchestrator: Codex CLI (gpt-5.5)      # top-level supervisor
+  orchestrator: Codex CLI (gpt-5.6-terra)  # top-level supervisor
   standard:     DeepSeek V3
   lite:         DeepSeek V3
 
@@ -333,7 +333,7 @@ _PRESETS: dict[str, dict[str, object]] = {
     },
     "codex_cli": {
         "adapter": "codex-cli",
-        "model": "gpt-5.5",
+        "model": "gpt-5.6-terra",
         "api_key_required": False,
         "max_tokens": 4096,
         "timeout_seconds": 180,
@@ -520,8 +520,12 @@ def resolve_provider_config(provider: str) -> ProviderConfig | None:
     timeout_seconds = _int_env(prefix + "TIMEOUT_SECONDS", int(preset.get("timeout_seconds", 180)))
 
     if provider_id == "codex_cli":
-        if not model:
-            model = settings.kaos_codex_model
+        # KAOS_CODEX_MODEL is the documented knob for the Codex backend, but the
+        # preset above always filled `model` first, so this only applied when
+        # both were empty — the setting never took effect and the model could
+        # not be changed without editing Python. The explicit per-provider
+        # override still wins over it.
+        model = str(_env(prefix + "MODEL", "")) or settings.kaos_codex_model or model
         command = command or settings.kaos_codex_command
         timeout_seconds = _int_env(prefix + "TIMEOUT_SECONDS", settings.kaos_codex_timeout_seconds)
 

--- a/kronos/llm_codex.py
+++ b/kronos/llm_codex.py
@@ -153,7 +153,13 @@ class ChatCodexCLI(BaseChatModel):
 def _read_codex_result(returncode: int | None, stdout: str, stderr: str, output_path: str) -> str:
     if returncode != 0:
         detail = (stderr or stdout).strip()
-        raise RuntimeError(f"Codex CLI failed ({returncode}): {detail[:1000]}")
+        # Keep the tail, not the head. Codex echoes the session banner and the
+        # entire prompt before it reports anything, so truncating from the
+        # front yields "Reading additional input from stdin..." and drops the
+        # actual cause — which hid a retired-model 404 from the logs and from
+        # is_retriable_llm_error, leaving the chain to re-raise instead of
+        # failing over to the next provider.
+        raise RuntimeError(f"Codex CLI failed ({returncode}): ...{detail[-1000:]}")
 
     text = Path(output_path).read_text(encoding="utf-8").strip() if os.path.exists(output_path) else ""
     if not text:

--- a/kronos/llm_codex.py
+++ b/kronos/llm_codex.py
@@ -33,7 +33,7 @@ class ChatCodexCLI(BaseChatModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    model_name: str = "gpt-5.5"
+    model_name: str = "gpt-5.6-terra"
     command: str = "codex"
     timeout_seconds: int = 180
     cwd: str = ""

--- a/kronos/security/cost_tracking.py
+++ b/kronos/security/cost_tracking.py
@@ -50,6 +50,7 @@ _MODEL_PRICES: dict[str, tuple[float, float]] = {
     "gpt-4.1": (2.00, 8.00),
     # Codex CLI uses ChatGPT OAuth (subscription, not per-token API billing),
     # so its marginal cost is zero. Override via env if billed per token.
+    "gpt-5.6-terra": (0.0, 0.0),
     "gpt-5.5": (0.0, 0.0),
     "gpt-5": (0.0, 0.0),
 }

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -269,6 +269,21 @@ def test_retriable_llm_error_classification() -> None:
     assert is_retriable_llm_error(RuntimeError("blocked by shield")) is False
 
 
+def test_retired_model_falls_through_to_next_provider() -> None:
+    """A CLI provider reporting a retired model must not fail the whole chain.
+
+    The Codex backend surfaces this as a plain RuntimeError with no status
+    code, and the message contains "Not Found" — which the generic marker list
+    treats as non-retriable. In production that left the daily pulse dead while
+    a healthy DeepSeek fallback sat unused behind it.
+    """
+    error = RuntimeError(
+        "Codex CLI failed (1): ERROR: unexpected status 404 Not Found: "
+        "The model `gpt-5.5` does not exist or you do not have access to it."
+    )
+    assert is_retriable_llm_error(error) is True
+
+
 def test_provider_config_can_come_from_dotenv_without_settings_fields(tmp_path):
     env_file = tmp_path / ".env"
     env_file.write_text(


### PR DESCRIPTION
The daily pulse for 2026-09-07 reported 0 trips (2 were created), 0 active
subscriptions (4), 0 trials (156 active) and a 6.5% LLM error rate (0%).

## Why it came back

The same fix was made on 2026-09-01 and committed **only on FRA-01**. It never
reached origin, so the next rsync deploy overwrote it with the August files.
`git log` on the server still showed the fix at HEAD — only `git diff HEAD`
revealed the working tree had lost 52 lines across three files.

## What is fixed

**Pulse data**
- `new_users_24h`: PostgREST reads filter values as literals, so
  `now()-interval'24 hours'` returned null and every signup count read as zero.
- Subscriptions and trials now come from the database. RevenueCat reports 0
  because the records were never mirrored into it.
- New fields `dau_24h`, `trips_24h`, `activities_24h`, `ai_messages_24h`,
  `saved_places_24h` — the prompt asked for DAU and feature usage, the payload
  carried neither, so the model invented both every day.
- Langfuse error rate excludes gateway probes and scanner traffic.
- `app_store` reads ANDROID_PACKAGE at call time, not import time.
- Prompt: absent or null is unknown, not zero.

**Sentry** — `resolution=1d` returns a single bucket for the calendar day that
has just begun, so yesterday evening read as zero. Hourly buckets, summed.

**LLM backend** — three separate faults found while verifying the above:
1. `gpt-5.5` is retired; OpenAI returns 404. The pulse could not generate at all.
2. `KAOS_CODEX_MODEL` never worked — the preset filled `model` first, and the
   setting was only consulted when empty. Two tests asserted it was honoured and
   passed only because the preset carried the same string.
3. The `codex-cli,kimi,deepseek` chain did not fail over: a retired model reports
   "404 Not Found", `not found` sits in the non-retriable markers, and the error
   was re-raised. Compounded by `llm_codex.py` truncating stderr from the front,
   where Codex echoes the prompt — so the real cause reached neither the logs nor
   the classifier.

## Verification

1986 tests pass. The new retriable-classifier test fails against the previous
code. On FRA-01 the standard `generate_daily_pulse()` path now reports trips 2,
subscriptions 4/3/156, Sentry 2 events, LLM 0% and "n/a" where data is missing —
each cross-checked against Supabase, GA4, Sentry and Langfuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)