### PR TITLE
fix(config): stop swarm agents inheriting the base agent's dotenv

### DIFF
--- a/kronos/__main__.py
+++ b/kronos/__main__.py
@@ -3,10 +3,6 @@
 import asyncio
 import logging
 
-from dotenv import load_dotenv
-
-load_dotenv()
-
 from kronos.app import main
 from kronos.logging import install_pii_filter
 

--- a/kronos/config.py
+++ b/kronos/config.py
@@ -5,7 +5,20 @@ import os
 from dotenv import load_dotenv
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-_ENV_FILE = os.environ.get("KAOS_ENV_FILE") or os.environ.get("KRONOS_ENV_FILE") or ".env"
+
+def _select_env_file() -> str:
+    """Keep each systemd agent isolated from the base agent's dotenv file."""
+    explicit = os.environ.get("KAOS_ENV_FILE") or os.environ.get("KRONOS_ENV_FILE")
+    if explicit:
+        return explicit
+
+    agent_name = os.environ.get("AGENT_NAME", "").strip()
+    if agent_name and agent_name != "kronos":
+        return f".env.{agent_name}"
+    return ".env"
+
+
+_ENV_FILE = _select_env_file()
 load_dotenv(_ENV_FILE, override=False)
 
 

--- a/tests/test_config_env_selection.py
+++ b/tests/test_config_env_selection.py
@@ -1,0 +1,55 @@
+"""Agent processes must not inherit another agent's dotenv values."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_module_entrypoint_loads_agent_specific_env(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text(
+        "AGENT_NAME=kronos\nSESSION_FILE=kronos.session\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".env.resonant").write_text(
+        "AGENT_NAME=resonant\n",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    for key in ("SESSION_FILE", "KAOS_ENV_FILE", "KRONOS_ENV_FILE"):
+        env.pop(key, None)
+    env["AGENT_NAME"] = "resonant"
+    env["PYTHONPATH"] = os.pathsep.join(part for part in (str(REPO_ROOT), env.get("PYTHONPATH", "")) if part)
+
+    script = """
+import json
+import os
+
+import kronos.__main__
+from kronos.config import _ENV_FILE, settings
+
+print(json.dumps({
+    "agent": settings.agent_name,
+    "env_file": _ENV_FILE,
+    "session_file": os.environ.get("SESSION_FILE"),
+}))
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = json.loads(completed.stdout.splitlines()[-1])
+    assert result == {
+        "agent": "resonant",
+        "env_file": ".env.resonant",
+        "session_file": None,
+    }


### PR DESCRIPTION
## Problem

Every agent process runs from the same working directory. `kronos/__main__.py`
called `load_dotenv()` unconditionally, and `kronos/config.py` fell back to
`.env`, so the base agent's dotenv was pulled into **every** agent's
environment. Any key the agent's own `.env.<agent>` did not define leaked in
from the base file.

The sharpest consequence is `SESSION_FILE`. `kronos/bridge.py:925` has the
right default:

```python
session_file = os.environ.get("SESSION_FILE", f"{settings.agent_name}.session")
```

…but the leak fills `SESSION_FILE` in before the default can apply, so
non-base agents open the **base agent's** Telethon session instead of their
own. Three agent processes then contend for one SQLite session file
(`telethon/sessions/sqlite.py` write errors on restart) and log in under the
wrong Telegram identity.

## Fix

- Select the dotenv file from `AGENT_NAME`; explicit `KAOS_ENV_FILE` /
  `KRONOS_ENV_FILE` still win, and the base agent keeps `.env`.
- Drop the entrypoint's blanket `load_dotenv()` so the selection is not
  pre-empted at import time — without this half, `config.py` alone cannot fix it.

## Test

`tests/test_config_env_selection.py` spawns a subprocess with `AGENT_NAME` set
and both dotenv files present, then asserts the agent resolves `.env.<agent>`
and does **not** inherit `SESSION_FILE`. Verified it fails on `main`
(`session_file == 'kronos.session'`, `env_file == '.env'`) and passes with the fix.

## Operator note

After this lands, an agent only sees what its own `.env.<agent>` defines.
Shared settings that currently reach the other agents only by leaking from the
base file must be written into each `.env.<agent>` — notably
`TOOL_APPROVALS_ENABLED` (defaults to `True`, i.e. fail-closed) and
`ENABLE_CODE_EXECUTION` (defaults to `False`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)