### PR TITLE
Give every agent its own storage, and its own name

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,6 +24,7 @@ data/
 logs/
 servers.yaml
 agents.yaml
+agents.local.yaml
 
 dashboard-ui/node_modules/
 dashboard-ui/.vite/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ venv/
 *.session-journal
 servers.yaml
 agents.yaml
+# Per-installation identity overlay (real Telegram @usernames) — never public.
+agents.local.yaml
 
 # Data
 data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Kronos Agent OS are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A stale @username in the registry sent replies to the wrong agent, and no
+  agent could see it** — an agent learns its own name from Telethon at login and
+  never from `agents.yaml`, so its own entry can be wrong indefinitely without
+  that agent noticing anything. The registry is what the *other* agents read to
+  build "this message is for lacuna, not me": with a wrong entry, her real handle
+  matches nobody, nobody skips, the implicit tiers stay open, and another agent
+  answers in her place — the same class of bug the cross-agent addressing guard
+  was written to close. Two changes. Identity is now separable from the org
+  chart: `agents.local.yaml`, an optional overlay beside the registry, is merged
+  field by field, so an installation overrides a username without restating the
+  ownership and escalation around it. It is gitignored and excluded from the
+  deploy rsync — the registry is deployed *over*, so anything that has to outlive
+  a deploy cannot live in it — which also keeps one installation's real Telegram
+  handles out of a public checkout. And every agent now compares its own entry
+  against Telegram at login and logs `Agent registry out of sync`, naming both
+  sides and the file to fix, because login is the only moment where the two
+  values are in the same process at the same time.
+
 ## [0.3.0] - 2026-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ All notable changes to Kronos Agent OS are documented here.
 
 ### Fixed
 
+- **Three agents shared one session database, and the last one to answer won** —
+  `.env.lacuna`, `.env.resonant` and `.env.keystone` each carried a copy-pasted
+  `DB_PATH=./data/kronos.db`. The legacy-path rewrite only recognised
+  `./data/<own agent_name>.db`, so the literal value survived and all three
+  resolved to a single store. `sessions` is keyed by `thread_id` alone and every
+  write replaces the whole row, so in any thread two of them could see, one
+  agent's history silently overwrote the other's — and everything derived from
+  the path's parent directory (`cron_state.json`, `logs/`, `mcp_registry.db`,
+  `sandbox/`) was shared the same way, down to two agents clobbering each other's
+  cron timestamps. A flat `./data/<name>.db` is now treated as the pre-isolation
+  layout whatever `<name>` says, and startup refuses a `DB_PATH` that resolves
+  outside the agent's own directory, the way a malformed policy already stops the
+  process rather than falling back to something permissive.
+- **Two agents wrote into one Qdrant directory and dropped each other's
+  memories** — `MEM0_QDRANT_PATH` was normalised only by the startup migration
+  moving the directory, never by the config, so a value naming another agent
+  survived. The main agent inherits `./data/nexus-qdrant` from the unit drop-in
+  that supplies the daily pulse its analytics keys; with two live processes on
+  one directory, the collection there flipped from `nexus_memories` to
+  `kronos_memories`, each dropping the other's. `./data/qdrant` and
+  `./data/<name>-qdrant` now normalise like flat DB paths, and the startup guard
+  covers both stores.
+- **Cron run history grew without bound** — thirteen jobs, some firing every 30
+  seconds, one JSON line each and nothing ever truncated: `cron_runs.jsonl` had
+  reached 174 MB on a disk at 92%. One rotated generation is kept at 32 MB.
+
 - **A stale @username in the registry sent replies to the wrong agent, and no
   agent could see it** — an agent learns its own name from Telethon at login and
   never from `agents.yaml`, so its own entry can be wrong indefinitely without

--- a/agents.example.yaml
+++ b/agents.example.yaml
@@ -19,6 +19,11 @@
 #   max_implicit_replies: per-agent override of the global implicit-reply cap
 #
 # You can have 1 to N agents. Each runs as a separate process.
+#
+# Real @usernames of a private installation do not belong here — this file is
+# shared configuration. Put them in `agents.local.yaml` beside it: an optional
+# overlay merged field by field over these entries, gitignored and excluded
+# from the deploy rsync, so it survives a deploy and stays out of the repo.
 
 strategist:
   username: strategist_bot

--- a/agents.yaml
+++ b/agents.yaml
@@ -12,6 +12,20 @@
 #   budget_usd_daily: this agent's slice of the swarm budget (0 = swarm cap only)
 #
 # Usernames can be overridden per-agent via env: AGENT_USERNAME_KRONOS=..., etc.
+#
+# Identity vs org chart: this file is shared configuration and travels with a
+# deploy, so it carries generic placeholder usernames. The real Telegram
+# @usernames of one installation belong in `agents.local.yaml` next to this
+# file — an optional overlay merged field by field over the entries here. It is
+# gitignored and excluded from the deploy rsync, so it survives a deploy and
+# never reaches a public checkout. Only override what actually differs:
+#
+#   kronos:
+#     username: my_real_handle
+#
+# Each agent checks its own entry against Telegram at login and logs
+# "Agent registry out of sync" when they disagree — a wrong entry is invisible
+# to the agent it describes and only misroutes the other agents' replies.
 
 kronos:
   username: kronosagnt

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -274,6 +274,7 @@ curl http://127.0.0.1:8789/api/health
     │   └── swarm.db
     ├── .env
     ├── agents.yaml
+    ├── agents.local.yaml     # real @usernames, never deployed over
     └── servers.yaml
 ```
 
@@ -296,4 +297,7 @@ app/
 └── servers.yaml
 ```
 
-`data/`, `.env`, `agents.yaml`, `servers.yaml`, `*.session`, and live `workspaces/<agent>/` files should not be committed.
+`data/`, `.env`, `agents.yaml`, `agents.local.yaml`, `servers.yaml`, `*.session`, and live
+`workspaces/<agent>/` files should not be committed. `agents.local.yaml` is also excluded
+from the deploy rsync: it carries this installation's real Telegram @usernames, so it has to
+survive a deploy that rewrites `agents.yaml`.

--- a/docs/SWARM.md
+++ b/docs/SWARM.md
@@ -77,6 +77,27 @@ strategist:
   max_implicit_replies: 2            # this agent's own tolerance for peers
 ```
 
+### Identity is per-installation
+
+The org chart is shared configuration and travels with a deploy. The Telegram
+@usernames are not: they belong to one installation, and a public checkout must
+not carry them. So `agents.yaml` holds placeholder usernames, and an optional
+`agents.local.yaml` beside it overlays the real ones, merged field by field —
+override only the username and the rest of the entry still comes from the org
+chart. The overlay is gitignored and excluded from the deploy rsync, so it
+survives a deploy that rewrites `agents.yaml`. `AGENTS_LOCAL_CONFIG_PATH` moves
+it; `AGENT_USERNAME_<NAME>` overrides one entry from the environment.
+
+A stale username is worth spelling out, because it fails in a direction that
+looks like nothing at all. An agent recognises its own name from what Telethon
+returns at login, never from the registry, so its own entry can be wrong
+forever without that agent noticing. The registry is what the *other* five read
+to build "this message is for lacuna, not me". With a wrong entry, `@lacuna`'s
+real handle matches nobody: no one skips, the implicit tiers stay open, and
+another agent answers in her place. Every agent therefore compares its entry
+against Telegram at login and logs `Agent registry out of sync` when they
+disagree — the only place the mismatch is visible.
+
 Validation is split by consequence (`kronos/swarm_config.py`). A broken
 `escalates_to` **raises at startup** — it names a delivery path that does not
 exist. Contested ownership and per-agent budgets summing above the swarm cap only

--- a/kronos/app.py
+++ b/kronos/app.py
@@ -90,18 +90,24 @@ def _validate_storage_layout_or_exit() -> None:
     be shared too, and ``sessions`` rows (keyed by ``thread_id`` alone) would
     overwrite each other. Same fail-closed reasoning as the policy loader.
     """
-    db_path = Path(settings.db_path).resolve()
     db_dir = Path(settings.db_dir).resolve()
-    if db_path.parent != db_dir:
-        log.error(
-            "Refusing to start: DB_PATH=%s lives outside this agent's data directory %s. "
-            "Agents sharing one session store overwrite each other's history. "
-            "Unset DB_PATH so it resolves to %s/session.db.",
-            settings.db_path,
-            settings.db_dir,
-            settings.db_dir,
-        )
-        raise SystemExit(1)
+    for label, configured in (
+        ("DB_PATH", settings.db_path),
+        ("MEM0_QDRANT_PATH", settings.mem0_qdrant_path),
+    ):
+        if Path(configured).resolve().parent != db_dir:
+            log.error(
+                "Refusing to start: %s=%s lives outside this agent's data directory %s. "
+                "Agents sharing one store overwrite each other — session history by "
+                "thread_id, Qdrant collections through meta.json. Unset %s to resolve "
+                "it under %s.",
+                label,
+                configured,
+                settings.db_dir,
+                label,
+                settings.db_dir,
+            )
+            raise SystemExit(1)
 
 
 def _ensure_data_dirs() -> None:

--- a/kronos/app.py
+++ b/kronos/app.py
@@ -80,6 +80,30 @@ def _migrate_legacy_layout() -> None:
         shutil.move(str(src), str(dst))
 
 
+def _validate_storage_layout_or_exit() -> None:
+    """Refuse to start when this agent's session DB sits outside its own data dir.
+
+    ``_is_legacy_flat_db_path`` normalises the flat ``./data/<name>.db`` form, but
+    an explicit ``DB_PATH=./data/kronos/session.db`` copied into another agent's
+    ``.env`` would slip through. Everything derived from ``db_path.parent`` —
+    ``cron_state.json``, ``logs/``, ``mcp_registry.db``, ``sandbox/`` — would then
+    be shared too, and ``sessions`` rows (keyed by ``thread_id`` alone) would
+    overwrite each other. Same fail-closed reasoning as the policy loader.
+    """
+    db_path = Path(settings.db_path).resolve()
+    db_dir = Path(settings.db_dir).resolve()
+    if db_path.parent != db_dir:
+        log.error(
+            "Refusing to start: DB_PATH=%s lives outside this agent's data directory %s. "
+            "Agents sharing one session store overwrite each other's history. "
+            "Unset DB_PATH so it resolves to %s/session.db.",
+            settings.db_path,
+            settings.db_dir,
+            settings.db_dir,
+        )
+        raise SystemExit(1)
+
+
 def _ensure_data_dirs() -> None:
     """Create required data directories at startup."""
     _migrate_legacy_layout()
@@ -150,6 +174,7 @@ async def main():
     log.info("Starting Kronos Agent OS v%s", __version__)
     _activate_policy_or_exit()
     _load_swarm_registry_or_exit()
+    _validate_storage_layout_or_exit()
     _ensure_data_dirs()
 
     session_store = SessionStore(settings.db_path, agent_name=settings.agent_name)

--- a/kronos/bridge.py
+++ b/kronos/bridge.py
@@ -1662,6 +1662,15 @@ async def run_bridge(agent: KronosAgent) -> None:
     _my_username = me.username
     log.info("Logged in as: %s (@%s, %d)", me.first_name, me.username, me.id)
 
+    # The registry is what the *other* agents read to route around me. A stale
+    # entry never breaks this process, so it has to be shouted about here or it
+    # stays invisible until someone @-addresses me and a peer answers instead.
+    from kronos.swarm_config import registry_username_mismatch
+
+    mismatch = registry_username_mismatch(settings.agent_name, me.username)
+    if mismatch:
+        log.warning("Agent registry out of sync: %s", mismatch)
+
     # Initialize group router for multi-agent chats
     global _group_router
     from kronos.group_router import GroupRouter

--- a/kronos/config.py
+++ b/kronos/config.py
@@ -38,6 +38,24 @@ def _is_legacy_flat_db_path(db_path: str) -> bool:
     return len(parts) == 2 and parts[0] == "data" and parts[1].endswith(".db")
 
 
+def _is_legacy_flat_qdrant_path(qdrant_path: str) -> bool:
+    """True for the pre-isolation ``./data/qdrant`` and ``./data/<name>-qdrant``.
+
+    The same failure as the flat DB path, one directory over. Nothing ever
+    normalised MEM0_QDRANT_PATH — only ``_migrate_legacy_layout`` moved the
+    directory — so a value naming another agent survived indefinitely. kronos
+    inherited ``./data/nexus-qdrant`` through its unit drop-in, and two live
+    processes on one Qdrant directory then raced on ``meta.json``, each
+    dropping the other's collection.
+    """
+    if not qdrant_path:
+        return True
+    parts = PurePosixPath(qdrant_path.removeprefix("./")).parts
+    if len(parts) != 2 or parts[0] != "data":
+        return False
+    return parts[1] == "qdrant" or parts[1].endswith("-qdrant")
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=_ENV_FILE, env_file_encoding="utf-8", extra="ignore")
 
@@ -214,14 +232,19 @@ class Settings(BaseSettings):
             ./data/<agent_name>/qdrant/          — Mem0 vector store
             ./data/swarm.db                       — shared cross-agent ledger
 
-        Legacy env overrides (``DB_PATH=./data/<name>.db``) are silently
-        rewritten to the new layout so existing ``.env`` files keep working
-        after upgrade — the migration in ``app._migrate_legacy_layout`` then
-        moves the physical file to match.
+        Legacy env overrides (``DB_PATH=./data/<name>.db``,
+        ``MEM0_QDRANT_PATH=./data/<name>-qdrant``) are silently rewritten to
+        the new layout so existing ``.env`` files keep working after upgrade —
+        the migration in ``app._migrate_legacy_layout`` then moves the physical
+        file to match. ``<name>`` is deliberately not matched against this
+        agent's own name: a copy-pasted value naming a *different* agent is the
+        exact failure these rewrites exist to prevent.
         """
-        # Detect a legacy flat DB_PATH and rewrite it in place.
+        # Detect legacy flat paths and rewrite them in place.
         if _is_legacy_flat_db_path(self.db_path):
             self.db_path = ""  # force re-resolution below
+        if _is_legacy_flat_qdrant_path(self.mem0_qdrant_path):
+            self.mem0_qdrant_path = ""
 
         if not self.db_dir:
             self.db_dir = f"./data/{self.agent_name}"

--- a/kronos/config.py
+++ b/kronos/config.py
@@ -1,6 +1,7 @@
 """Application settings via Pydantic Settings."""
 
 import os
+from pathlib import PurePosixPath
 
 from dotenv import load_dotenv
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -20,6 +21,21 @@ def _select_env_file() -> str:
 
 _ENV_FILE = _select_env_file()
 load_dotenv(_ENV_FILE, override=False)
+
+
+def _is_legacy_flat_db_path(db_path: str) -> bool:
+    """True for the pre-isolation ``./data/<name>.db`` layout, whatever <name> is.
+
+    Matching only the agent's own name left a copy-pasted ``DB_PATH=./data/kronos.db``
+    intact in three ``.env.<agent>`` files, so lacuna, resonant and keystone all
+    resolved to one session store. ``sessions`` is keyed by ``thread_id`` alone and
+    every write replaces the whole row, so the agent that answered last silently
+    overwrote the others' history in that thread.
+    """
+    if not db_path:
+        return True
+    parts = PurePosixPath(db_path.removeprefix("./")).parts
+    return len(parts) == 2 and parts[0] == "data" and parts[1].endswith(".db")
 
 
 class Settings(BaseSettings):
@@ -204,8 +220,7 @@ class Settings(BaseSettings):
         moves the physical file to match.
         """
         # Detect a legacy flat DB_PATH and rewrite it in place.
-        legacy_flat = f"./data/{self.agent_name}.db"
-        if self.db_path in ("", legacy_flat, f"data/{self.agent_name}.db"):
+        if _is_legacy_flat_db_path(self.db_path):
             self.db_path = ""  # force re-resolution below
 
         if not self.db_dir:

--- a/kronos/cron/scheduler.py
+++ b/kronos/cron/scheduler.py
@@ -30,10 +30,25 @@ def _history_file() -> Path:
     return Path(settings.db_path).parent / "logs" / "cron_runs.jsonl"
 
 
+# One line per job run, ~13 jobs firing as often as every 30s: the file grows
+# without bound and nothing ever read it beyond the recent tail. Keep one
+# rotated generation so a post-mortem still has yesterday.
+MAX_HISTORY_BYTES = 32 * 1024 * 1024
+
+
+def _rotate_history_if_large(path: Path) -> None:
+    try:
+        if path.exists() and path.stat().st_size > MAX_HISTORY_BYTES:
+            path.replace(path.with_name(path.name + ".1"))
+    except OSError as e:
+        log.debug("Failed to rotate cron run history: %s", e)
+
+
 def _append_run_history(entry: dict) -> None:
     try:
         path = _history_file()
         path.parent.mkdir(parents=True, exist_ok=True)
+        _rotate_history_if_large(path)
         with open(path, "a") as f:
             f.write(json.dumps(entry, ensure_ascii=False, default=str) + "\n")
     except Exception as e:

--- a/kronos/swarm_config.py
+++ b/kronos/swarm_config.py
@@ -41,6 +41,21 @@ log = logging.getLogger("kronos.swarm_config")
 DEFAULT_AGENTS_FILE = "agents.yaml"
 ENV_AGENTS_FILE = "AGENTS_CONFIG_PATH"
 
+# The registry answers two questions that do not belong in the same file.
+#
+# *What the swarm does* — roles, ownership, escalation, budgets — is shared
+# configuration: it is edited in the checkout and shipped to the host with the
+# rest of the code. *Who the agents are* — the Telegram @usernames Telethon
+# hands back at login — is per-installation, and a public checkout must not
+# carry the handles of one private swarm.
+#
+# So `agents.yaml` keeps the org chart, and an optional sibling overlay carries
+# the identity of this installation. The overlay is deployed-around (excluded
+# from the deploy rsync) and gitignored, so it survives a deploy that rewrites
+# `agents.yaml`, and never reaches the public repository.
+DEFAULT_LOCAL_AGENTS_FILE = "agents.local.yaml"
+ENV_LOCAL_AGENTS_FILE = "AGENTS_LOCAL_CONFIG_PATH"
+
 DISSENT_MODES = ("allow", "require")
 
 # Owner-first routing defaults. 15 minutes is short enough that a silent owner
@@ -149,16 +164,17 @@ def agents_file_path(path: str | Path | None = None) -> Path:
     return (Path(__file__).resolve().parent.parent / DEFAULT_AGENTS_FILE).resolve()
 
 
-def load_profiles(path: str | Path | None = None) -> dict[str, AgentProfile]:
-    """Load and validate the registry.
+def local_agents_file_path(base: Path) -> Path:
+    """Where the per-installation overlay lives: env > sibling of the registry."""
+    from_env = os.environ.get(ENV_LOCAL_AGENTS_FILE)
+    if from_env:
+        return Path(from_env)
+    return base.parent / DEFAULT_LOCAL_AGENTS_FILE
 
-    A missing file yields an empty swarm (the packaged distribution ships
-    without one), an unparsable or self-contradicting file raises.
-    """
-    config_path = agents_file_path(path)
 
+def _read_registry(config_path: Path) -> dict[str, Any]:
+    """Parse one registry file. A missing file reads as an empty mapping."""
     if not config_path.exists():
-        log.warning("agents.yaml not found at %s — using empty profile set", config_path)
         return {}
 
     try:
@@ -169,7 +185,45 @@ def load_profiles(path: str | Path | None = None) -> dict[str, AgentProfile]:
     if not isinstance(raw, dict):
         raise SwarmConfigError(f"{config_path} must map agent names to profiles, got {type(raw).__name__}")
 
-    profiles = {name: profile_from_dict(name, entry) for name, entry in raw.items()}
+    return raw
+
+
+def _merge_registries(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Overlay entries win field by field, so an overlay can set only a username.
+
+    Merging per field rather than per agent is the whole point: the overlay
+    exists to correct identity, and re-stating `owns`/`escalates_to` there would
+    fork the org chart into two files that drift apart.
+    """
+    merged: dict[str, Any] = {}
+    for source in (base, overlay):
+        for name, entry in source.items():
+            if entry and not isinstance(entry, dict):
+                raise SwarmConfigError(f"agent '{name}' must be a mapping of fields, got {type(entry).__name__}")
+            merged[name] = {**merged.get(name, {}), **(entry or {})}
+    return merged
+
+
+def load_profiles(path: str | Path | None = None) -> dict[str, AgentProfile]:
+    """Load and validate the registry, with the local overlay applied.
+
+    A missing file yields an empty swarm (the packaged distribution ships
+    without one), an unparsable or self-contradicting file raises.
+    """
+    config_path = agents_file_path(path)
+    overlay_path = local_agents_file_path(config_path)
+
+    raw = _read_registry(config_path)
+    overlay = _read_registry(overlay_path)
+
+    if not raw and not overlay:
+        log.warning("agents.yaml not found at %s — using empty profile set", config_path)
+        return {}
+
+    if overlay:
+        log.info("agents registry: %d entries overlaid from %s", len(overlay), overlay_path)
+
+    profiles = {name: profile_from_dict(name, entry) for name, entry in _merge_registries(raw, overlay).items()}
     validate_profiles(profiles)
     return profiles
 
@@ -262,3 +316,45 @@ def topic_owner(profiles: dict[str, AgentProfile], topic: str) -> str:
         return ""
     owners = [name for name, profile in profiles.items() if profile.owns_topic(topic)]
     return owners[0] if len(owners) == 1 else ""
+
+
+def registry_username_mismatch(agent_name: str, actual_username: str | None) -> str:
+    """Compare what Telegram calls this agent against what the registry claims.
+
+    An agent never reads its own entry to recognise its own name — Telethon
+    hands it the real @username at login — so a stale registry is invisible
+    from the inside and stays green in every health check. It only bites the
+    *other* five processes: they build their "this message is for lacuna, not
+    me" index out of the registry alone, so a wrong entry means an @-address to
+    that agent reads as addressed to nobody, no one skips, and the wrong agent
+    answers. That is the failure this returns a string for.
+
+    Empty string means "nothing to report" — either they agree, or Telegram
+    gave no username to compare (a bot-token login, say).
+    """
+    actual = (actual_username or "").lower().lstrip("@")
+    if not actual:
+        return ""
+
+    from kronos.group_router import AGENT_PROFILES
+
+    entry = AGENT_PROFILES.get(agent_name)
+    overlay_path = local_agents_file_path(agents_file_path())
+
+    if entry is None:
+        return (
+            f"agent '{agent_name}' logged in as @{actual} but is absent from the registry — "
+            f"the other agents cannot tell that @{actual} is this agent, so a message addressed "
+            f"to it may be answered by someone else. Add it to {overlay_path}"
+        )
+
+    registered = (entry.get("username") or "").lower().lstrip("@")
+    if registered == actual:
+        return ""
+
+    return (
+        f"agent '{agent_name}' logged in as @{actual} but the registry says @{registered} — "
+        f"the other agents will not recognise @{actual} as this agent, so a message addressed "
+        f"to it may be answered by someone else. Fix it in {overlay_path} "
+        f"(or set AGENT_USERNAME_{agent_name.upper()})"
+    )

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -113,6 +113,7 @@ sync_files() {
     --exclude='data/' \
     --exclude='.env' \
     --exclude='.env.*' \
+    --exclude='agents.local.yaml' \
     --exclude='*.session' \
     --exclude='*.session-*' \
     --exclude='.venv/' \

--- a/tests/test_config_db_layout.py
+++ b/tests/test_config_db_layout.py
@@ -1,0 +1,107 @@
+"""Every agent gets its own session store, whatever DB_PATH says.
+
+``sessions`` is keyed by ``thread_id`` alone and each write replaces the whole
+row, so two agents sharing one file silently overwrite each other's history in
+any thread they both see.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from kronos.config import _is_legacy_flat_db_path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    "db_path",
+    [
+        "",
+        "./data/kronos.db",
+        "data/kronos.db",
+        "./data/lacuna.db",
+        "./data/some-future-agent.db",
+    ],
+)
+def test_flat_data_db_is_legacy(db_path: str) -> None:
+    assert _is_legacy_flat_db_path(db_path)
+
+
+@pytest.mark.parametrize(
+    "db_path",
+    [
+        "./data/kronos/session.db",
+        "data/lacuna/session.db",
+        "/srv/kronos/session.db",
+        "./var/kronos.db",
+    ],
+)
+def test_explicit_paths_are_kept(db_path: str) -> None:
+    assert not _is_legacy_flat_db_path(db_path)
+
+
+def test_another_agents_flat_db_path_resolves_to_own_directory(tmp_path: Path) -> None:
+    """The regression: three ``.env.<agent>`` files carried DB_PATH=./data/kronos.db."""
+    (tmp_path / ".env").write_text("AGENT_NAME=kronos\nDB_PATH=./data/kronos.db\n", encoding="utf-8")
+    (tmp_path / ".env.lacuna").write_text("AGENT_NAME=lacuna\nDB_PATH=./data/kronos.db\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    for key in ("DB_PATH", "DB_DIR", "MEM0_QDRANT_PATH", "KAOS_ENV_FILE", "KRONOS_ENV_FILE"):
+        env.pop(key, None)
+    env["AGENT_NAME"] = "lacuna"
+    env["PYTHONPATH"] = os.pathsep.join(part for part in (str(REPO_ROOT), env.get("PYTHONPATH", "")) if part)
+
+    script = """
+import json
+
+from kronos.config import settings
+
+print(json.dumps({
+    "agent": settings.agent_name,
+    "db_path": settings.db_path,
+    "db_dir": settings.db_dir,
+    "qdrant": settings.mem0_qdrant_path,
+}))
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(completed.stdout.splitlines()[-1]) == {
+        "agent": "lacuna",
+        "db_path": "./data/lacuna/session.db",
+        "db_dir": "./data/lacuna",
+        "qdrant": "./data/lacuna/qdrant",
+    }
+
+
+def test_startup_refuses_a_session_db_outside_the_agent_directory(monkeypatch, tmp_path: Path) -> None:
+    """An explicit nested path into another agent's directory must not start."""
+    from kronos.app import _validate_storage_layout_or_exit
+    from kronos.config import settings
+
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path / "lacuna"))
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "kronos" / "session.db"))
+
+    with pytest.raises(SystemExit):
+        _validate_storage_layout_or_exit()
+
+
+def test_startup_accepts_the_resolved_per_agent_layout(monkeypatch, tmp_path: Path) -> None:
+    from kronos.app import _validate_storage_layout_or_exit
+    from kronos.config import settings
+
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path / "lacuna"))
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "lacuna" / "session.db"))
+
+    _validate_storage_layout_or_exit()

--- a/tests/test_config_db_layout.py
+++ b/tests/test_config_db_layout.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 
-from kronos.config import _is_legacy_flat_db_path
+from kronos.config import _is_legacy_flat_db_path, _is_legacy_flat_qdrant_path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -92,6 +92,7 @@ def test_startup_refuses_a_session_db_outside_the_agent_directory(monkeypatch, t
 
     monkeypatch.setattr(settings, "db_dir", str(tmp_path / "lacuna"))
     monkeypatch.setattr(settings, "db_path", str(tmp_path / "kronos" / "session.db"))
+    monkeypatch.setattr(settings, "mem0_qdrant_path", str(tmp_path / "lacuna" / "qdrant"))
 
     with pytest.raises(SystemExit):
         _validate_storage_layout_or_exit()
@@ -103,5 +104,66 @@ def test_startup_accepts_the_resolved_per_agent_layout(monkeypatch, tmp_path: Pa
 
     monkeypatch.setattr(settings, "db_dir", str(tmp_path / "lacuna"))
     monkeypatch.setattr(settings, "db_path", str(tmp_path / "lacuna" / "session.db"))
+    monkeypatch.setattr(settings, "mem0_qdrant_path", str(tmp_path / "lacuna" / "qdrant"))
 
     _validate_storage_layout_or_exit()
+
+
+@pytest.mark.parametrize(
+    "qdrant_path",
+    ["", "./data/qdrant", "data/qdrant", "./data/nexus-qdrant", "./data/impulse-qdrant"],
+)
+def test_flat_qdrant_dirs_are_legacy(qdrant_path: str) -> None:
+    assert _is_legacy_flat_qdrant_path(qdrant_path)
+
+
+@pytest.mark.parametrize(
+    "qdrant_path",
+    ["./data/kronos/qdrant", "data/nexus/qdrant", "/srv/qdrant", "./data/kronos.db"],
+)
+def test_nested_qdrant_dirs_are_kept(qdrant_path: str) -> None:
+    assert not _is_legacy_flat_qdrant_path(qdrant_path)
+
+
+def test_another_agents_qdrant_dir_resolves_to_own_directory(tmp_path: Path) -> None:
+    """kronos inherited MEM0_QDRANT_PATH=./data/nexus-qdrant from a unit drop-in."""
+    (tmp_path / ".env").write_text("AGENT_NAME=kronos\nMEM0_QDRANT_PATH=./data/nexus-qdrant\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    for key in ("DB_PATH", "DB_DIR", "MEM0_QDRANT_PATH", "KAOS_ENV_FILE", "KRONOS_ENV_FILE"):
+        env.pop(key, None)
+    env["AGENT_NAME"] = "kronos"
+    env["PYTHONPATH"] = os.pathsep.join(part for part in (str(REPO_ROOT), env.get("PYTHONPATH", "")) if part)
+
+    script = """
+import json
+
+from kronos.config import settings
+
+print(json.dumps({"qdrant": settings.mem0_qdrant_path, "db_dir": settings.db_dir}))
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(completed.stdout.splitlines()[-1]) == {
+        "qdrant": "./data/kronos/qdrant",
+        "db_dir": "./data/kronos",
+    }
+
+
+def test_startup_refuses_a_qdrant_dir_outside_the_agent_directory(monkeypatch, tmp_path: Path) -> None:
+    from kronos.app import _validate_storage_layout_or_exit
+    from kronos.config import settings
+
+    monkeypatch.setattr(settings, "db_dir", str(tmp_path / "kronos"))
+    monkeypatch.setattr(settings, "db_path", str(tmp_path / "kronos" / "session.db"))
+    monkeypatch.setattr(settings, "mem0_qdrant_path", str(tmp_path / "nexus" / "qdrant"))
+
+    with pytest.raises(SystemExit):
+        _validate_storage_layout_or_exit()

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -385,3 +385,42 @@ def test_manifest_prunes_frontend_and_runtime_artifacts():
     assert "prune dashboard-ui/dist" in manifest
     assert "prune workspaces" in manifest
     assert "prune data" in manifest
+
+
+def test_tracked_agent_registry_carries_no_real_handles():
+    """The org chart is public; the identities behind it are not.
+
+    `agents.yaml` travels with a deploy and sits in a public checkout, so it
+    keeps the generated `<name>agnt` placeholders and `agents.local.yaml`
+    carries the real ones. Asserting the shape rather than a denylist means
+    this test never has to spell a real handle out to defend against it.
+    """
+    if not _git_ls_files("agents.yaml"):
+        return  # untracked registry — nothing public to leak
+
+    registry = yaml.safe_load((ROOT / "agents.yaml").read_text(encoding="utf-8")) or {}
+    assert registry, "a tracked agents.yaml should not be empty"
+
+    for name, entry in registry.items():
+        username = (entry or {}).get("username", f"{name}agnt")
+        assert username == f"{name}agnt", (
+            f"agents.yaml gives '{name}' a non-placeholder username — real handles belong in agents.local.yaml"
+        )
+
+
+def test_identity_overlay_stays_private_and_survives_deploy():
+    """The overlay is only useful if a deploy cannot overwrite it.
+
+    `agents.yaml` is rsynced from the checkout, so the installation's real
+    usernames have to live in a file the same rsync skips — otherwise every
+    deploy silently restores the placeholders and the swarm starts misrouting
+    @-addresses again.
+    """
+    gitignore = (ROOT / ".gitignore").read_text(encoding="utf-8")
+    dockerignore = (ROOT / ".dockerignore").read_text(encoding="utf-8")
+    deploy = (ROOT / "scripts" / "deploy.sh").read_text(encoding="utf-8")
+
+    assert "agents.local.yaml" in gitignore
+    assert "agents.local.yaml" in dockerignore
+    assert "--exclude='agents.local.yaml'" in deploy
+    assert not _git_ls_files("agents.local.yaml")

--- a/tests/test_swarm_config.py
+++ b/tests/test_swarm_config.py
@@ -17,6 +17,7 @@ from kronos.swarm_config import (
     load_profiles,
     profile_for,
     profile_from_dict,
+    registry_username_mismatch,
     topic_owner,
     validate_profiles,
 )
@@ -282,3 +283,129 @@ def test_startup_accepts_a_valid_registry(tmp_path, monkeypatch):
     monkeypatch.setenv("AGENTS_CONFIG_PATH", _write(tmp_path, ORGANISED))
 
     _load_swarm_registry_or_exit()  # must not raise
+
+
+# --- identity overlay ---------------------------------------------------------
+#
+# The org chart is shared configuration and travels with a deploy; the Telegram
+# @usernames belong to one installation and must not reach a public checkout.
+# `agents.local.yaml` is where the two are allowed to disagree.
+
+
+def _write_overlay(tmp_path, payload) -> None:
+    (tmp_path / "agents.local.yaml").write_text(yaml.safe_dump(payload, allow_unicode=True), encoding="utf-8")
+
+
+def test_overlay_corrects_the_username_and_keeps_the_org_chart(tmp_path):
+    base = _write(tmp_path, ORGANISED)
+    _write_overlay(tmp_path, {"kronos": {"username": "kronosiibot"}})
+
+    profiles = load_profiles(base)
+
+    kronos = profiles["kronos"]
+    assert kronos.username == "kronosiibot"
+    # Merging per field, not per agent: an overlay that only sets a username
+    # must not silently drop ownership or escalation with it.
+    assert kronos.owns == ["planning", "priorities"]
+    assert kronos.escalates_to == "nexus"
+    assert kronos.role == "strategic advisor"
+    assert profiles["nexus"].username == "nexusagnt"
+
+
+def test_overlay_alone_is_enough_when_the_registry_is_absent(tmp_path):
+    _write_overlay(tmp_path, {"impulse": {"username": "impulseag", "role": "action catalyst"}})
+
+    profiles = load_profiles(tmp_path / "agents.yaml")
+
+    assert profiles["impulse"].username == "impulseag"
+
+
+def test_no_overlay_leaves_the_registry_untouched(tmp_path):
+    profiles = load_profiles(_write(tmp_path, LEGACY))
+
+    assert profiles["kronos"].username == "kronosagnt"
+
+
+def test_overlay_path_is_configurable(tmp_path, monkeypatch):
+    elsewhere = tmp_path / "private" / "identity.yaml"
+    elsewhere.parent.mkdir()
+    elsewhere.write_text(yaml.safe_dump({"kronos": {"username": "kronosiibot"}}), encoding="utf-8")
+    monkeypatch.setenv("AGENTS_LOCAL_CONFIG_PATH", str(elsewhere))
+
+    profiles = load_profiles(_write(tmp_path, LEGACY))
+
+    assert profiles["kronos"].username == "kronosiibot"
+
+
+def test_env_still_wins_over_the_overlay(tmp_path, monkeypatch):
+    monkeypatch.setenv("AGENT_USERNAME_KRONOS", "kronos_staging")
+    base = _write(tmp_path, LEGACY)
+    _write_overlay(tmp_path, {"kronos": {"username": "kronosiibot"}})
+
+    profiles = load_profiles(base)
+
+    assert profiles["kronos"].username == "kronos_staging"
+
+
+def test_an_overlay_that_is_not_a_mapping_is_an_error(tmp_path):
+    base = _write(tmp_path, LEGACY)
+    _write_overlay(tmp_path, {"kronos": "kronosiibot"})
+
+    with pytest.raises(SwarmConfigError, match="mapping of fields"):
+        load_profiles(base)
+
+
+# --- drift between the registry and Telegram ----------------------------------
+#
+# An agent reads its own name from Telethon, never from the registry, so a
+# stale entry is invisible to the agent it describes. It only misroutes the
+# other five, which is why login is the one place worth checking.
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    from kronos import group_router
+
+    def _install(profiles):
+        monkeypatch.setattr(group_router, "AGENT_PROFILES", dict(profiles))
+
+    return _install
+
+
+def test_matching_username_reports_nothing(registry):
+    registry(LEGACY)
+
+    assert registry_username_mismatch("kronos", "kronosagnt") == ""
+
+
+def test_matching_username_ignores_case_and_the_at_sign(registry):
+    registry(LEGACY)
+
+    assert registry_username_mismatch("kronos", "@KronosAgnt") == ""
+
+
+def test_a_stale_entry_is_reported_with_both_names(registry):
+    registry(LEGACY)
+
+    warning = registry_username_mismatch("kronos", "kronosiibot")
+
+    assert "kronosiibot" in warning
+    assert "kronosagnt" in warning
+    assert "agents.local.yaml" in warning
+    assert "AGENT_USERNAME_KRONOS" in warning
+
+
+def test_an_unregistered_agent_is_reported(registry):
+    registry(LEGACY)
+
+    warning = registry_username_mismatch("lacuna", "lacunaagent")
+
+    assert "lacunaagent" in warning
+    assert "absent from the registry" in warning
+
+
+def test_a_login_without_a_username_has_nothing_to_compare(registry):
+    registry(LEGACY)
+
+    assert registry_username_mismatch("kronos", None) == ""
+    assert registry_username_mismatch("kronos", "") == ""


### PR DESCRIPTION
Three failures with one shape: a value copy-pasted between agents' configs outlives the agent it came from, and nothing in the code objects.

## Session databases

`.env.lacuna`, `.env.resonant` and `.env.keystone` each carried `DB_PATH=./data/kronos.db`. The legacy-path rewrite only recognised `./data/<own agent_name>.db`, so the literal value survived and all three resolved to one store.

`sessions` is keyed by `thread_id` alone and every write replaces the whole row, so in any thread two agents could see, one history silently overwrote the other. `data/kronos.db` on the host holds a dialogue where the assistant introduces itself as Резонант, in a thread that also exists in kronos's own store. Everything derived from `db_path.parent` was shared too — `cron_state.json`, `logs/`, `mcp_registry.db`, `sandbox/` — and `recover_abandoned_turns()` selects running turns with no agent filter.

Any flat `./data/<name>.db` is now the pre-isolation layout whatever `<name>` says, and startup refuses a `DB_PATH` resolving outside the agent's own directory.

## Qdrant directories

The same gap one directory over: `MEM0_QDRANT_PATH` was normalised only by `_migrate_legacy_layout` moving the directory, never by the config. The kronos unit inherits `./data/nexus-qdrant` from the `env-nexus.conf` drop-in that feeds the daily pulse its analytics keys. Two live processes on one Qdrant directory race on `meta.json`: the collection there flipped from `nexus_memories` to `kronos_memories`, each dropping the other's. The drop-in still supplies the keys — only the storage path comes back under the agent's own directory.

## Agent usernames

An agent reads its own handle from Telethon at login and never from `agents.yaml`, so a stale entry is invisible to the agent it describes and only breaks the others, whose `target_agents` detection is built from the registry alone. `agents.yaml` is public and rsynced over on every deploy, so real handles cannot live there. Identity moves to an optional `agents.local.yaml` overlay, merged field by field, gitignored and excluded from the deploy rsync; `bridge.py` compares its entry against Telegram after `get_me()` and warns on drift.

## Also

`cron_runs.jsonl` had reached 174 MB on a disk at 92% — one rotated generation is kept at 32 MB.

## Verification

2151 tests pass, ruff clean. The session-database fix is already proven in production: it reached the host with an unrelated deploy on 8 September, and lacuna and resonant have logged `db=./data/lacuna/session.db` and `db=./data/resonant/session.db` ever since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)