### PR TITLE
Run the deploy eval gate from a clean checkout

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -77,7 +77,13 @@ run_eval_gate() {
 
   echo "Running deploy eval gate: pytest -m eval"
   if command -v uv >/dev/null 2>&1; then
-    (cd "$SOURCE_DIR" && uv run pytest -q -m eval)
+    # --extra dev, because pytest is an optional dependency: `uv run pytest`
+    # only found it when the checkout already had a .venv someone had installed
+    # dev into. From a fresh worktree — the one safe way to deploy, since rsync
+    # ships the working tree and a shared checkout leaks a parallel session's
+    # edits — uv built a base-only venv and the gate died on "Failed to spawn:
+    # pytest" instead of running.
+    (cd "$SOURCE_DIR" && uv run --extra dev pytest -q -m eval)
   elif [ -x "$SOURCE_DIR/.venv/bin/python" ]; then
     (cd "$SOURCE_DIR" && .venv/bin/python -m pytest -q -m eval)
   else

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -237,6 +237,10 @@ def test_deploy_runs_eval_gate_before_sync() -> None:
 
     assert "run_eval_gate()" in text
     assert "pytest -q -m eval" in text
+    # pytest is an optional dependency, so the gate has to ask for it by name —
+    # otherwise it only runs in a checkout that already had dev installed, and
+    # dies on a fresh worktree.
+    assert "uv run --extra dev pytest -q -m eval" in text
     assert text.index("run_eval_gate\nsync_files") < text.index('if [ "${1:-}" = "--first-run" ]; then')
 
 
@@ -271,7 +275,7 @@ def test_deploy_aborts_when_eval_gate_fails_before_sync(tmp_path: Path) -> None:
 
     assert result.returncode == 7
     assert "Running deploy eval gate: pytest -m eval" in result.stdout
-    assert "run pytest -q -m eval" in uv_log.read_text(encoding="utf-8")
+    assert "run --extra dev pytest -q -m eval" in uv_log.read_text(encoding="utf-8")
     assert not rsync_log.exists()
 
 


### PR DESCRIPTION
The gate was passing for a reason that had nothing to do with the gate.

`run_eval_gate()` calls `uv run pytest -q -m eval`, but pytest lives in `[project.optional-dependencies].dev`. `uv run` without `--extra dev` resolves only the base dependencies — it found pytest solely because the main working copy already has a `.venv` with dev installed, and `uv run` reuses it.

That makes the gate work exactly where it is least needed and fail where it matters. `deploy.sh` rsyncs the *working tree*, so deploying from a shared checkout ships whatever a parallel session left uncommitted — which is how an unrelated branch and eleven uncommitted files reached the host on 8 September. The fix for that is deploying from a fresh worktree, and a fresh worktree is precisely where the gate died:

```
Installed 88 packages in 125ms
error: Failed to spawn: `pytest`
  Caused by: No such file or directory (os error 2)
```

Verified both ways in a throwaway worktree with no `.venv`: the old command reproduces the spawn failure, `uv run --extra dev pytest -q -m eval` runs the 8 eval tests.

`test_deploy_runs_eval_gate_before_sync` now asserts the extra is requested by name, so the dependency cannot silently go back to being implicit; `test_deploy_aborts_when_eval_gate_fails_before_sync` checks the new invocation reaches uv. 2151 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)