### PR TITLE
Exclude a worktree's .git file from the deploy rsync

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -103,10 +103,19 @@ sync_files() {
   fi
 
   # Sync code — explicitly exclude everything that must survive deploy.
+  #
+  # .git is listed twice on purpose: in a worktree it is a file, not a
+  # directory, so the trailing-slash pattern misses it and rsync tries to put
+  # that file where the host keeps its .git directory — "could not make way for
+  # new regular file: .git", then "cannot delete non-empty directory: .git",
+  # after it has already emptied the directory. That blocked deploying from a
+  # worktree at all, which is the only way that does not ship a parallel
+  # session's uncommitted edits to production.
   echo "Syncing files..."
   rsync -avz --delete \
     --exclude='.DS_Store' \
     --exclude='.git/' \
+    --exclude='.git' \
     --exclude='.codegraph/' \
     --exclude='.pytest_cache/' \
     --exclude='.ruff_cache/' \

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -244,6 +244,20 @@ def test_deploy_runs_eval_gate_before_sync() -> None:
     assert text.index("run_eval_gate\nsync_files") < text.index('if [ "${1:-}" = "--first-run" ]; then')
 
 
+def test_deploy_excludes_git_as_both_file_and_directory() -> None:
+    """A worktree's .git is a file, so the trailing-slash pattern alone misses it.
+
+    Without the bare pattern rsync tries to write that file over the host's .git
+    directory, empties it, and aborts the deploy — which is exactly the setup the
+    worktree exists for: shipping a commit instead of whatever a parallel session
+    left in a shared checkout.
+    """
+    text = DEPLOY.read_text(encoding="utf-8")
+
+    assert "--exclude='.git/'" in text
+    assert "--exclude='.git'" in text
+
+
 def test_deploy_aborts_when_eval_gate_fails_before_sync(tmp_path: Path) -> None:
     remote_dir = tmp_path / "remote"
     remote_dir.mkdir()


### PR DESCRIPTION
Follow-up to #79, same root cause one step later: `deploy.sh` could not actually deploy from a worktree.

In a worktree `.git` is a *file* holding a `gitdir:` pointer, not a directory. `--exclude='.git/'` only matches directories, so rsync tried to write that file over the host's `.git` directory:

```
could not make way for new regular file: .git
Transfer starting: 870 files
cannot delete non-empty directory: .git
rsync(18166): warning: child 18167 exited with status 23
```

By the time it gave up, `--delete` had emptied the host's `.git` (`git rev-parse` on the host now reports "not a git repository"), and the non-zero exit aborted the script *before* the systemd restarts — leaving freshly synced code beside processes still running the old one. The code files themselves transferred fine, so this is silent unless you check the exit code.

Deploying from a worktree is not optional: `deploy.sh` rsyncs the working tree, so a shared checkout ships whatever a parallel session left uncommitted — which is how an unrelated branch reached production on 8 September.

Both patterns are listed now. `test_deploy_excludes_git_as_both_file_and_directory` keeps the bare one from being tidied away as a duplicate. 2152 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)