### PR TITLE
Stop the example configs teaching a layout the config rewrites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,7 +150,11 @@ NTFY_TOKEN=tk_...
 NTFY_TOPIC=kronos-alerts
 
 # === Memory (Mem0) ===
-MEM0_QDRANT_PATH=./data/qdrant       # Qdrant local mode, no external service
+# MEM0_QDRANT_PATH=                   # override; if empty, resolved to ./data/<agent_name>/qdrant
+#                                     # A flat ./data/qdrant or ./data/<name>-qdrant is the
+#                                     # pre-isolation layout and is rewritten to the per-agent
+#                                     # directory: two processes on one Qdrant directory race on
+#                                     # meta.json and drop each other's collections.
 
 # === Observability (optional) ===
 LANGFUSE_PUBLIC_KEY=pk-lf-...

--- a/.env.worker.example
+++ b/.env.worker.example
@@ -51,7 +51,10 @@ NTFY_TOKEN=tk_...
 NTFY_TOPIC=worker-alerts               # separate topic from main agent
 
 # === Memory (Mem0) ===
-MEM0_QDRANT_PATH=./data/worker-qdrant  # separate from main agent
+# MEM0_QDRANT_PATH=                    # leave empty — AGENT_NAME already separates the store,
+#                                      # resolved to ./data/<agent_name>/qdrant. Naming a flat
+#                                      # directory here does not isolate anything: it is treated
+#                                      # as the pre-isolation layout and rewritten.
 
 # === Observability (optional) ===
 LANGFUSE_PUBLIC_KEY=pk-lf-...

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -39,6 +39,19 @@ def test_private_runtime_files_are_ignored():
     assert "dashboard-ui/dist/" in gitignore
 
 
+def test_examples_do_not_set_flat_storage_paths() -> None:
+    """A copy-pasted flat path is what put three agents on one session store.
+
+    config.py now rewrites those, so a value set here is silently ignored —
+    worse than useless, since it reads as configuration that does something.
+    Both examples must leave the storage paths commented out.
+    """
+    for name in (".env.example", ".env.worker.example"):
+        text = (ROOT / name).read_text(encoding="utf-8")
+        active = [line for line in text.splitlines() if line.startswith(("DB_PATH=", "DB_DIR=", "MEM0_QDRANT_PATH="))]
+        assert not active, f"{name} sets a storage path the config ignores: {active}"
+
+
 def test_workspace_env_roles_are_documented():
     env_example = (ROOT / ".env.example").read_text(encoding="utf-8")
     backup_script = (ROOT / "scripts" / "workspace-backup.sh").read_text(encoding="utf-8")


### PR DESCRIPTION
Cleaning the host's `.env` files after #78 surfaced where the flat paths kept coming from: the examples still hand them out.

`MEM0_QDRANT_PATH` was set and uncommented in both `.env.example` and `.env.worker.example`. Since #78 the config rewrites any flat `./data/qdrant` or `./data/<name>-qdrant` to the per-agent directory, so those lines do nothing. The worker example additionally annotated it *"separate from main agent"* — `AGENT_NAME` is what separates the store; naming a flat directory there isolates nothing.

A line that reads as configuration and silently does nothing is worse than no line at all. Copying exactly such a line between agent configs is how `DB_PATH=./data/kronos.db` reached three `.env.<agent>` files and put lacuna, resonant and keystone on one session database.

Both are now commented out with what the empty value resolves to, matching how `DB_PATH` was already documented. `test_examples_do_not_set_flat_storage_paths` fails if either example sets `DB_PATH`, `DB_DIR` or `MEM0_QDRANT_PATH` again.

On the host all eight such lines are gone from the six `.env` files; effective paths compared identical before and after, and lacuna restarted clean on the trimmed config. 2153 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)