### PR TITLE
agents.yaml is tracked on purpose, so stop ignoring it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,10 @@ venv/
 *.session
 *.session-journal
 servers.yaml
-agents.yaml
+# agents.yaml is deliberately NOT ignored: it is the shared org chart (role,
+# owns, escalates_to, budgets) and has to travel with a deploy. It carries
+# placeholder usernames following the <name>agnt scheme, which
+# test_public_surface enforces, so no real handle can reach the public repo.
 # Per-installation identity overlay (real Telegram @usernames) — never public.
 agents.local.yaml
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -297,7 +297,9 @@ app/
 └── servers.yaml
 ```
 
-`data/`, `.env`, `agents.yaml`, `agents.local.yaml`, `servers.yaml`, `*.session`, and live
-`workspaces/<agent>/` files should not be committed. `agents.local.yaml` is also excluded
-from the deploy rsync: it carries this installation's real Telegram @usernames, so it has to
-survive a deploy that rewrites `agents.yaml`.
+`data/`, `.env`, `agents.local.yaml`, `servers.yaml`, `*.session`, and live
+`workspaces/<agent>/` files should not be committed. `agents.yaml` is the exception and is
+tracked on purpose: it is the shared org chart and has to travel with a deploy, so it carries
+placeholder usernames only. `agents.local.yaml` is also excluded from the deploy rsync: it
+carries this installation's real Telegram @usernames, so it has to survive a deploy that
+rewrites `agents.yaml`.

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -34,8 +34,15 @@ def test_private_runtime_files_are_ignored():
     assert "workspace/" in gitignore
     assert "workspaces/*" in gitignore
     assert "!workspaces/_template/**" in gitignore
-    assert "agents.yaml" in gitignore
-    assert "servers.yaml" in gitignore
+    # Line-exact: "agents.yaml" as a substring also matches "agents.local.yaml",
+    # which hid that the org chart was ignored and tracked at the same time.
+    ignored = {line.strip() for line in gitignore.splitlines()}
+    assert "agents.local.yaml" in ignored
+    assert "servers.yaml" in ignored
+    assert "agents.yaml" not in ignored, (
+        "agents.yaml is tracked on purpose — it is the shared org chart and has to "
+        "travel with a deploy; ignoring it here contradicts the index"
+    )
     assert "dashboard-ui/dist/" in gitignore
 
 


### PR DESCRIPTION
`agents.yaml` was listed in `.gitignore`, in `.dockerignore`, and in `docs/DEPLOYMENT.md`'s "should not be committed" list — while being tracked in the index the entire time. `.gitignore` has no effect on files git already knows about, so all three declarations were inert and served only to mislead whoever read them next.

Tracking it is the right behaviour, not an oversight. `agents.yaml` is the shared org chart — `role`, `owns`, `escalates_to`, budgets — and it has to travel with a deploy; that is exactly why identity was split out into `agents.local.yaml` (gitignored, excluded from the rsync) rather than by hiding the registry. The tracked file carries placeholder usernames following the `<name>agnt` scheme, which `test_public_surface` already enforces, so a real Telegram handle cannot reach the public repo through it.

The old assertion was `"agents.yaml" in gitignore` — a substring check that `agents.local.yaml` satisfies on its own. That is how a file could be ignored and tracked simultaneously without any test noticing. Both checks are line-exact now, and one of them fails if `agents.yaml` is ever re-added to `.gitignore`.

`servers.yaml` is untouched: it is genuinely untracked, so ignoring it is correct.

Left alone deliberately: `.dockerignore` still lists `agents.yaml`. The production install runs under systemd, not Docker, so whether the image should carry the org chart is a separate question I have no evidence on — worth a look if the container path is ever used.

2153 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)